### PR TITLE
feat(robot-model): prepare the pinned SO-101 description pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: ruff check .
       - name: Verify generated schemas
         run: python -m deferred_teleop.schema --check
+      - name: Verify generated SO-101 description
+        run: python -m deferred_teleop.robot_model.so101 --check
       - name: Verify M1 golden session and release evidence
         run: python -m deferred_teleop.release_gate verify --scope ci --skip-pytest
       - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ## Unreleased
 
+### Added
+
+- pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
+
 ## 0.1.0 - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
-| SO-101 twin | Planned for M2 |
+| SO-101 twin | M2.1 pinned structural description; FK, Unreal articulation and IK remain planned |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,8 @@ reference Unreal platform for `v0.1.0`. This release does not claim Unreal suppo
 
 ## M2 — Mathematical SO-101 twin in Unreal
 
+Status: **implementation in progress; M2.1 structural description complete**
+
 - textual robot description;
 - forward kinematics, Jacobian and constrained damped-least-squares IK in C++;
 - separate rigid link meshes, without a skeletal mesh;

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,17 +1,46 @@
 # Third-party notices
 
-No third-party robot meshes, textures, datasets, trained weights or copied source files are included in M0.
+The Apache-2.0 licence at the repository root applies to original Deferred Teleoperation code
+unless a file or directory explicitly states otherwise. It does not relicense third-party
+material.
 
-Before adding third-party material, a pull request must record:
+## TheRobotStudio SO-ARM100 / SO-101 structural description
+
+This repository vendors one unmodified source file for deterministic development and tests:
+
+```text
+Project:     SO-ARM100
+Source:      https://github.com/TheRobotStudio/SO-ARM100
+Commit:      385e8d7c68e24945df6c60d9bd68837a4b7411ae
+File:        Simulation/SO101/so101_new_calib.urdf
+Git blob:    9552a231d8b23bed68ec15779eba620c5d875ec4
+Local path:  robots/so101/upstream/so101_new_calib.urdf
+Licence:     Apache License 2.0
+Modified:    no
+```
+
+The source file states that it was generated with `onshape-to-robot` from the linked Onshape CAD
+model. Deferred Teleoperation preserves that source comment in the vendored file.
+
+Any generated canonical description is a source-derived representation and must retain this
+provenance. Official mesh files are **not** included by this notice; each exact mesh and any
+converted Unreal asset must be reviewed and recorded before it is added.
+
+## Policy for future third-party material
+
+Before adding a robot mesh, texture, dataset, trained weight or copied source file, a pull request
+must record:
 
 - source and immutable version or commit;
 - copyright holder when known;
 - licence and redistribution conditions;
 - local modifications;
 - required notices;
-- whether the material may be bundled, downloaded separately, or used only as a development dependency.
+- whether the material may be bundled, downloaded separately, or used only as a development
+  dependency.
 
-The Apache-2.0 licence applies to original repository code unless a file or directory explicitly states otherwise. It does not relicense third-party material.
+The Apache-2.0 licence applies to original repository code unless a file or directory explicitly
+states otherwise. It does not relicense third-party material.
 
 ## Direct Python runtime dependencies
 
@@ -24,4 +53,5 @@ repository:
 | websockets | `>=15,<17` | 16.1.1 | <https://github.com/python-websockets/websockets> | BSD-3-Clause |
 
 Their distributions carry the applicable copyright and licence texts. No robot assets,
-datasets, model weights or copied third-party source files are introduced by M1.3.
+datasets or model weights were introduced by M1. The pinned SO-101 URDF described above is the
+first robot source vendored for M2.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -50,10 +50,17 @@ The exact commands, environment and visible evidence are recorded on bootstrap p
 - Unreal Engine 5.8.2 validation on Windows, the reference Unreal platform for `v0.1.0`;
 - portable Python validation on Linux through GitHub CI.
 
+## Implemented in M2
+
+- pinned, unmodified SO-101 structural URDF with immutable source identity and licence metadata;
+- deterministic canonical right-handed metre/radian robot description;
+- explicit arm and gripper joint groups plus the `gripper_frame_link` tool frame;
+- offline source-hash, structure and generated-description drift checks on Linux and Windows.
+
 ## Planned, not implemented
 
 - VR interaction and headset-specific presentation (the desktop Unreal visualization exists);
-- SO-101 geometry, kinematics or hardware integration;
+- SO-101 forward kinematics, articulated Unreal visualization, IK and hardware integration;
 - Simulation Worker;
 - LeRobot integration;
 - learned policies or LLM planning.

--- a/python/src/deferred_teleop/robot_model/__init__.py
+++ b/python/src/deferred_teleop/robot_model/__init__.py
@@ -1,0 +1,1 @@
+"""Development-time robot-description tools."""

