### PR TITLE
feat(storage): add durable M1 node journal

### DIFF
--- a/docs/adr/0003-durable-node-store.md
+++ b/docs/adr/0003-durable-node-store.md
@@ -1,0 +1,45 @@
+# ADR 0003: SQLite durable node store and effect boundary
+
+- Status: Proposed for M1
+- Date: 2026-09-04
+- Scope: M1 Mission, Field and dummy Robot processes
+- Issue: #6
+
+## Decision
+
+Each logical node owns a separate SQLite database. The Python runtime configures WAL mode,
+full synchronous commits, foreign keys and a 5000 ms busy timeout. Explicit numbered migrations
+create the inbox, outbox, execution journal and append-only execution audit.
+
+Incoming envelopes are committed before a handler sees them. A unique `message_id` makes
+redelivery idempotent; reuse of the same identifier with different bytes is a loud conflict.
+Handler completion and all outgoing consequences can be committed in one transaction. Pending
+outbox records survive restart and remain at-least-once until acknowledged.
+
+One execution-journal row owns each `(contract_id, contract_revision)`. A globally unique
+`effect_key` prevents two contract rows from claiming the same semantic effect. Terminal fields
+are immutable; later forensic annotations go into the append-only audit table.
+
+## Exact guarantee boundary
+
+For the M1 dummy, the effect is a database fact (`effect_count = 1`). That fact, the immutable
+terminal result and the terminal-event outbox record are committed atomically. Redelivery and
+restart can therefore produce **at most one dummy effect** and eventually retransmit one durable
+terminal result.
+
+SQLite cannot make a future physical action and a database commit atomic. A physical adapter
+must use hardware acknowledgement, an idempotency key, or record an explicit uncertain outcome;
+it must never infer exactly-once execution merely from a committed dispatch. This ADR makes no
+exactly-once network or physical-effect claim.
+
+## Recovery
+
+- `PROCESSING` inbox rows are returned to `RECEIVED` after a detected process restart.
+- committed outbox rows remain pending with their attempt count and next-attempt time;
+- accepted and dispatch-recorded contracts resume from their durable journal state;
+- terminal results and their outgoing events are committed together;
+- corrupt typed envelopes raise without rewriting the stored bytes.
+
+The crash-window suite closes and reopens real file-backed databases at every boundary specified
+by #6. Distributed SQL, consensus, production HA, key storage and retention policy remain out of
+scope.

--- a/python/src/deferred_teleop/__init__.py
+++ b/python/src/deferred_teleop/__init__.py
@@ -1,8 +1,9 @@
 """Public Python namespace for Deferred Teleoperation."""
 
 from deferred_teleop.protocol import MessageEnvelope
+from deferred_teleop.storage import NodeStore
 
