### PR TITLE
feat(protocol): prepare the minimal M1 protocol spine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,7 @@ jobs:
         run: python -m pip install -e ".[dev]"
       - name: Lint
         run: ruff check .
+      - name: Verify generated schemas
+        run: python -m deferred_teleop.schema --check
       - name: Test
         run: pytest

--- a/docs/adr/0002-dtt0-python-wire-models.md
+++ b/docs/adr/0002-dtt0-python-wire-models.md
@@ -1,0 +1,123 @@
+# ADR 0002: Python wire models and JSON Schema artefacts for `dtt/0`
+
+- Status: Proposed for M1
+- Date: 2026-09-03
+- Scope: experimental `dtt/0` protocol only
+- Issue: #5
+
+## Context
+
+The first runnable delayed-dummy slice needs strict typed messages in Python, reviewable language-neutral interoperability artefacts, and a path to Unreal/C++ consumption.
+
+The project must avoid two opposite failure modes:
+
+1. passing arbitrary dictionaries between Mission, Field and Robot until incompatible assumptions spread through the code;
+2. freezing a large supposedly final protocol before one physical vertical slice has exercised it.
+
+The existing M0 envelope is a committed Draft 2020-12 JSON Schema. M1 adds the constrained semantic spine:
+
+```text
+OperationIntent
+-> GroundedOperation
+-> OperationPlan / TaskGraph
+-> TaskAssignment
+-> ExecutionContract
+-> ExecutionEvent
+```
+
+## Decision
+
+For `dtt/0`:
+
+1. Python wire DTOs use **Pydantic v2** with strict validation and `extra="forbid"`.
+2. Domain services do not exchange unvalidated arbitrary dictionaries.
+3. Conversion between wire DTOs and future internal/domain representations remains explicit.
+4. Draft 2020-12 JSON Schemas are generated from the Python wire DTOs and committed as interoperability artefacts.
+5. CI regenerates the schemas and fails when committed artefacts drift from the models.
+6. The first conformance bundle covers only the constrained delayed dummy/button path.
+7. Spatial values use SI units and the canonical right-handed frame convention.
+8. Evidence-bearing values retain source, time, frame, revision and provenance metadata.
+9. Predicted or simulated data cannot be relabelled as measured by serialization or visualization code.
+10. Message and model names remain `dtt/0` and explicitly experimental; breaking changes are allowed before the physical delayed-button slice is complete.
+
+## Envelope consequences
+
+The M1 envelope adds the fields needed for durable retry and causal audit:
+
+```text
+message_id
+message_type
+source_id
+source_boot_id
+source_sequence / sequence_id
+destination_id
+correlation_id
+causation_id when the message is a direct consequence
+created_at
+not_before
+expires_at
+payload
+```
+
+Causation is not mandatory for genuine roots such as an operator-created `OperationIntent` or periodic telemetry. It is mandatory for direct consequences such as a plan, assignment, contract or execution event.
+
+## State-machine consequences
+
+Contract transitions are validated separately from syntactic message validation. The initial M1 path is:
+
+```text
+RECEIVED
+-> ACCEPTED
+-> DISPATCH_RECORDED
+-> RUNNING
+-> SUCCEEDED | FAILED | HELD | CANCELLED
+```
+
+A stable `(contract_id, contract_revision)` is terminal once a terminal state is durably recorded. Retry or rebase requires an explicit new revision.
+
+The schema does not itself guarantee effect-once execution. That guarantee belongs to the durable execution journal in #6.
+
+## Alternatives considered
+
+### Hand-written JSON Schema plus hand-written Python models
+
+Rejected for M1 because the two representations would drift quickly. It may be reconsidered if a stable multi-language protocol later requires a schema-first workflow.
+
+### Protobuf immediately
+
+Deferred. It offers mature code generation and evolution rules, but adds Unreal/C++ build integration and makes the first experimental payloads less inspectable. A later stable version may adopt Protobuf or another IDL behind the same domain boundaries.
+
+### Python dataclasses with ad-hoc validation
+
+Rejected. They provide insufficient strict wire validation without rebuilding a validation framework.
+
+### Pydantic models as permanent protocol authority
+
+Not decided. This ADR applies only to `dtt/0`. Before a stable `dtt/1`, the project must review interoperability, generated C++ ergonomics, binary transport needs and compatibility guarantees.
+
+## Consequences
+
+Positive:
+
+- readable and strongly validated Python code;
+- generated schemas for non-Python clients and conformance tests;
+- quick iteration while the protocol remains experimental;
+- explicit rejection of unknown fields and illegal states;
+- recognizable tooling for external contributors.
+
+Costs and risks:
+
+- Pydantic becomes a runtime dependency for the Python path;
+- generated schemas may change with tool versions, so the dependency range and output must be controlled;
+- Unreal still needs explicit DTO parsing or later code generation;
+- large generated schemas should not hide whether the exercised fixture is actually understandable.
+
+## Validation gate
+
+This ADR is accepted when #5 demonstrates:
+
+- one strict complete dummy-operation fixture;
+- generated-schema drift detection in CI;
+- typed envelope payload parsing;
+- illegal transition and provenance failures;
+- no transport, Unreal Actor or SO-101 dependency in the protocol package.

--- a/protocol/v0/README.md
+++ b/protocol/v0/README.md
@@ -1,10 +1,31 @@
 # Experimental protocol namespace `dtt/0`
 
-The protocol is intentionally incomplete and unstable. M0 defines only enough shared structure to build conformance fixtures for the first vertical slice.
+The protocol is intentionally incomplete and unstable. M1 defines only the strict semantic spine
+needed by the delayed dummy vertical slice.
 
 ## Current contract
 