--- a/python/src/deferred_teleop/robot_model/so101.py
+++ b/python/src/deferred_teleop/robot_model/so101.py
@@ -1,0 +1,406 @@
+"""Generate the canonical SO-101 structural description from a pinned URDF.
+
+This module is deliberately a development-time tool. Unreal runtime code consumes the
+small generated JSON description; it does not parse arbitrary URDF/XML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import tomllib
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+DESCRIPTION_SCHEMA_VERSION = "dtt.robot-description/0"
+SOURCE_LOCK_SCHEMA_VERSION = "dtt.source-lock/0"
+
+
+def git_blob_sha1(data: bytes) -> str:
+    """Return the SHA-1 used by Git for a blob containing *data*."""
+
+    header = f"blob {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data).hexdigest()  # noqa: S324 - Git object identity
+
+
+def _parse_vector(
+    raw: str | None,
+    *,
+    default: tuple[float, float, float],
+    field_name: str,
+) -> list[float]:
+    if raw is None:
+        values = list(default)
+    else:
+        parts = raw.split()
+        if len(parts) != 3:
+            raise ValueError(f"{field_name} must contain exactly three values")
+        values = [float(part) for part in parts]
+
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"{field_name} contains a non-finite value")
+    return values
+
+
+def _quaternion_multiply(left: list[float], right: list[float]) -> list[float]:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    return [
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    ]
+
+
+def _rpy_to_quaternion(roll: float, pitch: float, yaw: float) -> list[float]:
+    """Convert URDF fixed-axis roll/pitch/yaw to an XYZW quaternion.
+
+    With column vectors this is the active rotation ``Rz(yaw) Ry(pitch) Rx(roll)``.
+    """
+
+    half_roll = 0.5 * roll
+    half_pitch = 0.5 * pitch
+    half_yaw = 0.5 * yaw
+
+    qx = [math.sin(half_roll), 0.0, 0.0, math.cos(half_roll)]
+    qy = [0.0, math.sin(half_pitch), 0.0, math.cos(half_pitch)]
+    qz = [0.0, 0.0, math.sin(half_yaw), math.cos(half_yaw)]
+    quaternion = _quaternion_multiply(qz, _quaternion_multiply(qy, qx))
+
+    norm = math.sqrt(sum(component * component for component in quaternion))
+    if not math.isfinite(norm) or norm <= 1e-15:
+        raise ValueError("origin rotation produced an invalid quaternion")
+    quaternion = [component / norm for component in quaternion]
+
+    # q and -q encode the same rotation. A stable hemisphere keeps generated JSON deterministic.
+    if quaternion[3] < 0.0:
+        quaternion = [-component for component in quaternion]
+    return quaternion
+
+
+def _parse_origin(element: ET.Element | None, *, field_name: str) -> dict[str, list[float]]:
+    if element is None:
+        xyz = [0.0, 0.0, 0.0]
+        rpy = [0.0, 0.0, 0.0]
+    else:
+        xyz = _parse_vector(
+            element.get("xyz"),
+            default=(0.0, 0.0, 0.0),
+            field_name=f"{field_name}.xyz",
+        )
+        rpy = _parse_vector(
+            element.get("rpy"),
+            default=(0.0, 0.0, 0.0),
+            field_name=f"{field_name}.rpy",
+        )
+
+    return {
+        "translation_m": xyz,
+        "rotation_xyzw": _rpy_to_quaternion(*rpy),
+    }
+
+
+def _normalise_axis(raw: str | None, *, joint_name: str) -> list[float]:
+    axis = _parse_vector(
+        raw,
+        default=(1.0, 0.0, 0.0),
+        field_name=f"joint {joint_name} axis",
+    )
+    norm = math.sqrt(sum(component * component for component in axis))
+    if not math.isfinite(norm) or norm <= 1e-12:
+        raise ValueError(f"revolute joint {joint_name} has a zero or invalid axis")
+    return [component / norm for component in axis]
+
+
+def _load_source_lock(path: Path) -> dict[str, Any]:
+    with path.open("rb") as stream:
+        lock = tomllib.load(stream)
+
+    if lock.get("schema_version") != SOURCE_LOCK_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported source-lock schema: {lock.get('schema_version')!r}"
+        )
+    for section in ("source", "vendor", "model"):
+        if section not in lock or not isinstance(lock[section], dict):
+            raise ValueError(f"source lock is missing [{section}]")
+    return lock
+
+
+def _require_unique(values: list[str], *, kind: str) -> None:
+    duplicates = sorted({value for value in values if values.count(value) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate {kind} names: {', '.join(duplicates)}")
+
+
+def _parse_visuals(link: ET.Element, *, link_name: str) -> list[dict[str, Any]]:
+    visuals: list[dict[str, Any]] = []
+    for index, visual in enumerate(link.findall("visual")):
+        mesh = visual.find("./geometry/mesh")
+        if mesh is None:
+            continue
+        filename = mesh.get("filename")
+        if not filename:
+            raise ValueError(f"visual {index} on link {link_name} has no mesh filename")
+        material = visual.find("material")
+        visuals.append(
+            {
+                "visual_id": f"{link_name}.visual.{index}",
+                "source_mesh": filename,
+                "material": material.get("name") if material is not None else None,
+                "link_to_visual": _parse_origin(
+                    visual.find("origin"),
+                    field_name=f"link {link_name} visual {index} origin",
+                ),
+            }
+        )
+    return visuals
+
+
+def _topological_order(
+    *,
+    link_names: list[str],
+    raw_joints: list[dict[str, Any]],
+) -> tuple[str, list[str], list[dict[str, Any]]]:
+    child_links = [joint["child_link"] for joint in raw_joints]
+    roots = sorted(set(link_names) - set(child_links))
+    if len(roots) != 1:
+        raise ValueError(f"robot description must have exactly one root link, found {roots}")
+    root_link = roots[0]
+
+    by_parent: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for joint in raw_joints:
+        by_parent[joint["parent_link"]].append(joint)
+    for joints in by_parent.values():
+        joints.sort(key=lambda item: item["name"])
+
+    ordered_links: list[str] = []
+    ordered_joints: list[dict[str, Any]] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(link_name: str) -> None:
+        if link_name in visiting:
+            raise ValueError(f"cycle detected at link {link_name}")
+        if link_name in visited:
+            raise ValueError(f"link {link_name} is reachable through multiple parents")
+
+        visiting.add(link_name)
+        ordered_links.append(link_name)
+        for joint in by_parent.get(link_name, []):
+            ordered_joints.append(joint)
+            visit(joint["child_link"])
+        visiting.remove(link_name)
+        visited.add(link_name)
+
+    visit(root_link)
+    missing = sorted(set(link_names) - visited)
+    if missing:
+        raise ValueError(f"disconnected links: {', '.join(missing)}")
+    return root_link, ordered_links, ordered_joints
+
+
+def generate_so101_description(source_path: Path, lock_path: Path) -> dict[str, Any]:
+    """Parse and validate the pinned SO-101 URDF into canonical runtime data."""
+
+    lock = _load_source_lock(lock_path)
+    source_bytes = source_path.read_bytes()
+    actual_blob_sha1 = git_blob_sha1(source_bytes)
+    expected_blob_sha1 = str(lock["source"].get("git_blob_sha1", ""))
+    if actual_blob_sha1 != expected_blob_sha1:
+        raise ValueError(
+            "vendored SO-101 source hash mismatch: "
+            f"expected {expected_blob_sha1}, got {actual_blob_sha1}"
+        )
+
+    root = ET.fromstring(source_bytes)
+    if root.tag != "robot":
+        raise ValueError(f"expected <robot> root, got <{root.tag}>")
+
+    link_elements = root.findall("link")
+    link_names = [link.get("name", "") for link in link_elements]
+    if any(not name for name in link_names):
+        raise ValueError("every link requires a non-empty name")
+    _require_unique(link_names, kind="link")
+    link_name_set = set(link_names)
+
+    raw_joints: list[dict[str, Any]] = []
+    joint_names: list[str] = []
+    child_to_joint: dict[str, str] = {}
+
+    for joint in root.findall("joint"):
+        name = joint.get("name", "")
+        joint_type = joint.get("type", "")
+        if not name:
+            raise ValueError("every joint requires a non-empty name")
+        if joint_type not in {"fixed", "revolute"}:
+            raise ValueError(f"unsupported joint type {joint_type!r} for {name}")
+
+        parent = joint.find("parent")
+        child = joint.find("child")
+        if parent is None or child is None:
+            raise ValueError(f"joint {name} requires parent and child elements")
+        parent_link = parent.get("link", "")
+        child_link = child.get("link", "")
+        if parent_link not in link_name_set or child_link not in link_name_set:
+            raise ValueError(f"joint {name} references an unknown link")
+        if child_link in child_to_joint:
+            raise ValueError(
+                f"link {child_link} has multiple parent joints: "
+                f"{child_to_joint[child_link]} and {name}"
+            )
+        child_to_joint[child_link] = name
+
+        axis: list[float] | None = None
+        position_limits_rad: dict[str, float] | None = None
+        if joint_type == "revolute":
+            axis_element = joint.find("axis")
+            axis = _normalise_axis(
+                axis_element.get("xyz") if axis_element is not None else None,
+                joint_name=name,
+            )
+            limit = joint.find("limit")
+            if limit is None or limit.get("lower") is None or limit.get("upper") is None:
+                raise ValueError(f"revolute joint {name} requires lower and upper limits")
+            lower = float(limit.get("lower", "nan"))
+            upper = float(limit.get("upper", "nan"))
+            if not math.isfinite(lower) or not math.isfinite(upper) or lower > upper:
+                raise ValueError(f"joint {name} has invalid position limits")
+            position_limits_rad = {"lower": lower, "upper": upper}
+
+        joint_names.append(name)
+        raw_joints.append(
+            {
+                "name": name,
+                "type": joint_type,
+                "parent_link": parent_link,
+                "child_link": child_link,
+                "parent_to_joint": _parse_origin(
+                    joint.find("origin"),
+                    field_name=f"joint {name} origin",
+                ),
+                "axis_joint_frame": axis,
+                "position_limits_rad": position_limits_rad,
+            }
+        )
+
+    _require_unique(joint_names, kind="joint")
+    root_link, ordered_link_names, ordered_joints = _topological_order(
+        link_names=link_names,
+        raw_joints=raw_joints,
+    )
+
+    configured_root = str(lock["model"].get("root_link", ""))
+    if root_link != configured_root:
+        raise ValueError(f"source root {root_link!r} does not match lock {configured_root!r}")
+
+    links_by_name = {link.get("name", ""): link for link in link_elements}
+    ordered_links = [
+        {
+            "name": link_name,
+            "visuals": _parse_visuals(links_by_name[link_name], link_name=link_name),
+        }
+        for link_name in ordered_link_names
+    ]
+
+    tool_frames = [str(value) for value in lock["model"].get("tool_frames", [])]
+    arm_group = [str(value) for value in lock["model"].get("arm_joint_group", [])]
+    gripper_group = [str(value) for value in lock["model"].get("gripper_joint_group", [])]
+
+    unknown_tools = sorted(set(tool_frames) - link_name_set)
+    unknown_group_joints = sorted((set(arm_group) | set(gripper_group)) - set(joint_names))
+    overlap = sorted(set(arm_group) & set(gripper_group))
+    if unknown_tools:
+        raise ValueError(f"unknown configured tool frames: {', '.join(unknown_tools)}")
+    if unknown_group_joints:
+        raise ValueError(f"unknown configured group joints: {', '.join(unknown_group_joints)}")
+    if overlap:
+        raise ValueError(f"joint groups overlap: {', '.join(overlap)}")
+
+    source = lock["source"]
+    return {
+        "schema_version": DESCRIPTION_SCHEMA_VERSION,
+        "model_id": str(lock.get("model_id", root.get("name", ""))),
+        "model_revision": f"git:{source['commit']}:{actual_blob_sha1}",
+        "source": {
+            "repository": str(source["repository"]),
+            "commit": str(source["commit"]),
+            "path": str(source["path"]),
+            "git_blob_sha1": actual_blob_sha1,
+            "licence": str(source["licence"]),
+            "vendor_modified": bool(lock["vendor"].get("modified", False)),
+        },
+        "coordinate_convention": {
+            "handedness": "RIGHT_HANDED",
+            "up_axis": "Z",
+            "length_unit": "metre",
+            "angle_unit": "radian",
+            "rotation_representation": "quaternion_xyzw",
+            "transform_notation": "parent_T_child",
+        },
+        "root_link": root_link,
+        "links": ordered_links,
+        "joints": ordered_joints,
+        "joint_groups": [
+            {"name": "arm", "joints": arm_group},
+            {"name": "gripper", "joints": gripper_group},
+        ],
+        "tool_frames": [{"name": frame, "link": frame} for frame in tool_frames],
+        "known_limitations": [str(lock["notes"]["gripper_mapping"])],
+    }
+
+
+def serialize_description(description: dict[str, Any]) -> str:
+    """Serialize canonical data deterministically for review and drift checks."""
+
+    return json.dumps(description, indent=2, ensure_ascii=False, allow_nan=False) + "\n"
+
+
+def _default_repo_path(relative: str) -> Path:
+    return Path(relative)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=_default_repo_path("robots/so101/upstream/so101_new_calib.urdf"),
+    )
+    parser.add_argument(
+        "--lock",
+        type=Path,
+        default=_default_repo_path("robots/so101/source-lock.toml"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_default_repo_path("robots/so101/generated/so101.kinematics.json"),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the committed generated file differs from a fresh generation.",
+    )
+    args = parser.parse_args(argv)
+
+    rendered = serialize_description(generate_so101_description(args.source, args.lock))
+    if args.check:
+        if not args.output.exists():
+            parser.error(f"generated output does not exist: {args.output}")
+        if args.output.read_text(encoding="utf-8") != rendered:
+            parser.error(f"generated output is stale: {args.output}")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robots/so101/README.md
+++ b/robots/so101/README.md
@@ -1,0 +1,84 @@
+# SO-101 structural source
+
+This directory prepares the canonical structural description used by the M2 mathematical twin.
+It does **not** contain per-device calibration or a hardware command mapping.
+
+## Source
+
+The vendored URDF is pinned in [`source-lock.toml`](source-lock.toml):
+
+```text
+repository  TheRobotStudio/SO-ARM100
+commit      385e8d7c68e24945df6c60d9bd68837a4b7411ae
+path        Simulation/SO101/so101_new_calib.urdf
+blob SHA-1  9552a231d8b23bed68ec15779eba620c5d875ec4
+licence     Apache-2.0
+```
+
+The copy under `upstream/` is unmodified. See the root
+[`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) before redistributing derived files.
+
+## Separation of concerns
+
+```text
+Structural model
+- links, joints, fixed transforms, axes, limits, tool frames
+
+Device calibration (later M3 work)
+- raw encoder values, homing offsets, directions and measured ranges
+
+Protocol state
+- model reference and named canonical joint values
+
+Unreal visuals
+- logical visual IDs mapped to Static Mesh assets
+```
+
+The upstream SO-101 simulation README states that LeRobot represents the gripper on a normalized
+`0` (closed) to `100` (open) scale and that this mapping is not reflected by the current URDF and
+MuJoCo descriptions. The generator therefore keeps the structural `gripper` joint separate from
+future hardware normalization.
+
+## Generate the canonical description
+
+From the repository root:
+
+```bash
+python -m deferred_teleop.robot_model.so101
+```
+
+This writes:
+
+```text
+robots/so101/generated/so101.kinematics.json
+```
+
+To verify the committed generated file without modifying it:
+
+```bash
+python -m deferred_teleop.robot_model.so101 --check
+```
+
+The output is deterministic and uses:
+
+```text
+right-handed coordinates
+Z up
+metres
+radians
+quaternion XYZW rotations
+```
+
+The Unreal runtime will consume the generated description rather than parse arbitrary URDF/XML.
+CI and unit tests reject source-hash drift or a generated file that no longer matches the pinned
+source and generator.
+
+On 4 September 2026, a fresh `--check` produced the same committed artifact with Python 3.11 and
+3.12 on Linux and Python 3.12.10 on Windows 11. Its SHA-256 is
+`36ce321332248351f5304630a9ccc4887d6665666e17b6933e3302874735e5f2`.
+
+## Current status
+
+The M2.1 increment contains the pinned source, source lock, deterministic generator, canonical
+generated description, third-party notice and drift checks. Forward kinematics, Unreal loading and
+hardware calibration remain separate later increments.

--- a/robots/so101/generated/so101.kinematics.json
+++ b/robots/so101/generated/so101.kinematics.json
@@ -1,0 +1,587 @@
+{
+  "schema_version": "dtt.robot-description/0",
+  "model_id": "so101_new_calib",
+  "model_revision": "git:385e8d7c68e24945df6c60d9bd68837a4b7411ae:9552a231d8b23bed68ec15779eba620c5d875ec4",
+  "source": {
+    "repository": "https://github.com/TheRobotStudio/SO-ARM100",
+    "commit": "385e8d7c68e24945df6c60d9bd68837a4b7411ae",
+    "path": "Simulation/SO101/so101_new_calib.urdf",
+    "git_blob_sha1": "9552a231d8b23bed68ec15779eba620c5d875ec4",
+    "licence": "Apache-2.0",
+    "vendor_modified": false
+  },
+  "coordinate_convention": {
+    "handedness": "RIGHT_HANDED",
+    "up_axis": "Z",
+    "length_unit": "metre",
+    "angle_unit": "radian",
+    "rotation_representation": "quaternion_xyzw",
+    "transform_notation": "parent_T_child"
+  },
+  "root_link": "base_link",
+  "links": [
+    {
+      "name": "base_link",
+      "visuals": [
+        {
+          "visual_id": "base_link.visual.0",
+          "source_mesh": "assets/base_motor_holder_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.00636471,
+              -9.94414e-05,
+              -0.0024
+            ],
+            "rotation_xyzw": [
+              0.49999999999662736,
+              0.5000018366025513,
+              0.49999999999662736,
+              0.4999981633974479
+            ]
+          }
+        },
+        {
+          "visual_id": "base_link.visual.1",
+          "source_mesh": "assets/base_so101_v2.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.00636471,
+              -8.97657e-09,
+              -0.0024
+            ],
+            "rotation_xyzw": [
+              0.4999999999966269,
+              0.5000018366025517,
+              0.4999999999966269,
+              0.49999816339744835
+            ]
+          }
+        },
+        {
+          "visual_id": "base_link.visual.2",
+          "source_mesh": "assets/sts3215_03a_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              0.0263353,
+              -8.97657e-09,
+              0.0437
+            ],
+            "rotation_xyzw": [
+              -4.10574e-16,
+              3.922564999999744e-18,
+              6.245e-16,
+              1.0
+            ]
+          }
+        },
+        {
+          "visual_id": "base_link.visual.3",
+          "source_mesh": "assets/waveshare_mounting_plate_so101_v2.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.0309827,
+              -0.000199441,
+              0.0474
+            ],
+            "rotation_xyzw": [
+              0.4999999999966303,
+              0.5000018366025483,
+              0.4999999999966303,
+              0.49999816339744496
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "shoulder_link",
+      "visuals": [
+        {
+          "visual_id": "shoulder_link.visual.0",
+          "source_mesh": "assets/sts3215_03a_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              -0.0303992,
+              0.000422241,
+              -0.0417
+            ],
+            "rotation_xyzw": [
+              0.4999999999966269,
+              0.4999999999966269,
+              -0.5000018366025517,
+              0.49999816339744835
+            ]
+          }
+        },
+        {
+          "visual_id": "shoulder_link.visual.1",
+          "source_mesh": "assets/motor_holder_so101_base_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.0675992,
+              -0.000177759,
+              0.0158499
+            ],
+            "rotation_xyzw": [
+              0.4999999999966269,
+              -0.4999999999966269,
+              0.5000018366025517,
+              0.49999816339744835
+            ]
+          }
+        },
+        {
+          "visual_id": "shoulder_link.visual.2",
+          "source_mesh": "assets/rotation_pitch_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              0.0122008,
+              2.22413e-05,
+              0.0464
+            ],
+            "rotation_xyzw": [
+              -0.7071080798594737,
+              8.316302935088776e-34,
+              8.316333482631262e-34,
+              0.7071054825112364
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "upper_arm_link",
+      "visuals": [
+        {
+          "visual_id": "upper_arm_link.visual.0",
+          "source_mesh": "assets/sts3215_03a_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              -0.11257,
+              -0.0155,
+              0.0187
+            ],
+            "rotation_xyzw": [
+              -0.707105482510614,
+              0.7071080798588513,
+              -9.381873919434471e-07,
+              9.381839454221639e-07
+            ]
+          }
+        },
+        {
+          "visual_id": "upper_arm_link.visual.1",
+          "source_mesh": "assets/upper_arm_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.065085,
+              0.012,
+              0.0182
+            ],
+            "rotation_xyzw": [
+              0.9999999999991198,
+              -6.545549999994239e-31,
+              -8.684602335947626e-37,
+              1.3267948966775328e-06
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "lower_arm_link",
+      "visuals": [
+        {
+          "visual_id": "lower_arm_link.visual.0",
+          "source_mesh": "assets/under_arm_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.0648499,
+              -0.032,
+              0.0182
+            ],
+            "rotation_xyzw": [
+              0.9999999999991198,
+              3.336009999997064e-31,
+              4.426201043265217e-37,
+              1.3267948966775328e-06
+            ]
+          }
+        },
+        {
+          "visual_id": "lower_arm_link.visual.1",
+          "source_mesh": "assets/motor_holder_so101_wrist_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -0.0648499,
+              -0.032,
+              0.018
+            ],
+            "rotation_xyzw": [
+              -0.9999999999991198,
+              -1.6939920173905883e-21,
+              -1.2767549999988762e-15,
+              1.3267948966775328e-06
+            ]
+          }
+        },
+        {
+          "visual_id": "lower_arm_link.visual.2",
+          "source_mesh": "assets/sts3215_03a_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              -0.1224,
+              0.0052,
+              0.0187
+            ],
+            "rotation_xyzw": [
+              -1.326794896676365e-06,
+              0.9999999999982396,
+              -1.326794896676365e-06,
+              1.760384697849545e-12
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "wrist_link",
+      "visuals": [
+        {
+          "visual_id": "wrist_link.visual.0",
+          "source_mesh": "assets/sts3215_03a_no_horn_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              8.32667e-17,
+              -0.0424,
+              0.0306
+            ],
+            "rotation_xyzw": [
+              0.4999999999966269,
+              0.4999999999966269,
+              -0.5000018366025517,
+              0.49999816339744835
+            ]
+          }
+        },
+        {
+          "visual_id": "wrist_link.visual.1",
+          "source_mesh": "assets/wrist_roll_pitch_so101_v2.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              0.0,
+              -0.028,
+              0.0181
+            ],
+            "rotation_xyzw": [
+              -0.4999999999966269,
+              -0.4999999999966269,
+              -0.5000018366025517,
+              0.49999816339744835
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "gripper_link",
+      "visuals": [
+        {
+          "visual_id": "gripper_link.visual.0",
+          "source_mesh": "assets/sts3215_03a_v1.stl",
+          "material": "sts3215",
+          "link_to_visual": {
+            "translation_m": [
+              0.0077,
+              0.0001,
+              -0.0234
+            ],
+            "rotation_xyzw": [
+              -0.7071080798594737,
+              4.05226990663838e-17,
+              -7.723398194918995e-17,
+              0.7071054825112364
+            ]
+          }
+        },
+        {
+          "visual_id": "gripper_link.visual.1",
+          "source_mesh": "assets/wrist_roll_follower_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              8.32667e-17,
+              -0.000218214,
+              0.000949706
+            ],
+            "rotation_xyzw": [
+              -0.9999999999991198,
+              -3.6825988434222926e-23,
+              -2.775559999997557e-17,
+              1.3267948966775328e-06
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "moving_jaw_so101_v1_link",
+      "visuals": [
+        {
+          "visual_id": "moving_jaw_so101_v1_link.visual.0",
+          "source_mesh": "assets/moving_jaw_so101_v1.stl",
+          "material": "3d_printed",
+          "link_to_visual": {
+            "translation_m": [
+              -5.55112e-17,
+              -5.55112e-17,
+              0.0189
+            ],
+            "rotation_xyzw": [
+              4.765725e-17,
+              3.469445e-18,
+              6.203849998346558e-25,
+              1.0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "gripper_frame_link",
+      "visuals": []
+    }
+  ],
+  "joints": [
+    {
+      "name": "shoulder_pan",
+      "type": "revolute",
+      "parent_link": "base_link",
+      "child_link": "shoulder_link",
+      "parent_to_joint": {
+        "translation_m": [
+          0.0388353,
+          -8.97657e-09,
+          0.0624
+        ],
+        "rotation_xyzw": [
+          1.326794896676365e-06,
+          -0.9999999999982396,
+          -1.326794896676365e-06,
+          1.760363785199545e-12
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -1.91986,
+        "upper": 1.91986
+      }
+    },
+    {
+      "name": "shoulder_lift",
+      "type": "revolute",
+      "parent_link": "shoulder_link",
+      "child_link": "upper_arm_link",
+      "parent_to_joint": {
+        "translation_m": [
+          -0.0303992,
+          -0.0182778,
+          -0.0542
+        ],
+        "rotation_xyzw": [
+          -0.4999999999966269,
+          -0.4999999999966269,
+          -0.5000018366025517,
+          0.49999816339744835
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -1.74533,
+        "upper": 1.74533
+      }
+    },
+    {
+      "name": "elbow_flex",
+      "type": "revolute",
+      "parent_link": "upper_arm_link",
+      "child_link": "lower_arm_link",
+      "parent_to_joint": {
+        "translation_m": [
+          -0.11257,
+          -0.028,
+          1.73763e-16
+        ],
+        "rotation_xyzw": [
+          -4.376672558070817e-16,
+          1.805564378817565e-16,
+          0.7071080798594737,
+          0.7071054825112364
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -1.69,
+        "upper": 1.69
+      }
+    },
+    {
+      "name": "wrist_flex",
+      "type": "revolute",
+      "parent_link": "lower_arm_link",
+      "child_link": "wrist_link",
+      "parent_to_joint": {
+        "translation_m": [
+          -0.1349,
+          0.0052,
+          3.62355e-17
+        ],
+        "rotation_xyzw": [
+          1.729553559529247e-15,
+          -1.1162412341786662e-15,
+          -0.7071080798594737,
+          0.7071054825112364
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -1.65806,
+        "upper": 1.65806
+      }
+    },
+    {
+      "name": "wrist_roll",
+      "type": "revolute",
+      "parent_link": "wrist_link",
+      "child_link": "gripper_link",
+      "parent_to_joint": {
+        "translation_m": [
+          5.55112e-17,
+          -0.0611,
+          0.0181
+        ],
+        "rotation_xyzw": [
+          -0.017208133464804664,
+          0.7068986593349474,
+          0.7068960170901372,
+          0.01721007249293119
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -2.74385,
+        "upper": 2.84121
+      }
+    },
+    {
+      "name": "gripper",
+      "type": "revolute",
+      "parent_link": "gripper_link",
+      "child_link": "moving_jaw_so101_v1_link",
+      "parent_to_joint": {
+        "translation_m": [
+          0.0202,
+          0.0188,
+          -0.0234
+        ],
+        "rotation_xyzw": [
+          0.7071080798594734,
+          -1.85362050401124e-08,
+          1.85362721265877e-08,
+          0.7071054825112362
+        ]
+      },
+      "axis_joint_frame": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "position_limits_rad": {
+        "lower": -0.174533,
+        "upper": 1.74533
+      }
+    },
+    {
+      "name": "gripper_frame_joint",
+      "type": "fixed",
+      "parent_link": "gripper_link",
+      "child_link": "gripper_frame_link",
+      "parent_to_joint": {
+        "translation_m": [
+          -0.0079,
+          -0.000218121,
+          -0.0981274
+        ],
+        "rotation_xyzw": [
+          0.0,
+          0.9999999999991198,
+          0.0,
+          1.3267948966775328e-06
+        ]
+      },
+      "axis_joint_frame": null,
+      "position_limits_rad": null
+    }
+  ],
+  "joint_groups": [
+    {
+      "name": "arm",
+      "joints": [
+        "shoulder_pan",
+        "shoulder_lift",
+        "elbow_flex",
+        "wrist_flex",
+        "wrist_roll"
+      ]
+    },
+    {
+      "name": "gripper",
+      "joints": [
+        "gripper"
+      ]
+    }
+  ],
+  "tool_frames": [
+    {
+      "name": "gripper_frame_link",
+      "link": "gripper_frame_link"
+    }
+  ],
+  "known_limitations": [
+    "The upstream README states that LeRobot's normalized 0-100 gripper convention is not represented by this URDF. Hardware normalization is intentionally deferred."
+  ]
+}

--- a/robots/so101/source-lock.toml
+++ b/robots/so101/source-lock.toml
@@ -1,0 +1,29 @@
+schema_version = "dtt.source-lock/0"
+model_id = "so101_new_calib"
+
+[source]
+repository = "https://github.com/TheRobotStudio/SO-ARM100"
+commit = "385e8d7c68e24945df6c60d9bd68837a4b7411ae"
+path = "Simulation/SO101/so101_new_calib.urdf"
+git_blob_sha1 = "9552a231d8b23bed68ec15779eba620c5d875ec4"
+licence = "Apache-2.0"
+retrieved_at = "2026-09-04"
+
+[vendor]
+path = "robots/so101/upstream/so101_new_calib.urdf"
+modified = false
+
+[model]
+root_link = "base_link"
+tool_frames = ["gripper_frame_link"]
+arm_joint_group = [
+  "shoulder_pan",
+  "shoulder_lift",
+  "elbow_flex",
+  "wrist_flex",
+  "wrist_roll",
+]
+gripper_joint_group = ["gripper"]
+
+[notes]
+gripper_mapping = "The upstream README states that LeRobot's normalized 0-100 gripper convention is not represented by this URDF. Hardware normalization is intentionally deferred."

--- a/robots/so101/upstream/so101_new_calib.urdf
+++ b/robots/so101/upstream/so101_new_calib.urdf
@@ -1,0 +1,453 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated using onshape-to-robot -->
+<!-- Onshape https://cad.onshape.com/documents/7715cc284bb430fe6dab4ffd/w/4fd0791b683777b02f8d975a/e/826c553ede3b7592eb9ca800 -->
+<robot name="so101_new_calib">
+
+  <!-- Materials -->
+  <material name="3d_printed">
+    <color rgba="1.0 0.82 0.12 1.0"/>
+  </material>
+  <material name="sts3215">
+    <color rgba="0.1 0.1 0.1 1.0"/>
+  </material>
+
+  <!-- Link base -->
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0.0137179 -5.19711e-05 0.0334843" rpy="0 0 0"/>
+      <mass value="0.147"/>
+      <inertia ixx="0.000114686" ixy="-4.59787e-07" ixz="4.97151e-06" iyy="0.000136117" iyz="9.75275e-08" izz="0.000130364"/>
+    </inertial>
+    <!-- Part base_motor_holder_so101_v1 -->
+    <visual>
+      <origin xyz="-0.00636471 -9.94414e-05 -0.0024" rpy="1.5708 -1.67685e-15 1.5708"/>
+      <geometry>
+        <mesh filename="assets/base_motor_holder_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.00636471 -9.94414e-05 -0.0024" rpy="1.5708 -1.67685e-15 1.5708"/>
+      <geometry>
+        <mesh filename="assets/base_motor_holder_so101_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part base_so101_v2 -->
+    <visual>
+      <origin xyz="-0.00636471 -8.97657e-09 -0.0024" rpy="1.5708 -2.78073e-29 1.5708"/>
+      <geometry>
+        <mesh filename="assets/base_so101_v2.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.00636471 -8.97657e-09 -0.0024" rpy="1.5708 -2.78073e-29 1.5708"/>
+      <geometry>
+        <mesh filename="assets/base_so101_v2.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part sts3215_03a_v1 -->
+    <visual>
+      <origin xyz="0.0263353 -8.97657e-09 0.0437" rpy="-8.21148e-16 7.84513e-18 1.249e-15"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0263353 -8.97657e-09 0.0437" rpy="-8.21148e-16 7.84513e-18 1.249e-15"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part waveshare_mounting_plate_so101_v2 -->
+    <visual>
+      <origin xyz="-0.0309827 -0.000199441 0.0474" rpy="1.5708 -1.35493e-14 1.5708"/>
+      <geometry>
+        <mesh filename="assets/waveshare_mounting_plate_so101_v2.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.0309827 -0.000199441 0.0474" rpy="1.5708 -1.35493e-14 1.5708"/>
+      <geometry>
+        <mesh filename="assets/waveshare_mounting_plate_so101_v2.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Link shoulder -->
+  <link name="shoulder_link">
+    <inertial>
+      <origin xyz="-0.0307604 -1.66727e-05 -0.0252713" rpy="0 0 0"/>
+      <mass value="0.100006"/>
+      <inertia ixx="8.3759e-05" ixy="7.55525e-08" ixz="-1.16342e-06" iyy="8.10403e-05" iyz="1.54663e-07" izz="2.39783e-05"/>
+    </inertial>
+    <!-- Part sts3215_03a_v1_2 -->
+    <visual>
+      <origin xyz="-0.0303992 0.000422241 -0.0417" rpy="1.5708 1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.0303992 0.000422241 -0.0417" rpy="1.5708 1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part motor_holder_so101_base_v1 -->
+    <visual>
+      <origin xyz="-0.0675992 -0.000177759 0.0158499" rpy="1.5708 -1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/motor_holder_so101_base_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.0675992 -0.000177759 0.0158499" rpy="1.5708 -1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/motor_holder_so101_base_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part rotation_pitch_so101_v1 -->
+    <visual>
+      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 2.35221e-33 0"/>
+      <geometry>
+        <mesh filename="assets/rotation_pitch_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 2.35221e-33 0"/>
+      <geometry>
+        <mesh filename="assets/rotation_pitch_so101_v1.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Link upper_arm -->
+  <link name="upper_arm_link">
+    <inertial>
+      <origin xyz="-0.0898471 -0.00838224 0.0184089" rpy="0 0 0"/>
+      <mass value="0.103"/>
+      <inertia ixx="4.08002e-05" ixy="-1.97819e-05" ixz="-4.03016e-08" iyy="0.000147318" iyz="8.97326e-09" izz="0.000142487"/>
+    </inertial>
+    <!-- Part sts3215_03a_v1_3 -->
+    <visual>
+      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -5.27356e-16 -1.5708"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -5.27356e-16 -1.5708"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part upper_arm_so101_v1 -->
+    <visual>
+      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -0 -1.30911e-30"/>
+      <geometry>
+        <mesh filename="assets/upper_arm_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -0 -1.30911e-30"/>
+      <geometry>
+        <mesh filename="assets/upper_arm_so101_v1.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Link lower_arm -->
+  <link name="lower_arm_link">
+    <inertial>
+      <origin xyz="-0.0980701 0.00324376 0.0182831" rpy="0 0 0"/>
+      <mass value="0.104"/>
+      <inertia ixx="2.87438e-05" ixy="7.41152e-06" ixz="1.26409e-06" iyy="0.000159844" iyz="-4.90188e-08" izz="0.00014529"/>
+    </inertial>
+    <!-- Part under_arm_so101_v1 -->
+    <visual>
+      <origin xyz="-0.0648499 -0.032 0.0182" rpy="3.14159 -0 6.67202e-31"/>
+      <geometry>
+        <mesh filename="assets/under_arm_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.0648499 -0.032 0.0182" rpy="3.14159 -0 6.67202e-31"/>
+      <geometry>
+        <mesh filename="assets/under_arm_so101_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part motor_holder_so101_wrist_v1 -->
+    <visual>
+      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 -2.55351e-15 -1.83387e-30"/>
+      <geometry>
+        <mesh filename="assets/motor_holder_so101_wrist_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 -2.55351e-15 -1.83387e-30"/>
+      <geometry>
+        <mesh filename="assets/motor_holder_so101_wrist_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part sts3215_03a_v1_4 -->
+    <visual>
+      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -7.88861e-31 -3.14159"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -7.88861e-31 -3.14159"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Link wrist -->
+  <link name="wrist_link">
+    <inertial>
+      <origin xyz="-0.000103312 -0.0386143 0.0281156" rpy="0 0 0"/>
+      <mass value="0.079"/>
+      <inertia ixx="3.68263e-05" ixy="1.7893e-08" ixz="-5.28128e-08" iyy="2.5391e-05" iyz="3.6412e-06" izz="2.1e-05"/>
+    </inertial>
+    <!-- Part sts3215_03a_no_horn_v1 -->
+    <visual>
+      <origin xyz="8.32667e-17 -0.0424 0.0306" rpy="1.5708 1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_no_horn_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="8.32667e-17 -0.0424 0.0306" rpy="1.5708 1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_no_horn_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part wrist_roll_pitch_so101_v2 -->
+    <visual>
+      <origin xyz="0 -0.028 0.0181" rpy="-1.5708 -1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/wrist_roll_pitch_so101_v2.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="0 -0.028 0.0181" rpy="-1.5708 -1.5708 0"/>
+      <geometry>
+        <mesh filename="assets/wrist_roll_pitch_so101_v2.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Link gripper -->
+  <link name="gripper_link">
+    <inertial>
+      <origin xyz="0.000213627 0.000245138 -0.025187" rpy="0 0 0"/>
+      <mass value="0.087"/>
+      <inertia ixx="2.75087e-05" ixy="-3.35241e-07" ixz="-5.7352e-06" iyy="4.33657e-05" iyz="-5.17847e-08" izz="3.45059e-05"/>
+    </inertial>
+    <!-- Part sts3215_03a_v1_5 -->
+    <visual>
+      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.19179e-17 -1.66533e-16"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+      <material name="sts3215"/>
+    </visual>
+    <collision>
+      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.19179e-17 -1.66533e-16"/>
+      <geometry>
+        <mesh filename="assets/sts3215_03a_v1.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part wrist_roll_follower_so101_v1 -->
+    <visual>
+      <origin xyz="8.32667e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
+      <geometry>
+        <mesh filename="assets/wrist_roll_follower_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="8.32667e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
+      <geometry>
+        <mesh filename="assets/wrist_roll_follower_so101_v1.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Gripper frame (dummy link + fixed joint) -->
+  <link name="gripper_frame_link">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1e-9"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+  </link>
+
+  <joint name="gripper_frame_joint" type="fixed">
+    <origin xyz="-0.0079 -0.000218121 -0.0981274" rpy="0 3.14159 0"/>
+    <parent link="gripper_link"/>
+    <child link="gripper_frame_link"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+
+  <!-- Link moving_jaw_so101_v1 -->
+  <link name="moving_jaw_so101_v1_link">
+    <inertial>
+      <origin xyz="-0.00157495 -0.0300244 0.0192755" rpy="0 0 0"/>
+      <mass value="0.012"/>
+      <inertia ixx="6.61427e-06" ixy="-3.19807e-07" ixz="-5.90717e-09" iyy="1.89032e-06" iyz="-1.09945e-07" izz="5.28738e-06"/>
+    </inertial>
+    <!-- Part moving_jaw_so101_v1 -->
+    <visual>
+      <origin xyz="-5.55112e-17 -5.55112e-17 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
+      <geometry>
+        <mesh filename="assets/moving_jaw_so101_v1.stl"/>
+      </geometry>
+      <material name="3d_printed"/>
+    </visual>
+    <collision>
+      <origin xyz="-5.55112e-17 -5.55112e-17 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
+      <geometry>
+        <mesh filename="assets/moving_jaw_so101_v1.stl"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Joint from gripper to moving_jaw_so101_v1 -->
+  <joint name="gripper" type="revolute">
+    <origin xyz="0.0202 0.0188 -0.0234" rpy="1.5708 -5.24284e-08 -1.41553e-15"/>
+    <parent link="gripper_link"/>
+    <child link="moving_jaw_so101_v1_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-0.174533" upper="1.74533"/>
+  </joint>
+
+  <transmission name="gripper_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="gripper">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor6">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <!-- Joint from wrist to gripper -->
+  <joint name="wrist_roll" type="revolute">
+    <origin xyz="5.55112e-17 -0.0611 0.0181" rpy="1.5708 0.0486795 3.14159"/>
+    <parent link="wrist_link"/>
+    <child link="gripper_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-2.74385" upper="2.84121"/>
+  </joint>
+
+  <transmission name="wrist_roll_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="wrist_roll">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor5">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <!-- Joint from lower_arm to wrist -->
+  <joint name="wrist_flex" type="revolute">
+    <origin xyz="-0.1349 0.0052 3.62355e-17" rpy="4.02456e-15 8.67362e-16 -1.5708"/>
+    <parent link="lower_arm_link"/>
+    <child link="wrist_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-1.65806" upper="1.65806"/>
+  </joint>
+
+  <transmission name="wrist_flex_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="wrist_flex">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor4">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <!-- Joint from upper_arm to lower_arm -->
+  <!-- Note: 5-degree calibration offset applied to joint limits -->
+  <joint name="elbow_flex" type="revolute">
+    <origin xyz="-0.11257 -0.028 1.73763e-16" rpy="-3.63608e-16 8.74301e-16 1.5708"/>
+    <parent link="upper_arm_link"/>
+    <child link="lower_arm_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-1.69" upper="1.69"/>
+  </joint>
+
+  <transmission name="elbow_flex_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="elbow_flex">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor3">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <!-- Joint from shoulder to upper_arm -->
+  <joint name="shoulder_lift" type="revolute">
+    <origin xyz="-0.0303992 -0.0182778 -0.0542" rpy="-1.5708 -1.5708 0"/>
+    <parent link="shoulder_link"/>
+    <child link="upper_arm_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-1.74533" upper="1.74533"/>
+  </joint>
+
+  <transmission name="shoulder_lift_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="shoulder_lift">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor2">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <!-- Joint from base to shoulder -->
+  <joint name="shoulder_pan" type="revolute">
+    <origin xyz="0.0388353 -8.97657e-09 0.0624" rpy="3.14159 4.18253e-17 -3.14159"/>
+    <parent link="base_link"/>
+    <child link="shoulder_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-1.91986" upper="1.91986"/>
+  </joint>
+
+  <transmission name="shoulder_pan_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="shoulder_pan">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor1">
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission> 
+
+</robot>

--- a/tests/test_so101_description.py
+++ b/tests/test_so101_description.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+from deferred_teleop.robot_model.so101 import (
+    generate_so101_description,
+    git_blob_sha1,
+    serialize_description,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "robots" / "so101" / "upstream" / "so101_new_calib.urdf"
+SOURCE_LOCK = ROOT / "robots" / "so101" / "source-lock.toml"
+GENERATED = ROOT / "robots" / "so101" / "generated" / "so101.kinematics.json"
+EXPECTED_BLOB_SHA1 = "9552a231d8b23bed68ec15779eba620c5d875ec4"
+
+EXPECTED_LINKS = {
+    "base_link",
+    "shoulder_link",
+    "upper_arm_link",
+    "lower_arm_link",
+    "wrist_link",
+    "gripper_link",
+    "gripper_frame_link",
+    "moving_jaw_so101_v1_link",
+}
+EXPECTED_ARM_JOINTS = [
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+]
+
+
+def _description() -> dict[str, object]:
+    return generate_so101_description(SOURCE, SOURCE_LOCK)
+
+
+def test_vendored_source_matches_pinned_git_blob() -> None:
+    assert git_blob_sha1(SOURCE.read_bytes()) == EXPECTED_BLOB_SHA1
+
+
+def test_generator_emits_expected_so101_structure() -> None:
+    description = _description()
+
+    assert description["schema_version"] == "dtt.robot-description/0"
+    assert description["model_id"] == "so101_new_calib"
+    assert description["root_link"] == "base_link"
+    assert {link["name"] for link in description["links"]} == EXPECTED_LINKS
+
+    joints = {joint["name"]: joint for joint in description["joints"]}
+    assert set(joints) == {
+        "shoulder_pan",
+        "shoulder_lift",
+        "elbow_flex",
+        "wrist_flex",
+        "wrist_roll",
+        "gripper",
+        "gripper_frame_joint",
+    }
+    assert joints["gripper_frame_joint"]["type"] == "fixed"
+    assert joints["gripper_frame_joint"]["axis_joint_frame"] is None
+    assert joints["gripper"]["type"] == "revolute"
+
+    groups = {group["name"]: group["joints"] for group in description["joint_groups"]}
+    assert groups["arm"] == EXPECTED_ARM_JOINTS
+    assert groups["gripper"] == ["gripper"]
+    assert description["tool_frames"] == [
+        {"name": "gripper_frame_link", "link": "gripper_frame_link"}
+    ]
+
+
+def test_revolute_axes_are_unit_length_and_limits_are_ordered() -> None:
+    for joint in _description()["joints"]:
+        if joint["type"] != "revolute":
+            continue
+        axis = joint["axis_joint_frame"]
+        assert math.sqrt(sum(component * component for component in axis)) == pytest.approx(1.0)
+        limits = joint["position_limits_rad"]
+        assert limits["lower"] <= limits["upper"]
+
+
+def test_generated_quaternions_are_finite_and_normalized() -> None:
+    description = _description()
+    transforms = [joint["parent_to_joint"] for joint in description["joints"]]
+    transforms.extend(
+        visual["link_to_visual"]
+        for link in description["links"]
+        for visual in link["visuals"]
+    )
+
+    for transform in transforms:
+        quaternion = transform["rotation_xyzw"]
+        assert all(math.isfinite(component) for component in quaternion)
+        assert sum(component * component for component in quaternion) == pytest.approx(1.0)
+
+
+def test_generation_is_byte_deterministic() -> None:
+    first = serialize_description(_description())
+    second = serialize_description(_description())
+    assert first == second
+    assert first.endswith("\n")
+
+
+def test_committed_description_matches_fresh_generation() -> None:
+    assert GENERATED.read_text(encoding="utf-8") == serialize_description(_description())
+
+
+def test_tampered_source_fails_before_parsing(tmp_path: Path) -> None:
+    tampered_source = tmp_path / "so101.urdf"
+    tampered_source.write_bytes(SOURCE.read_bytes() + b"\n")
+
+    with pytest.raises(ValueError, match="source hash mismatch"):
+        generate_so101_description(tampered_source, SOURCE_LOCK)


### PR DESCRIPTION
## Summary

Prepares the M2.1 structural-model pipeline independently from M1 runtime development.

## Included

- exact unmodified SO-101 URDF vendored from a pinned upstream commit;
- source lock with repository, commit, path, Git blob identity and licence;
- third-party notice and separation-of-concerns documentation;
- standard-library Python generator for the supported fixed/revolute URDF subset;
- committed deterministic canonical right-handed metre/radian description;
- explicit `arm` and `gripper` joint groups and `gripper_frame_link` tool frame;
- validation for source drift, duplicate names, tree connectivity, axes, limits and configured groups;
- tests for source identity, expected SO-101 structure, quaternion normalisation, deterministic serialization and generated-file drift;
- CI command `python -m deferred_teleop.robot_model.so101 --check`.

## Important boundaries

- structural description is separate from per-device calibration;
- no LeRobot 0-100 gripper value is interpreted as a structural joint angle;
- no Unreal, hardware, IK, FK or transport dependency;
- Unreal runtime will consume generated canonical JSON rather than parse arbitrary URDF;
- official mesh files are not yet included.

## Source pin

```text
repository: TheRobotStudio/SO-ARM100
commit:     385e8d7c68e24945df6c60d9bd68837a4b7411ae
path:       Simulation/SO101/so101_new_calib.urdf
blob SHA-1: 9552a231d8b23bed68ec15779eba620c5d875ec4
licence:    Apache-2.0
```

The local vendored file has the same Git blob identity. The committed generated description is byte-identical to the artefact produced by the generator in GitHub Actions.

## Validation completed

- the full pinned URDF was parsed successfully in GitHub Actions on Python 3.11 and 3.12;
- source/hash, structure, axes, limits, quaternion and deterministic-generation tests passed before the final drift gate was added;
- the exact CI-generated artefact is now committed;
- the branch now contains both a unit drift assertion and the explicit generator `--check` CI step.

A fresh CI run on the final head remains the last mechanical gate before the PR is marked ready.

## Stack / dependencies

Base: `main`  
Parent epic: #12  
Implements: #13

This work is deliberately independent from M1 domain/runtime behavior. It should be rebased if an overlapping Python/CI change lands before merge.