-__all__ = ["MessageEnvelope", "PROTOCOL_VERSION", "__version__"]
+__all__ = ["MessageEnvelope", "NodeStore", "PROTOCOL_VERSION", "__version__"]
 
 __version__ = "0.0.0"
 PROTOCOL_VERSION = "dtt/0"

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -1,0 +1,653 @@
+"""Durable SQLite endpoint state for the M1 delayed-dummy runtime.
+
+The store provides at-least-once message processing and an effect-once database
+boundary for the dummy effect. It deliberately does not claim that SQLite can
+make a future external physical action exactly-once.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from deferred_teleop.protocol import ContractState, ExecutionEvent, MessageEnvelope
+
+CURRENT_SCHEMA_VERSION = 2
+DEFAULT_BUSY_TIMEOUT_MS = 5_000
+TERMINAL_STATES = frozenset(
+    {
+        ContractState.SUCCEEDED.value,
+        ContractState.FAILED.value,
+        ContractState.HELD.value,
+        ContractState.CANCELLED.value,
+    }
+)
+
+
+class StorageError(RuntimeError):
+    """Base class for durable-store failures."""
+
+
+class IncompatibleSchemaError(StorageError):
+    """The database schema is newer than this implementation."""
+
+
+class CorruptRecordError(StorageError):
+    """A persisted record cannot be decoded without changing forensic data."""
+
+
+class RecordConflictError(StorageError):
+    """A stable identifier was reused for different immutable content."""
+
+
+class InvalidStateTransitionError(StorageError):
+    """A requested durable state transition is illegal."""
+
+
+def _utc_text(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_text() -> str:
+    return _utc_text(datetime.now(UTC))
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _envelope_json(envelope: MessageEnvelope) -> str:
+    return _canonical_json(envelope.model_dump(mode="json"))
+
+
+def _result_json(result: Mapping[str, Any]) -> str:
+    try:
+        encoded = _canonical_json(result)
+    except (TypeError, ValueError) as error:
+        raise ValueError("terminal results must be JSON objects") from error
+    if not isinstance(json.loads(encoded), dict):
+        raise ValueError("terminal results must be JSON objects")
+    return encoded
+
+
+def _configure(connection: sqlite3.Connection, busy_timeout_ms: int) -> None:
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
+    connection.execute("PRAGMA journal_mode = WAL")
+    connection.execute("PRAGMA synchronous = FULL")
+
+
+def _migration_1(connection: sqlite3.Connection) -> None:
+    statements = (
+        """
+        CREATE TABLE inbox (
+            message_id TEXT PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            source_boot_id TEXT NOT NULL,
+            source_sequence INTEGER NOT NULL CHECK (source_sequence >= 0),
+            correlation_id TEXT NOT NULL,
+            received_at TEXT NOT NULL,
+            payload_type TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            processing_state TEXT NOT NULL
+                CHECK (processing_state IN ('RECEIVED', 'PROCESSING', 'PROCESSED', 'FAILED')),
+            processed_at TEXT,
+            handler_result_reference TEXT,
+            error_json TEXT
+        )
+        """,
+        """
+        CREATE TABLE outbox (
+            message_id TEXT PRIMARY KEY,
+            destination_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            not_before TEXT,
+            expires_at TEXT,
+            payload_json TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+            next_attempt_at TEXT,
+            ack_state TEXT NOT NULL DEFAULT 'PENDING'
+                CHECK (ack_state IN ('PENDING', 'ACKED')),
+            acked_at TEXT
+        )
+        """,
+        """
+        CREATE TABLE execution_journal (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL CHECK (contract_revision >= 1),
+            operation_id TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            effect_key TEXT NOT NULL UNIQUE,
+            effect_count INTEGER NOT NULL DEFAULT 0 CHECK (effect_count IN (0, 1)),
+            accepted_at TEXT NOT NULL,
+            dispatch_recorded_at TEXT,
+            effect_started_at TEXT,
+            terminal_at TEXT,
+            terminal_result_json TEXT,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """,
+    )
+    for statement in statements:
+        connection.execute(statement)
+
+
+def _migration_2(connection: sqlite3.Connection) -> None:
+    statements = (
+        """
+        CREATE TABLE execution_audit (
+            audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL,
+            recorded_at TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            FOREIGN KEY (contract_id, contract_revision)
+                REFERENCES execution_journal (contract_id, contract_revision)
+        )
+        """,
+        "CREATE INDEX inbox_processing_idx ON inbox (processing_state, received_at)",
+        "CREATE INDEX outbox_pending_idx ON outbox (ack_state, next_attempt_at, created_at)",
+        "CREATE INDEX inbox_correlation_idx ON inbox (correlation_id)",
+        "CREATE INDEX outbox_correlation_idx ON outbox (correlation_id)",
+    )
+    for statement in statements:
+        connection.execute(statement)
+
+
+MIGRATIONS = {1: _migration_1, 2: _migration_2}
+
+
+def initialize_database(
+    path: str | Path,
+    *,
+    target_version: int = CURRENT_SCHEMA_VERSION,
+    busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+) -> None:
+    """Create or upgrade a node database through explicit numbered migrations."""
+
+    if not 0 <= target_version <= CURRENT_SCHEMA_VERSION:
+        raise ValueError(f"unsupported migration target: {target_version}")
+    connection = sqlite3.connect(Path(path), isolation_level=None)
+    try:
+        _configure(connection, busy_timeout_ms)
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            )
+            """
+        )
+        row = connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
+        current = int(row[0] or 0)
+        if current > CURRENT_SCHEMA_VERSION:
+            raise IncompatibleSchemaError(
+                f"database schema {current} is newer than supported {CURRENT_SCHEMA_VERSION}"
+            )
+        for version in range(current + 1, target_version + 1):
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                MIGRATIONS[version](connection)
+                connection.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (version, _now_text()),
+                )
+            except BaseException:
+                connection.rollback()
+                raise
+            else:
+                connection.commit()
+    finally:
+        connection.close()
+
+
+class NodeStore:
+    """One durable SQLite store for one logical Mission, Field, or Robot node."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        initialize_database(self.path, busy_timeout_ms=busy_timeout_ms)
+        self._connection = sqlite3.connect(self.path, isolation_level=None)
+        self._connection.row_factory = sqlite3.Row
+        _configure(self._connection, busy_timeout_ms)
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def __enter__(self) -> NodeStore:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        self._connection.execute("BEGIN IMMEDIATE")
+        try:
+            yield self._connection
+        except BaseException:
+            self._connection.rollback()
+            raise
+        else:
+            self._connection.commit()
+
+    @property
+    def schema_version(self) -> int:
+        row = self._connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
+        return int(row[0] or 0)
+
+    def pragmas(self) -> dict[str, int | str]:
+        journal_mode = str(self._connection.execute("PRAGMA journal_mode").fetchone()[0])
+        busy_timeout = int(self._connection.execute("PRAGMA busy_timeout").fetchone()[0])
+        return {"journal_mode": journal_mode, "busy_timeout_ms": busy_timeout}
+
+    def receive(self, envelope: MessageEnvelope, *, received_at: datetime) -> bool:
+        """Persist before handling; return False only for an identical duplicate."""
+
+        encoded = _envelope_json(envelope)
+        with self._transaction() as connection:
+            existing = connection.execute(
+                "SELECT payload_json FROM inbox WHERE message_id = ?", (str(envelope.message_id),)
+            ).fetchone()
+            if existing is not None:
+                if existing["payload_json"] != encoded:
+                    raise RecordConflictError(f"inbox message_id collision: {envelope.message_id}")
+                return False
+            connection.execute(
+                """
+                INSERT INTO inbox (
+                    message_id, source_id, source_boot_id, source_sequence, correlation_id,
+                    received_at, payload_type, payload_json, processing_state
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'RECEIVED')
+                """,
+                (
+                    str(envelope.message_id),
+                    envelope.source_id,
+                    str(envelope.source_boot_id),
+                    envelope.source_sequence,
+                    str(envelope.correlation_id),
+                    _utc_text(received_at),
+                    envelope.message_type,
+                    encoded,
+                ),
+            )
+        return True
+
+    def recover_interrupted_processing(self) -> int:
+        """Make messages claimed by a crashed handler available for retry."""
+
+        with self._transaction() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'RECEIVED'
+                WHERE processing_state = 'PROCESSING'
+                """
+            )
+        return cursor.rowcount
+
+    def claim_next_inbox(self) -> MessageEnvelope | None:
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT message_id, payload_json FROM inbox
+                WHERE processing_state IN ('RECEIVED', 'FAILED')
+                ORDER BY received_at, message_id LIMIT 1
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            envelope = self._decode_envelope("inbox", row["message_id"], row["payload_json"])
+            connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'PROCESSING', error_json = NULL
+                WHERE message_id = ?
+                """,
+                (row["message_id"],),
+            )
+            return envelope
+
+    def fail_inbox(self, message_id: UUID, error: Mapping[str, Any]) -> None:
+        with self._transaction() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'FAILED', error_json = ?
+                WHERE message_id = ? AND processing_state = 'PROCESSING'
+                """,
+                (_result_json(error), str(message_id)),
+            )
+            if cursor.rowcount != 1:
+                raise InvalidStateTransitionError("only PROCESSING inbox messages can fail")
+
+    def complete_inbox(
+        self,
+        message_id: UUID,
+        *,
+        processed_at: datetime,
+        handler_result_reference: str,
+        outgoing: Sequence[MessageEnvelope] = (),
+    ) -> None:
+        """Atomically commit handler completion and all outgoing consequences."""
+
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT processing_state FROM inbox WHERE message_id = ?", (str(message_id),)
+            ).fetchone()
+            if row is None or row["processing_state"] != "PROCESSING":
+                raise InvalidStateTransitionError("only PROCESSING inbox messages can complete")
+            for envelope in outgoing:
+                self._insert_outbox(connection, envelope)
+            connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'PROCESSED', processed_at = ?,
+                    handler_result_reference = ?, error_json = NULL
+                WHERE message_id = ?
+                """,
+                (_utc_text(processed_at), handler_result_reference, str(message_id)),
+            )
+
+    def enqueue(self, envelope: MessageEnvelope) -> bool:
+        with self._transaction() as connection:
+            return self._insert_outbox(connection, envelope)
+
+    def _insert_outbox(
+        self, connection: sqlite3.Connection, envelope: MessageEnvelope
+    ) -> bool:
+        encoded = _envelope_json(envelope)
+        existing = connection.execute(
+            "SELECT payload_json FROM outbox WHERE message_id = ?", (str(envelope.message_id),)
+        ).fetchone()
+        if existing is not None:
+            if existing["payload_json"] != encoded:
+                raise RecordConflictError(f"outbox message_id collision: {envelope.message_id}")
+            return False
+        connection.execute(
+            """
+            INSERT INTO outbox (
+                message_id, destination_id, correlation_id, created_at, not_before,
+                expires_at, payload_json, next_attempt_at, ack_state
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING')
+            """,
+            (
+                str(envelope.message_id),
+                envelope.destination_id,
+                str(envelope.correlation_id),
+                _utc_text(envelope.created_at),
+                _utc_text(envelope.not_before) if envelope.not_before else None,
+                _utc_text(envelope.expires_at) if envelope.expires_at else None,
+                encoded,
+                _utc_text(envelope.not_before or envelope.created_at),
+            ),
+        )
+        return True
+
+    def pending_outbox(self, *, now: datetime) -> list[MessageEnvelope]:
+        rows = self._connection.execute(
+            """
+            SELECT message_id, payload_json FROM outbox
+            WHERE ack_state = 'PENDING'
+              AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+              AND (expires_at IS NULL OR expires_at > ?)
+            ORDER BY created_at, message_id
+            """,
+            (_utc_text(now), _utc_text(now)),
+        ).fetchall()
+        return [
+            self._decode_envelope("outbox", row["message_id"], row["payload_json"])
+            for row in rows
+        ]
+
+    def record_attempt(self, message_id: UUID, *, next_attempt_at: datetime) -> int:
+        with self._transaction() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE outbox SET attempt_count = attempt_count + 1, next_attempt_at = ?
+                WHERE message_id = ? AND ack_state = 'PENDING'
+                """,
+                (_utc_text(next_attempt_at), str(message_id)),
+            )
+            if cursor.rowcount != 1:
+                raise InvalidStateTransitionError("only pending outbox messages can be attempted")
+            row = connection.execute(
+                "SELECT attempt_count FROM outbox WHERE message_id = ?", (str(message_id),)
+            ).fetchone()
+            return int(row["attempt_count"])
+
+    def acknowledge(self, message_id: UUID, *, acked_at: datetime) -> bool:
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT ack_state FROM outbox WHERE message_id = ?", (str(message_id),)
+            ).fetchone()
+            if row is None:
+                raise KeyError(str(message_id))
+            if row["ack_state"] == "ACKED":
+                return False
+            connection.execute(
+                "UPDATE outbox SET ack_state = 'ACKED', acked_at = ? WHERE message_id = ?",
+                (_utc_text(acked_at), str(message_id)),
+            )
+            return True
+
+    def accept_contract(
+        self,
+        *,
+        contract_id: UUID,
+        contract_revision: int,
+        operation_id: UUID,
+        task_id: UUID,
+        effect_key: str,
+        accepted_at: datetime,
+    ) -> bool:
+        immutable = (str(operation_id), str(task_id), effect_key)
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT operation_id, task_id, effect_key FROM execution_journal
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (str(contract_id), contract_revision),
+            ).fetchone()
+            if row is not None:
+                if tuple(row) != immutable:
+                    raise RecordConflictError("contract revision collision")
+                return False
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO execution_journal (
+                        contract_id, contract_revision, operation_id, task_id, state,
+                        effect_key, accepted_at
+                    ) VALUES (?, ?, ?, ?, 'ACCEPTED', ?, ?)
+                    """,
+                    (
+                        str(contract_id),
+                        contract_revision,
+                        str(operation_id),
+                        str(task_id),
+                        effect_key,
+                        _utc_text(accepted_at),
+                    ),
+                )
+            except sqlite3.IntegrityError as error:
+                raise RecordConflictError(f"effect_key already claimed: {effect_key}") from error
+        return True
+
+    def record_dispatch(
+        self, contract_id: UUID, contract_revision: int, *, recorded_at: datetime
+    ) -> bool:
+        with self._transaction() as connection:
+            row = self._journal_row(connection, contract_id, contract_revision)
+            if row["dispatch_recorded_at"] is not None:
+                return False
+            if row["state"] != "ACCEPTED":
+                raise InvalidStateTransitionError("dispatch requires ACCEPTED state")
+            connection.execute(
+                """
+                UPDATE execution_journal
+                SET state = 'DISPATCH_RECORDED', dispatch_recorded_at = ?
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (_utc_text(recorded_at), str(contract_id), contract_revision),
+            )
+        return True
+
+    def commit_dummy_effect(
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        terminal_state: ContractState,
+        terminal_result: Mapping[str, Any],
+        occurred_at: datetime,
+        terminal_event: MessageEnvelope,
+    ) -> bool:
+        """Atomically record one dummy effect, terminal result, and its outbox event."""
+
+        if terminal_state.value not in TERMINAL_STATES:
+            raise ValueError("terminal_state must be terminal")
+        event = terminal_event.payload
+        if not isinstance(event, ExecutionEvent):
+            raise ValueError("terminal_event must contain an ExecutionEvent")
+        if (
+            event.contract_id != contract_id
+            or event.contract_revision != contract_revision
+            or event.previous_state is not ContractState.RUNNING
+            or event.next_state is not terminal_state
+        ):
+            raise RecordConflictError("terminal event does not match the journal transition")
+        with self._transaction() as connection:
+            row = self._journal_row(connection, contract_id, contract_revision)
+            if row["terminal_at"] is not None:
+                return False
+            if row["state"] != "DISPATCH_RECORDED" or row["effect_count"] != 0:
+                raise InvalidStateTransitionError(
+                    "dummy effect requires one unconsumed DISPATCH_RECORDED journal entry"
+                )
+            encoded_result = _result_json(terminal_result)
+            self._insert_outbox(connection, terminal_event)
+            connection.execute(
+                """
+                UPDATE execution_journal SET state = ?, effect_count = 1,
+                    effect_started_at = ?, terminal_at = ?, terminal_result_json = ?
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (
+                    terminal_state.value,
+                    _utc_text(occurred_at),
+                    _utc_text(occurred_at),
+                    encoded_result,
+                    str(contract_id),
+                    contract_revision,
+                ),
+            )
+        return True
+
+    def append_execution_audit(
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        event_type: str,
+        metadata: Mapping[str, Any],
+        recorded_at: datetime,
+    ) -> None:
+        if not event_type:
+            raise ValueError("event_type must not be empty")
+        with self._transaction() as connection:
+            self._journal_row(connection, contract_id, contract_revision)
+            connection.execute(
+                """
+                INSERT INTO execution_audit (
+                    contract_id, contract_revision, recorded_at, event_type, metadata_json
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    str(contract_id),
+                    contract_revision,
+                    _utc_text(recorded_at),
+                    event_type,
+                    _result_json(metadata),
+                ),
+            )
+
+    def inspect_inbox(self) -> list[dict[str, Any]]:
+        return self._rows("SELECT * FROM inbox ORDER BY received_at, message_id")
+
+    def inspect_outbox(self) -> list[dict[str, Any]]:
+        return self._rows("SELECT * FROM outbox ORDER BY created_at, message_id")
+
+    def inspect_execution_journal(self) -> list[dict[str, Any]]:
+        return self._rows(
+            "SELECT * FROM execution_journal ORDER BY contract_id, contract_revision"
+        )
+
+    def causal_history(self, correlation_id: UUID) -> list[dict[str, Any]]:
+        rows = self._connection.execute(
+            """
+            SELECT 'inbox' AS direction, message_id, received_at AS stored_at,
+                   payload_type, payload_json
+            FROM inbox WHERE correlation_id = ?
+            UNION ALL
+            SELECT 'outbox' AS direction, message_id, created_at AS stored_at,
+                   json_extract(payload_json, '$.message_type') AS payload_type, payload_json
+            FROM outbox WHERE correlation_id = ?
+            ORDER BY stored_at, message_id
+            """,
+            (str(correlation_id), str(correlation_id)),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def contract_history(
+        self, contract_id: UUID, contract_revision: int
+    ) -> dict[str, Any]:
+        journal = dict(self._journal_row(self._connection, contract_id, contract_revision))
+        audit = self._connection.execute(
+            """
+            SELECT recorded_at, event_type, metadata_json FROM execution_audit
+            WHERE contract_id = ? AND contract_revision = ? ORDER BY audit_id
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchall()
+        return {"journal": journal, "audit": [dict(row) for row in audit]}
+
+    def _rows(self, query: str) -> list[dict[str, Any]]:
+        return [dict(row) for row in self._connection.execute(query).fetchall()]
+
+    def _decode_envelope(self, table: str, key: str, encoded: str) -> MessageEnvelope:
+        try:
+            return MessageEnvelope.model_validate_json(encoded)
+        except (ValidationError, ValueError) as error:
+            raise CorruptRecordError(f"invalid {table} record {key}") from error
+
+    @staticmethod
+    def _journal_row(
+        connection: sqlite3.Connection, contract_id: UUID, contract_revision: int
+    ) -> sqlite3.Row:
+        row = connection.execute(
+            """
+            SELECT * FROM execution_journal
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"{contract_id}:{contract_revision}")
+        return row

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,289 @@
+import json
+import sqlite3
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from deferred_teleop.protocol import ContractState, MessageEnvelope
+from deferred_teleop.storage import (
+    CURRENT_SCHEMA_VERSION,
+    CorruptRecordError,
+    IncompatibleSchemaError,
+    NodeStore,
+    RecordConflictError,
+    initialize_database,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN_PATH = ROOT / "protocol" / "v0" / "fixtures" / "valid" / "dummy-operation-chain.json"
+NOW = datetime(2026, 9, 4, 9, 0, tzinfo=UTC)
+CONTRACT_ID = UUID("70000000-0000-4000-8000-000000000001")
+OPERATION_ID = UUID("30000000-0000-4000-8000-000000000001")
+TASK_ID = UUID("50000000-0000-4000-8000-000000000001")
+
+
+def _raw_messages() -> list[dict[str, object]]:
+    return json.loads(CHAIN_PATH.read_text(encoding="utf-8"))["messages"]
+
+
+def _messages() -> list[MessageEnvelope]:
+    return [MessageEnvelope.model_validate_json(json.dumps(item)) for item in _raw_messages()]
+
+
+def _terminal_event() -> MessageEnvelope:
+    raw = deepcopy(_raw_messages()[-1])
+    raw["message_id"] = "00000000-0000-4000-8000-000000000099"
+    raw["source_sequence"] = 99
+    raw["payload"]["event_id"] = "80000000-0000-4000-8000-000000000099"
+    raw["payload"]["previous_state"] = "RUNNING"
+    raw["payload"]["next_state"] = "SUCCEEDED"
+    return MessageEnvelope.model_validate_json(json.dumps(raw))
+
+
+def _accept(store: NodeStore, *, effect_key: str = "press:dummy-button-1") -> None:
+    assert store.accept_contract(
+        contract_id=CONTRACT_ID,
+        contract_revision=1,
+        operation_id=OPERATION_ID,
+        task_id=TASK_ID,
+        effect_key=effect_key,
+        accepted_at=NOW,
+    )
+
+
+def _dispatch(store: NodeStore) -> None:
+    _accept(store)
+    assert store.record_dispatch(CONTRACT_ID, 1, recorded_at=NOW + timedelta(seconds=1))
+
+
+def _effect(store: NodeStore) -> None:
+    assert store.commit_dummy_effect(
+        CONTRACT_ID,
+        1,
+        terminal_state=ContractState.SUCCEEDED,
+        terminal_result={"effect_counter": 1, "button": "dummy-button-1"},
+        occurred_at=NOW + timedelta(seconds=2),
+        terminal_event=_terminal_event(),
+    )
+
+
+def test_migrations_initialize_v1_and_upgrade_to_current(tmp_path: Path) -> None:
+    path = tmp_path / "node.sqlite3"
+    initialize_database(path, target_version=1)
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 1
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name = 'execution_audit'"
+        ).fetchone()[0] == 0
+
+    with NodeStore(path) as store:
+        assert store.schema_version == CURRENT_SCHEMA_VERSION
+        assert store.pragmas() == {"journal_mode": "wal", "busy_timeout_ms": 5_000}
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name = 'execution_audit'"
+        ).fetchone()[0] == 1
+
+
+def test_newer_schema_fails_loudly_without_mutation(tmp_path: Path) -> None:
+    path = tmp_path / "future.sqlite3"
+    initialize_database(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "INSERT INTO schema_migrations (version, applied_at) VALUES (999, ?)",
+            ("2099-01-01T00:00:00Z",),
+        )
+    with pytest.raises(IncompatibleSchemaError):
+        NodeStore(path)
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 999
+
+
+def test_duplicate_inbox_is_deduplicated_and_collision_fails(tmp_path: Path) -> None:
+    path = tmp_path / "field.sqlite3"
+    intent = _messages()[0]
+    with NodeStore(path) as store:
+        assert store.receive(intent, received_at=NOW)
+        assert not store.receive(intent, received_at=NOW + timedelta(seconds=1))
+        assert len(store.inspect_inbox()) == 1
+
+        conflicting = intent.model_copy(update={"source_id": "forged-source"})
+        with pytest.raises(RecordConflictError):
+            store.receive(conflicting, received_at=NOW)
+
+
+def test_crash_after_outbox_commit_preserves_pending_delivery(tmp_path: Path) -> None:
+    path = tmp_path / "mission.sqlite3"
+    intent = _messages()[0]
+    with NodeStore(path) as store:
+        assert store.enqueue(intent)
+
+    with NodeStore(path) as restarted:
+        assert restarted.pending_outbox(now=NOW + timedelta(seconds=1)) == [intent]
+
+
+def test_crash_after_inbox_commit_retries_processing_atomically(tmp_path: Path) -> None:
+    path = tmp_path / "field.sqlite3"
+    intent, grounded = _messages()[:2]
+    with NodeStore(path) as store:
+        store.receive(intent, received_at=NOW)
+        assert store.claim_next_inbox() == intent
+
+    with NodeStore(path) as restarted:
+        assert restarted.recover_interrupted_processing() == 1
+        assert restarted.claim_next_inbox() == intent
+        restarted.complete_inbox(
+            intent.message_id,
+            processed_at=NOW + timedelta(seconds=1),
+            handler_result_reference="grounding:1",
+            outgoing=[grounded],
+        )
+        assert restarted.inspect_inbox()[0]["processing_state"] == "PROCESSED"
+        assert restarted.pending_outbox(now=NOW + timedelta(seconds=2)) == [grounded]
+
+
+def test_handler_completion_and_outbox_consequence_roll_back_together(tmp_path: Path) -> None:
+    intent, grounded = _messages()[:2]
+    conflicting = grounded.model_copy(update={"source_id": "forged-field"})
+    with NodeStore(tmp_path / "field.sqlite3") as store:
+        store.receive(intent, received_at=NOW)
+        assert store.claim_next_inbox() == intent
+        store.enqueue(grounded)
+        with pytest.raises(RecordConflictError):
+            store.complete_inbox(
+                intent.message_id,
+                processed_at=NOW + timedelta(seconds=1),
+                handler_result_reference="must-rollback",
+                outgoing=[conflicting],
+            )
+        assert store.inspect_inbox()[0]["processing_state"] == "PROCESSING"
+
+
+def test_crash_after_acceptance_resumes_before_dispatch(tmp_path: Path) -> None:
+    path = tmp_path / "robot.sqlite3"
+    with NodeStore(path) as store:
+        _accept(store)
+
+    with NodeStore(path) as restarted:
+        assert restarted.inspect_execution_journal()[0]["state"] == "ACCEPTED"
+        assert restarted.record_dispatch(CONTRACT_ID, 1, recorded_at=NOW + timedelta(seconds=1))
+
+
+def test_crash_after_dispatch_resumes_before_dummy_effect(tmp_path: Path) -> None:
+    path = tmp_path / "robot.sqlite3"
+    with NodeStore(path) as store:
+        _dispatch(store)
+
+    with NodeStore(path) as restarted:
+        _effect(restarted)
+        journal = restarted.inspect_execution_journal()[0]
+        assert journal["effect_count"] == 1
+        assert journal["state"] == "SUCCEEDED"
+
+
+def test_crash_after_effect_preserves_terminal_result_and_event(tmp_path: Path) -> None:
+    path = tmp_path / "robot.sqlite3"
+    terminal_event = _terminal_event()
+    with NodeStore(path) as store:
+        _dispatch(store)
+        _effect(store)
+
+    with NodeStore(path) as restarted:
+        journal = restarted.inspect_execution_journal()[0]
+        assert json.loads(journal["terminal_result_json"])["effect_counter"] == 1
+        assert restarted.pending_outbox(now=NOW + timedelta(seconds=6)) == [terminal_event]
+        assert not restarted.commit_dummy_effect(
+            CONTRACT_ID,
+            1,
+            terminal_state=ContractState.SUCCEEDED,
+            terminal_result={"effect_counter": 2},
+            occurred_at=NOW + timedelta(seconds=4),
+            terminal_event=terminal_event,
+        )
+        assert restarted.inspect_execution_journal()[0]["effect_count"] == 1
+
+
+def test_crash_before_ack_preserves_attempt_and_acknowledges_once(tmp_path: Path) -> None:
+    path = tmp_path / "robot.sqlite3"
+    terminal_event = _terminal_event()
+    with NodeStore(path) as store:
+        _dispatch(store)
+        _effect(store)
+        assert store.record_attempt(
+            terminal_event.message_id, next_attempt_at=NOW + timedelta(seconds=4)
+        ) == 1
+
+    with NodeStore(path) as restarted:
+        record = restarted.inspect_outbox()[0]
+        assert record["attempt_count"] == 1
+        assert record["ack_state"] == "PENDING"
+        assert restarted.acknowledge(
+            terminal_event.message_id, acked_at=NOW + timedelta(seconds=5)
+        )
+        assert not restarted.acknowledge(
+            terminal_event.message_id, acked_at=NOW + timedelta(seconds=6)
+        )
+        assert restarted.pending_outbox(now=NOW + timedelta(seconds=7)) == []
+
+
+def test_duplicate_contract_and_effect_key_never_duplicate_effect(tmp_path: Path) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _accept(store)
+        assert not store.accept_contract(
+            contract_id=CONTRACT_ID,
+            contract_revision=1,
+            operation_id=OPERATION_ID,
+            task_id=TASK_ID,
+            effect_key="press:dummy-button-1",
+            accepted_at=NOW + timedelta(seconds=1),
+        )
+        with pytest.raises(RecordConflictError):
+            store.accept_contract(
+                contract_id=uuid4(),
+                contract_revision=1,
+                operation_id=OPERATION_ID,
+                task_id=TASK_ID,
+                effect_key="press:dummy-button-1",
+                accepted_at=NOW,
+            )
+
+
+def test_contract_history_keeps_terminal_result_immutable_and_audit_append_only(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        _effect(store)
+        store.append_execution_audit(
+            CONTRACT_ID,
+            1,
+            event_type="delivery-observed",
+            metadata={"relay": "field-1"},
+            recorded_at=NOW + timedelta(seconds=6),
+        )
+        history = store.contract_history(CONTRACT_ID, 1)
+        assert history["journal"]["state"] == "SUCCEEDED"
+        assert history["journal"]["effect_count"] == 1
+        assert [item["event_type"] for item in history["audit"]] == ["delivery-observed"]
+
+
+def test_corrupt_outbox_fails_loudly_without_rewriting_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "mission.sqlite3"
+    intent = _messages()[0]
+    with NodeStore(path) as store:
+        store.enqueue(intent)
+
+    corrupt = "{not-json"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE outbox SET payload_json = ? WHERE message_id = ?",
+            (corrupt, str(intent.message_id)),
+        )
+
+    with NodeStore(path) as restarted:
+        with pytest.raises(CorruptRecordError):
+            restarted.pending_outbox(now=NOW + timedelta(seconds=1))
+        assert restarted.inspect_outbox()[0]["payload_json"] == corrupt