-`message-envelope.schema.json` describes transport-independent metadata around a typed payload. It does not define delivery, storage or physical-execution semantics by itself.
+`message-envelope.schema.json` is deterministically generated from strict Pydantic v2 wire DTOs.
+It describes transport-independent metadata around typed payloads, but does not define delivery,
+storage or physical-execution semantics by itself. Regenerate it with
+`python -m deferred_teleop.schema`; CI verifies it with `--check`.
+
+The constrained chain is:
+
+```text
+OperationIntent -> GroundedOperation -> OperationPlan (one TaskNode)
+-> TaskAssignment -> ExecutionContract -> ExecutionEvent
+```
+
+Operation states are `DRAFT -> SUBMITTED -> RECEIVED_BY_FIELD -> ADMITTED | HELD | REJECTED`.
+The M1 contract transition validator accepts only:
+
+```text
+RECEIVED -> ACCEPTED | HELD
+ACCEPTED -> DISPATCH_RECORDED | CANCELLED
+DISPATCH_RECORDED -> RUNNING
+RUNNING -> SUCCEEDED | FAILED | HELD | CANCELLED
+```
 
 Inter-site assumptions:
 

--- a/protocol/v0/fixtures/invalid/m1-cases.json
+++ b/protocol/v0/fixtures/invalid/m1-cases.json
@@ -1,0 +1,60 @@
+{
+  "unknown_field": {
+    "protocol_version": "dtt/0",
+    "message_id": "00000000-0000-4000-8000-000000000011",
+    "message_type": "operation.intent",
+    "source_id": "mission-1",
+    "source_boot_id": "10000000-0000-4000-8000-000000000001",
+    "source_sequence": 11,
+    "destination_id": "field-1",
+    "correlation_id": "20000000-0000-4000-8000-000000000001",
+    "created_at": "2026-09-04T09:00:00Z",
+    "unexpected": true,
+    "payload": {
+      "operation_id": "30000000-0000-4000-8000-000000000001",
+      "operation_type": "PRESS_BUTTON",
+      "selector": {"entity_id": "dummy-button-1"},
+      "preferred_executor": "dummy-robot-1",
+      "approval_policy": "AUTO_IF_WHITELISTED",
+      "state": "SUBMITTED"
+    }
+  },
+  "missing_causation": {
+    "protocol_version": "dtt/0",
+    "message_id": "00000000-0000-4000-8000-000000000012",
+    "message_type": "operation.plan",
+    "source_id": "field-1",
+    "source_boot_id": "10000000-0000-4000-8000-000000000002",
+    "source_sequence": 12,
+    "destination_id": "mission-1",
+    "correlation_id": "20000000-0000-4000-8000-000000000001",
+    "created_at": "2026-09-04T09:00:02Z",
+    "payload": {
+      "plan_id": "40000000-0000-4000-8000-000000000001",
+      "operation_id": "30000000-0000-4000-8000-000000000001",
+      "tasks": [{
+        "task_id": "50000000-0000-4000-8000-000000000001",
+        "skill": "PRESS_BUTTON",
+        "target_entity_id": "dummy-button-1"
+      }]
+    }
+  },
+  "invalid_spatial_metadata": {
+    "source_message_index": 1,
+    "replace": {
+      "payload.target_pose.frame.length_unit": "centimetre",
+      "payload.target_pose.frame.convention": "LEFT_HANDED_Z_UP"
+    }
+  },
+  "invalid_quaternion": {
+    "source_message_index": 1,
+    "replace": {"payload.target_pose.orientation.w": 2.0}
+  },
+  "illegal_contract_transition": {
+    "source_message_index": 5,
+    "replace": {
+      "payload.previous_state": "RECEIVED",
+      "payload.next_state": "SUCCEEDED"
+    }
+  }
+}

--- a/protocol/v0/fixtures/valid/dummy-operation-chain.json
+++ b/protocol/v0/fixtures/valid/dummy-operation-chain.json
@@ -1,0 +1,137 @@
+{
+  "messages": [
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000001",
+      "message_type": "operation.intent",
+      "source_id": "mission-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000001",
+      "source_sequence": 1,
+      "destination_id": "field-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "created_at": "2026-09-04T09:00:00Z",
+      "payload": {
+        "operation_id": "30000000-0000-4000-8000-000000000001",
+        "operation_type": "PRESS_BUTTON",
+        "selector": {"entity_id": "dummy-button-1"},
+        "preferred_executor": "dummy-robot-1",
+        "approval_policy": "AUTO_IF_WHITELISTED",
+        "state": "SUBMITTED"
+      }
+    },
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000002",
+      "message_type": "operation.grounded",
+      "source_id": "field-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000002",
+      "source_sequence": 1,
+      "destination_id": "mission-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "causation_id": "00000000-0000-4000-8000-000000000001",
+      "created_at": "2026-09-04T09:00:01Z",
+      "payload": {
+        "operation_id": "30000000-0000-4000-8000-000000000001",
+        "target_entity_id": "dummy-button-1",
+        "target_pose": {
+          "position": {"x": 0.4, "y": 0.1, "z": 0.2},
+          "orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+          "frame": {
+            "frame_id": "field-world",
+            "convention": "RIGHT_HANDED_Z_UP",
+            "length_unit": "metre",
+            "angle_unit": "radian",
+            "calibration_version": "cal-1"
+          }
+        },
+        "state": "ADMITTED",
+        "evidence": {
+          "source_ids": ["field-fixture"],
+          "observed_at": "2026-09-04T08:59:59Z",
+          "produced_at": "2026-09-04T09:00:01Z",
+          "provenance": "MEASURED",
+          "world_revision": 1,
+          "fresh_until": "2026-09-04T09:01:00Z"
+        }
+      }
+    },
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000003",
+      "message_type": "operation.plan",
+      "source_id": "field-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000002",
+      "source_sequence": 2,
+      "destination_id": "mission-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "causation_id": "00000000-0000-4000-8000-000000000002",
+      "created_at": "2026-09-04T09:00:02Z",
+      "payload": {
+        "plan_id": "40000000-0000-4000-8000-000000000001",
+        "operation_id": "30000000-0000-4000-8000-000000000001",
+        "tasks": [{
+          "task_id": "50000000-0000-4000-8000-000000000001",
+          "skill": "PRESS_BUTTON",
+          "target_entity_id": "dummy-button-1"
+        }]
+      }
+    },
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000004",
+      "message_type": "task.assignment",
+      "source_id": "field-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000002",
+      "source_sequence": 3,
+      "destination_id": "dummy-robot-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "causation_id": "00000000-0000-4000-8000-000000000003",
+      "created_at": "2026-09-04T09:00:03Z",
+      "payload": {
+        "assignment_id": "60000000-0000-4000-8000-000000000001",
+        "plan_id": "40000000-0000-4000-8000-000000000001",
+        "task_id": "50000000-0000-4000-8000-000000000001",
+        "executor_id": "dummy-robot-1"
+      }
+    },
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000005",
+      "message_type": "execution.contract",
+      "source_id": "field-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000002",
+      "source_sequence": 4,
+      "destination_id": "dummy-robot-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "causation_id": "00000000-0000-4000-8000-000000000004",
+      "created_at": "2026-09-04T09:00:04Z",
+      "payload": {
+        "contract_id": "70000000-0000-4000-8000-000000000001",
+        "contract_revision": 1,
+        "operation_id": "30000000-0000-4000-8000-000000000001",
+        "assignment_id": "60000000-0000-4000-8000-000000000001",
+        "state": "RECEIVED"
+      }
+    },
+    {
+      "protocol_version": "dtt/0",
+      "message_id": "00000000-0000-4000-8000-000000000006",
+      "message_type": "execution.event",
+      "source_id": "dummy-robot-1",
+      "source_boot_id": "10000000-0000-4000-8000-000000000003",
+      "source_sequence": 1,
+      "destination_id": "field-1",
+      "correlation_id": "20000000-0000-4000-8000-000000000001",
+      "causation_id": "00000000-0000-4000-8000-000000000005",
+      "created_at": "2026-09-04T09:00:05Z",
+      "payload": {
+        "event_id": "80000000-0000-4000-8000-000000000001",
+        "contract_id": "70000000-0000-4000-8000-000000000001",
+        "contract_revision": 1,
+        "previous_state": "RECEIVED",
+        "next_state": "ACCEPTED",
+        "occurred_at": "2026-09-04T09:00:05Z"
+      }
+    }
+  ]
+}

--- a/protocol/v0/fixtures/valid/message-envelope.json
+++ b/protocol/v0/fixtures/valid/message-envelope.json
@@ -1,14 +1,19 @@
 {
   "protocol_version": "dtt/0",
   "message_id": "9e4c8f49-d715-4fa5-93a9-bc4e41cfa1f9",
-  "message_type": "system.hello",
+  "message_type": "operation.intent",
   "source_id": "mission-dev",
+  "source_boot_id": "1e4c8f49-d715-4fa5-93a9-bc4e41cfa1f9",
   "destination_id": "field-dev",
-  "sequence_id": 0,
+  "source_sequence": 0,
   "correlation_id": "65d31b96-d35c-4fc3-97ed-f13e2c4b6ee5",
   "created_at": "2026-09-03T08:30:00Z",
   "payload": {
-    "implementation": "deferred-teleop",
-    "status": "experimental"
+    "operation_id": "30000000-0000-4000-8000-000000000001",
+    "operation_type": "PRESS_BUTTON",
+    "selector": {"entity_id": "dummy-button-1"},
+    "preferred_executor": "dummy-robot-1",
+    "approval_policy": "AUTO_IF_WHITELISTED",
+    "state": "SUBMITTED"
   }
 }