### PR DESCRIPTION
## Problem

The inter-site link is at-least-once: messages may be delayed, duplicated, reordered or redelivered, and processes may restart at any persistence boundary. M1 needs durable endpoint state without claiming network-level exactly-once delivery.

## Approach

- explicit SQLite v1 -> v2 migrations;
- WAL mode, full synchronous commits, foreign keys and a deliberate 5000 ms busy timeout;
- durable deduplicating inbox and retryable/acknowledged outbox;
- atomic handler completion plus outgoing consequences;
- one execution-journal row per contract revision with a unique semantic effect key;
- atomic dummy effect, immutable terminal result and terminal-event outbox record;
- read-only inbox, outbox, causal and contract-history inspection helpers;
- loud corrupt/incompatible-record failures that preserve forensic bytes.

## Authority and safety impact

- Robot authority impact: the journal guards execution of an already accepted contract; it grants no new authority.
- Field authority impact: none beyond durable decisions/outgoing consequences.
- Mission authority impact: none beyond durable messages.
- Hardware path enabled or changed: no.

## Protocol or public API impact

Adds the NodeStore Python API and ADR 0003. Storage is per logical node. Schema migrations are explicit. No dtt/0 wire-schema change is introduced by this stacked PR.

## Validation

- [x] Linked issue: #6
- [x] Tests added or updated
- [x] pytest passes: 23 tests
- [x] ruff check . passes
- [x] python -m deferred_teleop.schema --check passes
- [x] All six required crash windows use real file-backed SQLite databases
- [x] Duplicate messages/contracts do not duplicate the dummy effect counter
- [x] Hardware remains disabled; no hardware path exists
- [x] Safety and trust assumptions reviewed in ADR 0003
- [x] No third-party asset or licence change

## Guarantee boundary

The M1 dummy effect is a database fact committed atomically with its terminal result and outgoing event, so restart/redelivery produces at most one dummy effect. SQLite cannot make a future physical action atomic with a database commit; physical adapters will require hardware acknowledgement, idempotency support or an explicit uncertain result. This PR makes no exactly-once network or physical-effect claim.

## Known limitations

Distributed SQL, consensus, production HA, cryptographic key storage, retention policy and physical-effect recovery are intentionally out of scope. This PR remains stacked on #11 until that protocol PR is merged.

Closes #6
Parent: #4