--- a/protocol/v0/schemas/message-envelope.schema.json
+++ b/protocol/v0/schemas/message-envelope.schema.json
@@ -1,65 +1,753 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "ContractState": {
+      "enum": [
+        "RECEIVED",
+        "ACCEPTED",
+        "DISPATCH_RECORDED",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+        "HELD",
+        "CANCELLED"
+      ],
+      "title": "ContractState",
+      "type": "string"
+    },
+    "EntitySelector": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_id": {
+          "minLength": 1,
+          "title": "Entity Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id"
+      ],
+      "title": "EntitySelector",
+      "type": "object"
+    },
+    "EvidenceMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "fresh_until": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fresh Until"
+        },
+        "model_version": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model Version"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "produced_at": {
+          "format": "date-time",
+          "title": "Produced At",
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ProvenanceKind"
+        },
+        "source_ids": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Source Ids",
+          "type": "array"
+        },
+        "world_revision": {
+          "minimum": 1,
+          "title": "World Revision",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "source_ids",
+        "observed_at",
+        "produced_at",
+        "provenance",
+        "world_revision"
+      ],
+      "title": "EvidenceMetadata",
+      "type": "object"
+    },
+    "ExecutionContract": {
+      "additionalProperties": false,
+      "properties": {
+        "assignment_id": {
+          "format": "uuid",
+          "title": "Assignment Id",
+          "type": "string"
+        },
+        "contract_id": {
+          "format": "uuid",
+          "title": "Contract Id",
+          "type": "string"
+        },
+        "contract_revision": {
+          "minimum": 1,
+          "title": "Contract Revision",
+          "type": "integer"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "state": {
+          "const": "RECEIVED",
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "contract_id",
+        "contract_revision",
+        "operation_id",
+        "assignment_id",
+        "state"
+      ],
+      "title": "ExecutionContract",
+      "type": "object"
+    },
+    "ExecutionEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "contract_id": {
+          "format": "uuid",
+          "title": "Contract Id",
+          "type": "string"
+        },
+        "contract_revision": {
+          "minimum": 1,
+          "title": "Contract Revision",
+          "type": "integer"
+        },
+        "event_id": {
+          "format": "uuid",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "next_state": {
+          "$ref": "#/$defs/ContractState"
+        },
+        "occurred_at": {
+          "format": "date-time",
+          "title": "Occurred At",
+          "type": "string"
+        },
+        "previous_state": {
+          "$ref": "#/$defs/ContractState"
+        }
+      },
+      "required": [
+        "event_id",
+        "contract_id",
+        "contract_revision",
+        "previous_state",
+        "next_state",
+        "occurred_at"
+      ],
+      "title": "ExecutionEvent",
+      "type": "object"
+    },
+    "GroundedOperation": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/EvidenceMetadata"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "state": {
+          "const": "ADMITTED",
+          "title": "State",
+          "type": "string"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        },
+        "target_pose": {
+          "$ref": "#/$defs/Pose"
+        }
+      },
+      "required": [
+        "operation_id",
+        "target_entity_id",
+        "target_pose",
+        "state",
+        "evidence"
+      ],
+      "title": "GroundedOperation",
+      "type": "object"
+    },
+    "OperationIntent": {
+      "additionalProperties": false,
+      "properties": {
+        "approval_policy": {
+          "const": "AUTO_IF_WHITELISTED",
+          "title": "Approval Policy",
+          "type": "string"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "operation_type": {
+          "const": "PRESS_BUTTON",
+          "title": "Operation Type",
+          "type": "string"
+        },
+        "preferred_executor": {
+          "minLength": 1,
+          "title": "Preferred Executor",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/EntitySelector"
+        },
+        "state": {
+          "const": "SUBMITTED",
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id",
+        "operation_type",
+        "selector",
+        "preferred_executor",
+        "approval_policy",
+        "state"
+      ],
+      "title": "OperationIntent",
+      "type": "object"
+    },
+    "OperationPlan": {
+      "additionalProperties": false,
+      "properties": {
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "plan_id": {
+          "format": "uuid",
+          "title": "Plan Id",
+          "type": "string"
+        },
+        "tasks": {
+          "items": {
+            "$ref": "#/$defs/TaskNode"
+          },
+          "maxItems": 1,
+          "minItems": 1,
+          "title": "Tasks",
+          "type": "array"
+        }
+      },
+      "required": [
+        "plan_id",
+        "operation_id",
+        "tasks"
+      ],
+      "title": "OperationPlan",
+      "type": "object"
+    },
+    "Pose": {
+      "additionalProperties": false,
+      "properties": {
+        "frame": {
+          "$ref": "#/$defs/SpatialFrame"
+        },
+        "orientation": {
+          "$ref": "#/$defs/Quaternion"
+        },
+        "position": {
+          "$ref": "#/$defs/Vector3"
+        }
+      },
+      "required": [
+        "position",
+        "orientation",
+        "frame"
+      ],
+      "title": "Pose",
+      "type": "object"
+    },
+    "PredictionManifest": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/EvidenceMetadata"
+        },
+        "forecast_ids": {
+          "items": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Forecast Ids",
+          "type": "array"
+        },
+        "generated_for_world_revision": {
+          "minimum": 1,
+          "title": "Generated For World Revision",
+          "type": "integer"
+        },
+        "manifest_id": {
+          "format": "uuid",
+          "title": "Manifest Id",
+          "type": "string"
+        },
+        "site_id": {
+          "minLength": 1,
+          "title": "Site Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest_id",
+        "site_id",
+        "forecast_ids",
+        "generated_for_world_revision",
+        "evidence"
+      ],
+      "title": "PredictionManifest",
+      "type": "object"
+    },
+    "ProvenanceKind": {
+      "enum": [
+        "MEASURED",
+        "FUSED",
+        "OPERATOR_ASSERTED",
+        "INFERRED",
+        "PREDICTED",
+        "SIMULATED"
+      ],
+      "title": "ProvenanceKind",
+      "type": "string"
+    },
+    "Quaternion": {
+      "additionalProperties": false,
+      "properties": {
+        "w": {
+          "title": "W",
+          "type": "number"
+        },
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z",
+        "w"
+      ],
+      "title": "Quaternion",
+      "type": "object"
+    },
+    "RobotForecast": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/EvidenceMetadata"
+        },
+        "predicted_for": {
+          "format": "date-time",
+          "title": "Predicted For",
+          "type": "string"
+        },
+        "predicted_pose": {
+          "$ref": "#/$defs/Pose"
+        },
+        "robot_id": {
+          "minLength": 1,
+          "title": "Robot Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "robot_id",
+        "predicted_pose",
+        "predicted_for",
+        "evidence"
+      ],
+      "title": "RobotForecast",
+      "type": "object"
+    },
+    "RobotState": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/EvidenceMetadata"
+        },
+        "pose": {
+          "$ref": "#/$defs/Pose"
+        },
+        "robot_id": {
+          "minLength": 1,
+          "title": "Robot Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "robot_id",
+        "pose",
+        "evidence"
+      ],
+      "title": "RobotState",
+      "type": "object"
+    },
+    "SiteSnapshot": {
+      "additionalProperties": false,
+      "properties": {
+        "entities": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Entities",
+          "type": "array"
+        },
+        "evidence": {
+          "$ref": "#/$defs/EvidenceMetadata"
+        },
+        "robot_states": {
+          "items": {
+            "$ref": "#/$defs/RobotState"
+          },
+          "title": "Robot States",
+          "type": "array"
+        },
+        "site_id": {
+          "minLength": 1,
+          "title": "Site Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "site_id",
+        "entities",
+        "robot_states",
+        "evidence"
+      ],
+      "title": "SiteSnapshot",
+      "type": "object"
+    },
+    "SpatialFrame": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_unit": {
+          "const": "radian",
+          "default": "radian",
+          "title": "Angle Unit",
+          "type": "string"
+        },
+        "calibration_version": {
+          "minLength": 1,
+          "title": "Calibration Version",
+          "type": "string"
+        },
+        "convention": {
+          "const": "RIGHT_HANDED_Z_UP",
+          "default": "RIGHT_HANDED_Z_UP",
+          "title": "Convention",
+          "type": "string"
+        },
+        "frame_id": {
+          "minLength": 1,
+          "title": "Frame Id",
+          "type": "string"
+        },
+        "length_unit": {
+          "const": "metre",
+          "default": "metre",
+          "title": "Length Unit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "frame_id",
+        "calibration_version"
+      ],
+      "title": "SpatialFrame",
+      "type": "object"
+    },
+    "TaskAssignment": {
+      "additionalProperties": false,
+      "properties": {
+        "assignment_id": {
+          "format": "uuid",
+          "title": "Assignment Id",
+          "type": "string"
+        },
+        "executor_id": {
+          "minLength": 1,
+          "title": "Executor Id",
+          "type": "string"
+        },
+        "plan_id": {
+          "format": "uuid",
+          "title": "Plan Id",
+          "type": "string"
+        },
+        "task_id": {
+          "format": "uuid",
+          "title": "Task Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "assignment_id",
+        "plan_id",
+        "task_id",
+        "executor_id"
+      ],
+      "title": "TaskAssignment",
+      "type": "object"
+    },
+    "TaskNode": {
+      "additionalProperties": false,
+      "properties": {
+        "skill": {
+          "const": "PRESS_BUTTON",
+          "title": "Skill",
+          "type": "string"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        },
+        "task_id": {
+          "format": "uuid",
+          "title": "Task Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "task_id",
+        "skill",
+        "target_entity_id"
+      ],
+      "title": "TaskNode",
+      "type": "object"
+    },
+    "Vector3": {
+      "additionalProperties": false,
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "title": "Vector3",
+      "type": "object"
+    }
+  },
   "$id": "https://github.com/YannickPr/Deferred-Teleoperation/protocol/v0/schemas/message-envelope.schema.json",
-  "title": "Deferred Teleoperation experimental message envelope",
-  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "properties": {
+    "causation_id": {
+      "anyOf": [
+        {
+          "format": "uuid",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Causation Id"
+    },
+    "correlation_id": {
+      "format": "uuid",
+      "title": "Correlation Id",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "destination_id": {
+      "minLength": 1,
+      "title": "Destination Id",
+      "type": "string"
+    },
+    "expires_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "message_id": {
+      "format": "uuid",
+      "title": "Message Id",
+      "type": "string"
+    },
+    "message_type": {
+      "enum": [
+        "operation.intent",
+        "operation.grounded",
+        "operation.plan",
+        "task.assignment",
+        "execution.contract",
+        "execution.event",
+        "robot.state",
+        "robot.forecast",
+        "site.snapshot",
+        "prediction.manifest"
+      ],
+      "title": "Message Type",
+      "type": "string"
+    },
+    "not_before": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Not Before"
+    },
+    "payload": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OperationIntent"
+        },
+        {
+          "$ref": "#/$defs/GroundedOperation"
+        },
+        {
+          "$ref": "#/$defs/OperationPlan"
+        },
+        {
+          "$ref": "#/$defs/TaskAssignment"
+        },
+        {
+          "$ref": "#/$defs/ExecutionContract"
+        },
+        {
+          "$ref": "#/$defs/ExecutionEvent"
+        },
+        {
+          "$ref": "#/$defs/RobotState"
+        },
+        {
+          "$ref": "#/$defs/RobotForecast"
+        },
+        {
+          "$ref": "#/$defs/SiteSnapshot"
+        },
+        {
+          "$ref": "#/$defs/PredictionManifest"
+        }
+      ],
+      "title": "Payload"
+    },
+    "protocol_version": {
+      "const": "dtt/0",
+      "default": "dtt/0",
+      "title": "Protocol Version",
+      "type": "string"
+    },
+    "source_boot_id": {
+      "format": "uuid",
+      "title": "Source Boot Id",
+      "type": "string"
+    },
+    "source_id": {
+      "minLength": 1,
+      "title": "Source Id",
+      "type": "string"
+    },
+    "source_sequence": {
+      "minimum": 0,
+      "title": "Source Sequence",
+      "type": "integer"
+    }
+  },
   "required": [
-    "protocol_version",
     "message_id",
     "message_type",
     "source_id",
+    "source_boot_id",
+    "source_sequence",
     "destination_id",
+    "correlation_id",
     "created_at",
     "payload"
   ],
-  "properties": {
-    "protocol_version": {
-      "const": "dtt/0"
-    },
-    "message_id": {
-      "type": "string",
-      "format": "uuid"
-    },
-    "message_type": {
-      "type": "string",
-      "minLength": 1,
-      "pattern": "^[A-Za-z][A-Za-z0-9_.-]*$"
-    },
-    "source_id": {
-      "type": "string",
-      "minLength": 1
-    },
-    "destination_id": {
-      "type": "string",
-      "minLength": 1
-    },
-    "sequence_id": {
-      "type": "integer",
-      "minimum": 0
-    },
-    "correlation_id": {
-      "type": "string",
-      "format": "uuid"
-    },
-    "causation_id": {
-      "type": "string",
-      "format": "uuid"
-    },
-    "created_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "observed_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "expires_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "payload": {
-      "type": "object"
-    }
-  }
+  "title": "MessageEnvelope",
+  "type": "object"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = []
+dependencies = [
+    "pydantic>=2.11,<3",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/python/src/deferred_teleop/__init__.py
+++ b/python/src/deferred_teleop/__init__.py
@@ -1,6 +1,8 @@
 """Public Python namespace for Deferred Teleoperation."""
 
-__all__ = ["PROTOCOL_VERSION", "__version__"]
+from deferred_teleop.protocol import MessageEnvelope
+
+__all__ = ["MessageEnvelope", "PROTOCOL_VERSION", "__version__"]
 
 __version__ = "0.0.0"
 PROTOCOL_VERSION = "dtt/0"

--- a/python/src/deferred_teleop/protocol.py
+++ b/python/src/deferred_teleop/protocol.py
@@ -1,0 +1,298 @@
+"""Strict experimental ``dtt/0`` wire models for the M1 dummy path."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class WireModel(BaseModel):
+    """Base for versioned wire DTOs; unknown fields are protocol errors."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+OpaqueId = Annotated[str, Field(min_length=1)]
+Revision = Annotated[int, Field(ge=1)]
+
+
+class ProvenanceKind(StrEnum):
+    MEASURED = "MEASURED"
+    FUSED = "FUSED"
+    OPERATOR_ASSERTED = "OPERATOR_ASSERTED"
+    INFERRED = "INFERRED"
+    PREDICTED = "PREDICTED"
+    SIMULATED = "SIMULATED"
+
+
+class EvidenceMetadata(WireModel):
+    source_ids: Annotated[tuple[OpaqueId, ...], Field(min_length=1)]
+    observed_at: datetime
+    produced_at: datetime
+    provenance: ProvenanceKind
+    world_revision: Revision
+    fresh_until: datetime | None = None
+    model_version: OpaqueId | None = None
+
+    @model_validator(mode="after")
+    def validate_times(self) -> EvidenceMetadata:
+        if self.produced_at < self.observed_at:
+            raise ValueError("produced_at cannot precede observed_at")
+        if self.fresh_until is not None and self.fresh_until < self.observed_at:
+            raise ValueError("fresh_until cannot precede observed_at")
+        if self.provenance in {ProvenanceKind.PREDICTED, ProvenanceKind.SIMULATED}:
+            if self.model_version is None:
+                raise ValueError("predicted or simulated evidence requires model_version")
+        return self
+
+
+class SpatialFrame(WireModel):
+    frame_id: OpaqueId
+    convention: Literal["RIGHT_HANDED_Z_UP"] = "RIGHT_HANDED_Z_UP"
+    length_unit: Literal["metre"] = "metre"
+    angle_unit: Literal["radian"] = "radian"
+    calibration_version: OpaqueId
+
+
+class Vector3(WireModel):
+    x: float
+    y: float
+    z: float
+
+
+class Quaternion(WireModel):
+    x: float
+    y: float
+    z: float
+    w: float
+
+    @model_validator(mode="after")
+    def validate_unit_length(self) -> Quaternion:
+        norm_squared = self.x**2 + self.y**2 + self.z**2 + self.w**2
+        if abs(norm_squared - 1.0) > 1e-6:
+            raise ValueError("quaternion must have unit length")
+        return self
+
+
+class Pose(WireModel):
+    position: Vector3
+    orientation: Quaternion
+    frame: SpatialFrame
+
+
+class OperationType(StrEnum):
+    PRESS_BUTTON = "PRESS_BUTTON"
+
+
+class ApprovalPolicy(StrEnum):
+    AUTO_IF_WHITELISTED = "AUTO_IF_WHITELISTED"
+
+
+class OperationState(StrEnum):
+    DRAFT = "DRAFT"
+    SUBMITTED = "SUBMITTED"
+    RECEIVED_BY_FIELD = "RECEIVED_BY_FIELD"
+    ADMITTED = "ADMITTED"
+    HELD = "HELD"
+    REJECTED = "REJECTED"
+
+
+class ContractState(StrEnum):
+    RECEIVED = "RECEIVED"
+    ACCEPTED = "ACCEPTED"
+    DISPATCH_RECORDED = "DISPATCH_RECORDED"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    HELD = "HELD"
+    CANCELLED = "CANCELLED"
+
+
+class EntitySelector(WireModel):
+    entity_id: OpaqueId
+
+
+class OperationIntent(WireModel):
+    operation_id: UUID
+    operation_type: Literal[OperationType.PRESS_BUTTON]
+    selector: EntitySelector
+    preferred_executor: OpaqueId
+    approval_policy: Literal[ApprovalPolicy.AUTO_IF_WHITELISTED]
+    state: Literal[OperationState.SUBMITTED]
+
+
+class GroundedOperation(WireModel):
+    operation_id: UUID
+    target_entity_id: OpaqueId
+    target_pose: Pose
+    state: Literal[OperationState.ADMITTED]
+    evidence: EvidenceMetadata
+
+
+class TaskNode(WireModel):
+    task_id: UUID
+    skill: Literal[OperationType.PRESS_BUTTON]
+    target_entity_id: OpaqueId
+
+
+class OperationPlan(WireModel):
+    plan_id: UUID
+    operation_id: UUID
+    tasks: Annotated[tuple[TaskNode, ...], Field(min_length=1, max_length=1)]
+
+
+class TaskAssignment(WireModel):
+    assignment_id: UUID
+    plan_id: UUID
+    task_id: UUID
+    executor_id: OpaqueId
+
+
+class ExecutionContract(WireModel):
+    contract_id: UUID
+    contract_revision: Revision
+    operation_id: UUID
+    assignment_id: UUID
+    state: Literal[ContractState.RECEIVED]
+
+
+CONTRACT_TRANSITIONS: dict[ContractState, frozenset[ContractState]] = {
+    ContractState.RECEIVED: frozenset({ContractState.ACCEPTED, ContractState.HELD}),
+    ContractState.ACCEPTED: frozenset({ContractState.DISPATCH_RECORDED, ContractState.CANCELLED}),
+    ContractState.DISPATCH_RECORDED: frozenset({ContractState.RUNNING}),
+    ContractState.RUNNING: frozenset(
+        {ContractState.SUCCEEDED, ContractState.FAILED, ContractState.HELD, ContractState.CANCELLED}
+    ),
+}
+
+
+class ExecutionEvent(WireModel):
+    event_id: UUID
+    contract_id: UUID
+    contract_revision: Revision
+    previous_state: ContractState
+    next_state: ContractState
+    occurred_at: datetime
+
+    @model_validator(mode="after")
+    def validate_transition(self) -> ExecutionEvent:
+        if self.next_state not in CONTRACT_TRANSITIONS.get(self.previous_state, frozenset()):
+            raise ValueError(
+                f"illegal contract transition: {self.previous_state} -> {self.next_state}"
+            )
+        return self
+
+
+class RobotState(WireModel):
+    robot_id: OpaqueId
+    pose: Pose
+    evidence: EvidenceMetadata
+
+
+class RobotForecast(WireModel):
+    robot_id: OpaqueId
+    predicted_pose: Pose
+    predicted_for: datetime
+    evidence: EvidenceMetadata
+
+    @model_validator(mode="after")
+    def validate_prediction(self) -> RobotForecast:
+        if self.evidence.provenance is not ProvenanceKind.PREDICTED:
+            raise ValueError("RobotForecast evidence must be PREDICTED")
+        if self.predicted_for <= self.evidence.produced_at:
+            raise ValueError("predicted_for must be after produced_at")
+        return self
+
+
+class SiteSnapshot(WireModel):
+    site_id: OpaqueId
+    entities: Annotated[tuple[OpaqueId, ...], Field(min_length=1)]
+    robot_states: tuple[RobotState, ...]
+    evidence: EvidenceMetadata
+
+
+class PredictionManifest(WireModel):
+    manifest_id: UUID
+    site_id: OpaqueId
+    forecast_ids: Annotated[tuple[UUID, ...], Field(min_length=1)]
+    generated_for_world_revision: Revision
+    evidence: EvidenceMetadata
+
+    @model_validator(mode="after")
+    def validate_prediction(self) -> PredictionManifest:
+        if self.evidence.provenance is not ProvenanceKind.PREDICTED:
+            raise ValueError("PredictionManifest evidence must be PREDICTED")
+        return self
+
+
+Payload = Annotated[
+    OperationIntent
+    | GroundedOperation
+    | OperationPlan
+    | TaskAssignment
+    | ExecutionContract
+    | ExecutionEvent
+    | RobotState
+    | RobotForecast
+    | SiteSnapshot
+    | PredictionManifest,
+    Field(union_mode="left_to_right"),
+]
+
+
+ROOT_MESSAGE_TYPES = frozenset({"operation.intent", "robot.state", "site.snapshot"})
+PAYLOAD_TYPES: dict[str, type[WireModel]] = {
+    "operation.intent": OperationIntent,
+    "operation.grounded": GroundedOperation,
+    "operation.plan": OperationPlan,
+    "task.assignment": TaskAssignment,
+    "execution.contract": ExecutionContract,
+    "execution.event": ExecutionEvent,
+    "robot.state": RobotState,
+    "robot.forecast": RobotForecast,
+    "site.snapshot": SiteSnapshot,
+    "prediction.manifest": PredictionManifest,
+}
+
+
+class MessageEnvelope(WireModel):
+    protocol_version: Literal["dtt/0"] = "dtt/0"
+    message_id: UUID
+    message_type: Literal[
+        "operation.intent",
+        "operation.grounded",
+        "operation.plan",
+        "task.assignment",
+        "execution.contract",
+        "execution.event",
+        "robot.state",
+        "robot.forecast",
+        "site.snapshot",
+        "prediction.manifest",
+    ]
+    source_id: OpaqueId
+    source_boot_id: UUID
+    source_sequence: Annotated[int, Field(ge=0)]
+    destination_id: OpaqueId
+    correlation_id: UUID
+    causation_id: UUID | None = None
+    created_at: datetime
+    not_before: datetime | None = None
+    expires_at: datetime | None = None
+    payload: Payload
+
+    @model_validator(mode="after")
+    def validate_envelope(self) -> MessageEnvelope:
+        expected = PAYLOAD_TYPES[self.message_type]
+        if type(self.payload) is not expected:
+            raise ValueError(f"{self.message_type} requires payload {expected.__name__}")
+        if self.message_type not in ROOT_MESSAGE_TYPES and self.causation_id is None:
+            raise ValueError("direct-consequence messages require causation_id")
+        if self.not_before is not None and self.expires_at is not None:
+            if self.expires_at <= self.not_before:
+                raise ValueError("expires_at must be after not_before")
+        return self

--- a/python/src/deferred_teleop/schema.py
+++ b/python/src/deferred_teleop/schema.py
@@ -1,0 +1,40 @@
+"""Generate or verify committed JSON Schema interoperability artefacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from deferred_teleop.protocol import MessageEnvelope
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "protocol" / "v0" / "schemas" / "message-envelope.schema.json"
+
+
+def rendered_schema() -> str:
+    schema = MessageEnvelope.model_json_schema(mode="validation")
+    schema["$id"] = (
+        "https://github.com/YannickPr/Deferred-Teleoperation/"
+        "protocol/v0/schemas/message-envelope.schema.json"
+    )
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    expected = rendered_schema()
+    if args.check:
+        if not SCHEMA_PATH.exists() or SCHEMA_PATH.read_text(encoding="utf-8") != expected:
+            print(f"schema drift detected: regenerate {SCHEMA_PATH}")
+            return 1
+        return 0
+    SCHEMA_PATH.write_text(expected, encoding="utf-8", newline="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_m1_protocol.py
+++ b/tests/test_m1_protocol.py
@@ -1,0 +1,77 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from deferred_teleop.protocol import MessageEnvelope
+from deferred_teleop.schema import SCHEMA_PATH, rendered_schema
+from pydantic import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN_PATH = ROOT / "protocol" / "v0" / "fixtures" / "valid" / "dummy-operation-chain.json"
+INVALID_PATH = ROOT / "protocol" / "v0" / "fixtures" / "invalid" / "m1-cases.json"
+
+
+def _load(path: Path) -> object:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def test_complete_dummy_chain_round_trips_and_preserves_cross_references() -> None:
+    raw_messages = _load(CHAIN_PATH)["messages"]
+    messages = [
+        MessageEnvelope.model_validate_json(json.dumps(message)) for message in raw_messages
+    ]
+
+    assert [message.message_type for message in messages] == [
+        "operation.intent",
+        "operation.grounded",
+        "operation.plan",
+        "task.assignment",
+        "execution.contract",
+        "execution.event",
+    ]
+    assert all(message.correlation_id == messages[0].correlation_id for message in messages)
+    assert all(
+        message.causation_id == messages[index - 1].message_id
+        for index, message in enumerate(messages[1:], start=1)
+    )
+    operation_id = UUID("30000000-0000-4000-8000-000000000001")
+    assert messages[0].payload.operation_id == operation_id
+    assert messages[4].payload.operation_id == operation_id
+    assert messages[2].payload.plan_id == messages[3].payload.plan_id
+    assert messages[2].payload.tasks[0].task_id == messages[3].payload.task_id
+    assert messages[3].payload.assignment_id == messages[4].payload.assignment_id
+    assert messages[4].payload.contract_id == messages[5].payload.contract_id
+    assert messages[4].payload.contract_revision == messages[5].payload.contract_revision
+
+    encoded = [message.model_dump_json() for message in messages]
+    assert [MessageEnvelope.model_validate_json(item) for item in encoded] == messages
+
+
+@pytest.mark.parametrize("case", ["unknown_field", "missing_causation"])
+def test_committed_invalid_envelopes_are_rejected(case: str) -> None:
+    with pytest.raises(ValidationError):
+        MessageEnvelope.model_validate_json(json.dumps(_load(INVALID_PATH)[case]))
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["invalid_spatial_metadata", "invalid_quaternion", "illegal_contract_transition"],
+)
+def test_committed_invalid_mutation_fixtures_are_rejected(case: str) -> None:
+    specification = _load(INVALID_PATH)[case]
+    message = deepcopy(_load(CHAIN_PATH)["messages"][specification["source_message_index"]])
+    for dotted_path, value in specification["replace"].items():
+        target = message
+        path = dotted_path.split(".")
+        for component in path[:-1]:
+            target = target[component]
+        target[path[-1]] = value
+    with pytest.raises(ValidationError):
+        MessageEnvelope.model_validate_json(json.dumps(message))
+
+
+def test_committed_schema_has_no_drift() -> None:
+    assert SCHEMA_PATH.read_text(encoding="utf-8") == rendered_schema()


### PR DESCRIPTION
## Summary

Implements the strict experimental `dtt/0` protocol spine required by #5 for the first delayed-dummy operation:

```text
OperationIntent -> GroundedOperation -> one-node OperationPlan
-> TaskAssignment -> ExecutionContract -> ExecutionEvent
```

Also includes the minimum `RobotState`, `RobotForecast`, `SiteSnapshot` and `PredictionManifest` wire models needed by later M1 runtime and visualization work.

## Included

- strict Pydantic v2 DTOs with unknown fields rejected;
- typed envelope payload parsing and causal metadata;
- SI units, right-handed Z-up frames, normalized quaternions and evidence provenance;
- validated contract transitions;
- deterministic committed Draft 2020-12 JSON Schema with CI drift detection;
- one complete valid dummy-operation chain and committed invalid mutation fixtures;
- round-trip, cross-reference, causation, spatial metadata and transition tests;
- no transport, Unreal Actor, SO-101 or hardware dependency.

## Validation

- `ruff check .`
- `python -m deferred_teleop.schema --check`
- `pytest` — 10 passed locally
- GitHub Actions — Python 3.11 and 3.12 passed

## Scope

The models remain explicitly experimental `dtt/0`. Pydantic is not established as the permanent authority for a future stable `dtt/1`.

Closes #5
Parent milestone: #4