### PR TITLE
feat(link): add deterministic M1 delayed-link emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Architecture and authority model | Defined, still experimental |
 | Public Python package | M0 foundation complete |
 | Unreal Engine plugin | M0 skeleton; locally verified with UE 5.8.2 on Windows |
-| Delay-tolerant dummy | Planned for M1 |
+| Delay-tolerant dummy | M1 in progress: protocol, durable store and link emulator implemented |
 | SO-101 twin | Planned for M2 |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
@@ -59,7 +59,8 @@ M0 does not freeze all of these messages. It establishes the vocabulary, trust b
 
 ## Development quickstart
 
-The Python package currently exposes only project metadata and protocol-fixture tests.
+The Python package exposes the experimental `dtt/0` models, durable endpoint storage and a
+deterministic development-link emulator.
 
 ```bash
 python -m venv .venv
@@ -68,6 +69,18 @@ python -m pip install -e ".[dev]"
 pytest
 ruff check .
 ```
+
+Run the local two-sided WebSocket link with a reproducible fault profile:
+
+```bash
+dtt-link --mission-listen 127.0.0.1:8765 --field-listen 127.0.0.1:8766 \
+  --profile profiles/15min-blackout.toml
+```
+
+The emulator queue is intentionally volatile and never acknowledges on behalf of a receiver.
+Durable endpoint outboxes retain messages for retry until a receiver persists the envelope and
+its ACK returns.
+See [ADR 0004](docs/adr/0004-deterministic-development-link.md).
 
 The Unreal host project and plugin skeleton live under `unreal/DeferredTeleopDemo`. See [the Unreal bootstrap notes](unreal/README.md). GitHub CI does not compile Unreal; the M0 skeleton was therefore verified locally with Unreal Engine 5.8.2 on Windows.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,3 +12,16 @@ Before adding third-party material, a pull request must record:
 - whether the material may be bundled, downloaded separately, or used only as a development dependency.
 
 The Apache-2.0 licence applies to original repository code unless a file or directory explicitly states otherwise. It does not relicense third-party material.
+
+## Direct Python runtime dependencies
+
+These packages are installed separately from PyPI and are not vendored or modified in this
+repository:
+
+| Package | Accepted versions | Version used for local validation | Source | Licence |
+|---|---:|---:|---|---|
+| Pydantic | `>=2.11,<3` | 2.13.5 | <https://github.com/pydantic/pydantic> | MIT |
+| websockets | `>=15,<17` | 16.1.1 | <https://github.com/python-websockets/websockets> | BSD-3-Clause |
+
+Their distributions carry the applicable copyright and licence texts. No robot assets,
+datasets, model weights or copied third-party source files are introduced by M1.3.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -26,12 +26,18 @@ Completed on 4 September 2026 on the primary Windows development platform with U
 
 The exact commands, environment and visible evidence are recorded on bootstrap pull request #2.
 
+## Implemented toward M1
+
+- strict Python wire models and JSON schemas for the constrained `dtt/0` dummy path;
+- durable SQLite inbox, outbox, execution journal and crash recovery primitives;
+- deterministic in-memory and two-sided WebSocket link emulator;
+- seeded delay, jitter, duplication, reordering, blackout, bandwidth and capacity profiles;
+- transport-level ACK frames, observability metrics and virtual-time fault tests.
+
 ## Planned, not implemented
 
-- Mission, Field or Robot processes;
-- persistent inbox/outbox;
-- delay and failure emulator;
-- `OperationIntent`, `OperationPlan`, `TaskAssignment` or `ExecutionContract` runtime models;
+- runnable Mission, Field and dummy Robot process orchestration;
+- end-to-end delayed dummy execution and reconciliation;
 - Unreal VR visualization;
 - SO-101 geometry, kinematics or hardware integration;
 - Simulation Worker;

--- a/docs/adr/0004-deterministic-development-link.md
+++ b/docs/adr/0004-deterministic-development-link.md
@@ -1,0 +1,48 @@
+# ADR 0004: Deterministic development link
+
+- Status: Proposed for M1
+- Date: 2026-09-04
+
+## Context
+
+M1 must demonstrate a delayed Mission-to-Field path, including acknowledgements,
+duplicates, reordering, blackouts, bandwidth pressure, and link-process restarts. The
+transport is a test instrument: endpoint SQLite inboxes and outboxes from ADR 0003 remain
+the authoritative source of delivery and processing state.
+
+## Decision
+
+`deferred_teleop.link` provides a pure, virtual-time `DeterministicLink` scheduling core.
+A `FaultProfile` fixes the seed and all delay/fault parameters; optional per-message scripts
+make exact scenarios reproducible. Both envelopes and ACK frames traverse this scheduler.
+
+Two adapters are provided:
+
+- `InMemoryTransport` implements the narrow `send`, `receive`, `acknowledge`, and `health`
+  port for domain tests.
+- `WebSocketRelay` exposes separate Mission and Field listeners so independently launched
+  Python processes can communicate through the same fault scheduler. The `dtt-link` command
+  loads a TOML profile and emits structured health snapshots.
+
+The emulator uses volatile queues by design. It never acknowledges a message on behalf of
+its destination. A receiver must first persist an envelope in its durable inbox, and only
+then send an ACK. The sender removes no pending outbox record until that ACK returns. Thus a
+link crash may lose an in-flight copy, but endpoint retry makes that loss temporary; inbox
+deduplication makes delivery duplicates harmless at the application boundary.
+
+ACK/control traffic has a separate bandwidth lane from data traffic. This prevents a large
+payload from indefinitely starving delivery control while preserving deterministic timing.
+Expired messages and capacity or disconnected-destination drops are reported, not hidden.
+Metrics also expose queue depth, next scheduled delivery, duplicate injections, blackout
+deferrals, transmitted bytes, and reconnects.
+
+## Consequences
+
+- A fixed profile and seed produces an identical delivery schedule.
+- Blackout and 15-minute-delay scenarios are tested with virtual time rather than real waits.
+- Transport delivery is at-least-once and non-authoritative; application idempotence belongs
+  to the durable endpoint store.
+- WebSocket is a local development adapter, not the production transport choice.
+
+DTN Bundle Protocol, QUIC, production authentication/key management, media/blob transfer,
+Unreal integration, and real robot integration remain outside this decision.

--- a/profiles/15min-blackout.toml
+++ b/profiles/15min-blackout.toml
@@ -1,0 +1,10 @@
+[profile]
+one_way_delay_seconds = 2.0
+jitter_distribution = "uniform"
+jitter_seconds = 0.5
+duplicate_probability = 0.1
+reorder_window_seconds = 1.0
+blackout_intervals = [[60.0, 960.0]]
+bandwidth_bytes_per_second = 4096.0
+queue_capacity = 1000
+seed = 1500

--- a/profiles/reliable-short-delay.toml
+++ b/profiles/reliable-short-delay.toml
@@ -1,0 +1,10 @@
+[profile]
+one_way_delay_seconds = 0.05
+jitter_distribution = "none"
+jitter_seconds = 0.0
+duplicate_probability = 0.0
+reorder_window_seconds = 0.0
+blackout_intervals = []
+bandwidth_bytes_per_second = 1000000.0
+queue_capacity = 1000
+seed = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.11,<3",
+    "websockets>=15,<17",
 ]
+
+[project.scripts]
+dtt-link = "deferred_teleop.link:main"
 
 [project.optional-dependencies]
 dev = [

--- a/python/src/deferred_teleop/link.py
+++ b/python/src/deferred_teleop/link.py
@@ -1,0 +1,476 @@
+"""Deterministic delayed/faulted link with in-memory and WebSocket adapters."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import heapq
+import json
+import random
+import time
+import tomllib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal, Protocol
+from uuid import UUID
+
+from websockets.asyncio.server import Server, ServerConnection, serve
+
+from deferred_teleop.protocol import MessageEnvelope
+
+Side = Literal["mission", "field"]
+FrameKind = Literal["envelope", "ack"]
+
+
+@dataclass(frozen=True)
+class ScriptedDelivery:
+    delay_seconds: float | None = None
+    duplicates: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.delay_seconds is not None and self.delay_seconds < 0:
+            raise ValueError("scripted delay must be non-negative")
+        if self.duplicates is not None and self.duplicates < 0:
+            raise ValueError("scripted duplicates must be non-negative")
+
+
+@dataclass(frozen=True)
+class FaultProfile:
+    one_way_delay_seconds: float = 0.0
+    jitter_distribution: Literal["none", "uniform"] = "none"
+    jitter_seconds: float = 0.0
+    duplicate_probability: float = 0.0
+    reorder_window_seconds: float = 0.0
+    blackout_intervals: tuple[tuple[float, float], ...] = ()
+    bandwidth_bytes_per_second: float | None = None
+    queue_capacity: int = 10_000
+    seed: int = 0
+    scripted: dict[str, ScriptedDelivery] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        non_negative = (
+            self.one_way_delay_seconds,
+            self.jitter_seconds,
+            self.reorder_window_seconds,
+        )
+        if any(value < 0 for value in non_negative):
+            raise ValueError("delay, jitter and reorder window must be non-negative")
+        if self.jitter_distribution not in {"none", "uniform"}:
+            raise ValueError("jitter_distribution must be 'none' or 'uniform'")
+        if not 0.0 <= self.duplicate_probability <= 1.0:
+            raise ValueError("duplicate_probability must be between 0 and 1")
+        if self.bandwidth_bytes_per_second is not None and self.bandwidth_bytes_per_second <= 0:
+            raise ValueError("bandwidth_bytes_per_second must be positive")
+        if self.queue_capacity < 1:
+            raise ValueError("queue_capacity must be positive")
+        for start, end in self.blackout_intervals:
+            if start < 0 or end <= start:
+                raise ValueError("blackout intervals require 0 <= start < end")
+
+    @classmethod
+    def from_toml(cls, path: str | Path) -> FaultProfile:
+        raw = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+        profile = dict(raw.get("profile", raw))
+        scripted = {
+            key: ScriptedDelivery(**value) for key, value in profile.pop("scripted", {}).items()
+        }
+        blackouts = tuple(tuple(item) for item in profile.pop("blackout_intervals", []))
+        return cls(**profile, scripted=scripted, blackout_intervals=blackouts)
+
+
+@dataclass(frozen=True)
+class LinkFrame:
+    kind: FrameKind
+    envelope: MessageEnvelope | None = None
+    acknowledged_message_id: UUID | None = None
+
+    @classmethod
+    def for_envelope(cls, envelope: MessageEnvelope) -> LinkFrame:
+        return cls(kind="envelope", envelope=envelope)
+
+    @classmethod
+    def for_ack(cls, message_id: UUID) -> LinkFrame:
+        return cls(kind="ack", acknowledged_message_id=message_id)
+
+    @property
+    def stable_id(self) -> str:
+        if self.kind == "envelope" and self.envelope is not None:
+            return str(self.envelope.message_id)
+        if self.kind == "ack" and self.acknowledged_message_id is not None:
+            return f"ack:{self.acknowledged_message_id}"
+        raise ValueError("incomplete link frame")
+
+    @property
+    def priority(self) -> int:
+        return 0 if self.kind == "ack" else 1
+
+    def to_json(self) -> str:
+        if self.kind == "envelope" and self.envelope is not None:
+            value = {"kind": "envelope", "envelope": self.envelope.model_dump(mode="json")}
+        elif self.kind == "ack" and self.acknowledged_message_id is not None:
+            value = {"kind": "ack", "message_id": str(self.acknowledged_message_id)}
+        else:
+            raise ValueError("incomplete link frame")
+        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, encoded: str) -> LinkFrame:
+        value = json.loads(encoded)
+        if set(value) == {"kind", "envelope"} and value["kind"] == "envelope":
+            envelope = MessageEnvelope.model_validate_json(json.dumps(value["envelope"]))
+            return cls.for_envelope(envelope)
+        if set(value) == {"kind", "message_id"} and value["kind"] == "ack":
+            return cls.for_ack(UUID(value["message_id"]))
+        raise ValueError("invalid link frame")
+
+
+class TransportPort(Protocol):
+    async def send(self, envelope: MessageEnvelope) -> None: ...
+
+    async def receive(self) -> LinkFrame: ...
+
+    async def acknowledge(self, message_id: UUID) -> None: ...
+
+    def health(self) -> dict[str, Any]: ...
+
+
+class InMemoryTransport:
+    """Substitutable domain-test transport with the same narrow port."""
+
+    def __init__(
+        self,
+        inbound: asyncio.Queue[LinkFrame],
+        outbound: asyncio.Queue[LinkFrame],
+    ) -> None:
+        self._inbound = inbound
+        self._outbound = outbound
+        self._sent = 0
+        self._received = 0
+
+    @classmethod
+    def pair(cls) -> tuple[InMemoryTransport, InMemoryTransport]:
+        left_to_right: asyncio.Queue[LinkFrame] = asyncio.Queue()
+        right_to_left: asyncio.Queue[LinkFrame] = asyncio.Queue()
+        return cls(right_to_left, left_to_right), cls(left_to_right, right_to_left)
+
+    async def send(self, envelope: MessageEnvelope) -> None:
+        await self._outbound.put(LinkFrame.for_envelope(envelope))
+        self._sent += 1
+
+    async def receive(self) -> LinkFrame:
+        frame = await self._inbound.get()
+        self._received += 1
+        return frame
+
+    async def acknowledge(self, message_id: UUID) -> None:
+        await self._outbound.put(LinkFrame.for_ack(message_id))
+        self._sent += 1
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "transport": "memory",
+            "sent": self._sent,
+            "received": self._received,
+            "queued_inbound": self._inbound.qsize(),
+        }
+
+
+@dataclass(order=True, frozen=True)
+class ScheduledFrame:
+    delivery_time: float
+    priority: int
+    sequence: int
+    destination: Side = field(compare=False)
+    frame: LinkFrame = field(compare=False)
+    encoded_size: int = field(compare=False)
+
+
+class DeterministicLink:
+    """Pure scheduling core driven by caller-supplied virtual time."""
+
+    def __init__(
+        self,
+        profile: FaultProfile,
+        *,
+        wall_epoch: datetime | None = None,
+    ) -> None:
+        self.profile = profile
+        self.wall_epoch = wall_epoch or datetime.now(UTC)
+        if self.wall_epoch.tzinfo is None or self.wall_epoch.utcoffset() is None:
+            raise ValueError("wall_epoch must be timezone-aware")
+        self._random = random.Random(profile.seed)
+        self._queue: list[ScheduledFrame] = []
+        self._sequence = 0
+        self._lane_available: dict[tuple[Side, int], float] = {}
+        self.metrics: dict[str, int] = {
+            "submitted": 0,
+            "delivered": 0,
+            "duplicates_injected": 0,
+            "dropped_capacity": 0,
+            "dropped_disconnected": 0,
+            "blackout_deferrals": 0,
+            "expired": 0,
+            "bytes_transmitted": 0,
+            "reconnect_count": 0,
+        }
+
+    def submit(self, source: Side, frame: LinkFrame, *, now: float) -> int:
+        if now < 0:
+            raise ValueError("virtual time must be non-negative")
+        if source not in {"mission", "field"}:
+            raise ValueError("source must be mission or field")
+        self.metrics["submitted"] += 1
+        directive = self.profile.scripted.get(frame.stable_id)
+        duplicate_count = self._duplicate_count(directive)
+        scheduled = 0
+        for copy_index in range(duplicate_count + 1):
+            if len(self._queue) >= self.profile.queue_capacity:
+                self.metrics["dropped_capacity"] += 1
+                continue
+            destination: Side = "field" if source == "mission" else "mission"
+            delivery = self._delivery_time(
+                destination, frame, now=now, copy_index=copy_index, directive=directive
+            )
+            if self._is_expired(frame, delivery):
+                self.metrics["expired"] += 1
+                continue
+            encoded_size = len(frame.to_json().encode("utf-8"))
+            self._sequence += 1
+            heapq.heappush(
+                self._queue,
+                ScheduledFrame(
+                    delivery,
+                    frame.priority,
+                    self._sequence,
+                    destination,
+                    frame,
+                    encoded_size,
+                ),
+            )
+            scheduled += 1
+        if duplicate_count:
+            self.metrics["duplicates_injected"] += max(0, scheduled - 1)
+        return scheduled
+
+    def deliver_due(self, *, now: float) -> list[ScheduledFrame]:
+        delivered: list[ScheduledFrame] = []
+        while self._queue and self._queue[0].delivery_time <= now:
+            item = heapq.heappop(self._queue)
+            delivered.append(item)
+            self.metrics["delivered"] += 1
+            self.metrics["bytes_transmitted"] += item.encoded_size
+        return delivered
+
+    def status(self, *, now: float) -> dict[str, Any]:
+        return {
+            **self.metrics,
+            "queued_deliveries": len(self._queue),
+            "next_delivery_time": self._queue[0].delivery_time if self._queue else None,
+            "blackout": self._in_blackout(now),
+        }
+
+    def _duplicate_count(self, directive: ScriptedDelivery | None) -> int:
+        if directive is not None and directive.duplicates is not None:
+            return directive.duplicates
+        return int(self._random.random() < self.profile.duplicate_probability)
+
+    def _delivery_time(
+        self,
+        destination: Side,
+        frame: LinkFrame,
+        *,
+        now: float,
+        copy_index: int,
+        directive: ScriptedDelivery | None,
+    ) -> float:
+        delay = self.profile.one_way_delay_seconds
+        if directive is not None and directive.delay_seconds is not None:
+            delay = directive.delay_seconds
+        if self.profile.jitter_distribution == "uniform":
+            delay += self._random.uniform(-self.profile.jitter_seconds, self.profile.jitter_seconds)
+        delay = max(0.0, delay)
+        reorder = self._random.uniform(0.0, self.profile.reorder_window_seconds)
+        candidate = now + delay + reorder + copy_index * 1e-6
+        encoded_size = len(frame.to_json().encode("utf-8"))
+        bandwidth = self.profile.bandwidth_bytes_per_second
+        if bandwidth is not None:
+            lane = (destination, frame.priority)
+            start = max(candidate, self._lane_available.get(lane, candidate))
+            candidate = start + encoded_size / bandwidth
+        after_blackout = self._after_blackout(candidate)
+        if bandwidth is not None:
+            self._lane_available[(destination, frame.priority)] = after_blackout
+        if after_blackout != candidate:
+            self.metrics["blackout_deferrals"] += 1
+        return after_blackout
+
+    def _after_blackout(self, candidate: float) -> float:
+        changed = True
+        while changed:
+            changed = False
+            for start, end in self.profile.blackout_intervals:
+                if start <= candidate < end:
+                    candidate = end
+                    changed = True
+        return candidate
+
+    def _in_blackout(self, now: float) -> bool:
+        return any(start <= now < end for start, end in self.profile.blackout_intervals)
+
+    def _is_expired(self, frame: LinkFrame, delivery: float) -> bool:
+        if frame.kind != "envelope" or frame.envelope is None:
+            return False
+        expires_at = frame.envelope.expires_at
+        if expires_at is None:
+            return False
+        delivery_wall_time = self.wall_epoch + timedelta(seconds=delivery)
+        return delivery_wall_time >= expires_at
+
+
+class WebSocketRelay:
+    """Development-only two-sided WebSocket adapter around the deterministic core."""
+
+    def __init__(
+        self,
+        profile: FaultProfile,
+        *,
+        mission_host: str = "127.0.0.1",
+        mission_port: int = 0,
+        field_host: str = "127.0.0.1",
+        field_port: int = 0,
+    ) -> None:
+        self.link = DeterministicLink(profile)
+        self._mission_address = (mission_host, mission_port)
+        self._field_address = (field_host, field_port)
+        self._servers: list[Server] = []
+        self._connections: dict[Side, set[ServerConnection]] = {
+            "mission": set(),
+            "field": set(),
+        }
+        self._connection_attempts: dict[Side, int] = {"mission": 0, "field": 0}
+        self._start_time = 0.0
+        self._delivery_task: asyncio.Task[None] | None = None
+
+    @property
+    def mission_port(self) -> int:
+        return self._bound_port(0)
+
+    @property
+    def field_port(self) -> int:
+        return self._bound_port(1)
+
+    async def start(self) -> None:
+        self._start_time = time.monotonic()
+        mission = await serve(
+            lambda connection: self._handle("mission", connection), *self._mission_address
+        )
+        field_server = await serve(
+            lambda connection: self._handle("field", connection), *self._field_address
+        )
+        self._servers = [mission, field_server]
+        self._delivery_task = asyncio.create_task(self._delivery_loop())
+
+    async def close(self) -> None:
+        if self._delivery_task is not None:
+            self._delivery_task.cancel()
+            await asyncio.gather(self._delivery_task, return_exceptions=True)
+        for server in self._servers:
+            server.close()
+        await asyncio.gather(*(server.wait_closed() for server in self._servers))
+        self._servers.clear()
+
+    async def __aenter__(self) -> WebSocketRelay:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self.close()
+
+    def health(self) -> dict[str, Any]:
+        return {
+            **self.link.status(now=self._now()),
+            "mission_connections": len(self._connections["mission"]),
+            "field_connections": len(self._connections["field"]),
+            "mission_port": self.mission_port,
+            "field_port": self.field_port,
+        }
+
+    async def _handle(self, side: Side, connection: ServerConnection) -> None:
+        if self._connection_attempts[side]:
+            self.link.metrics["reconnect_count"] += 1
+        self._connection_attempts[side] += 1
+        self._connections[side].add(connection)
+        try:
+            async for encoded in connection:
+                if not isinstance(encoded, str):
+                    raise ValueError("binary frames are not supported")
+                self.link.submit(side, LinkFrame.from_json(encoded), now=self._now())
+        finally:
+            self._connections[side].discard(connection)
+
+    async def _delivery_loop(self) -> None:
+        while True:
+            for scheduled in self.link.deliver_due(now=self._now()):
+                encoded = scheduled.frame.to_json()
+                connections = tuple(self._connections[scheduled.destination])
+                if connections:
+                    await asyncio.gather(*(connection.send(encoded) for connection in connections))
+                else:
+                    self.link.metrics["dropped_disconnected"] += 1
+            await asyncio.sleep(0.001)
+
+    def _now(self) -> float:
+        return time.monotonic() - self._start_time
+
+    def _bound_port(self, server_index: int) -> int:
+        if len(self._servers) <= server_index or not self._servers[server_index].sockets:
+            return 0
+        return int(self._servers[server_index].sockets[0].getsockname()[1])
+
+
+def _parse_address(value: str) -> tuple[str, int]:
+    host, separator, port = value.rpartition(":")
+    if not separator or not host:
+        raise argparse.ArgumentTypeError("address must be HOST:PORT")
+    try:
+        return host, int(port)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("port must be an integer") from error
+
+
+async def _run_cli(args: argparse.Namespace) -> None:
+    profile = FaultProfile.from_toml(args.profile)
+    mission_host, mission_port = args.mission_listen
+    field_host, field_port = args.field_listen
+    relay = WebSocketRelay(
+        profile,
+        mission_host=mission_host,
+        mission_port=mission_port,
+        field_host=field_host,
+        field_port=field_port,
+    )
+    await relay.start()
+    print(json.dumps({"event": "dtt-link.started", **relay.health()}, sort_keys=True), flush=True)
+    try:
+        while True:
+            await asyncio.sleep(args.status_interval)
+            print(
+                json.dumps({"event": "dtt-link.status", **relay.health()}, sort_keys=True),
+                flush=True,
+            )
+    finally:
+        await relay.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mission-listen", type=_parse_address, default=("127.0.0.1", 8765))
+    parser.add_argument("--field-listen", type=_parse_address, default=("127.0.0.1", 8766))
+    parser.add_argument("--profile", type=Path, required=True)
+    parser.add_argument("--status-interval", type=float, default=5.0)
+    asyncio.run(_run_cli(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,312 @@
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from deferred_teleop.link import (
+    DeterministicLink,
+    FaultProfile,
+    InMemoryTransport,
+    LinkFrame,
+    ScriptedDelivery,
+    WebSocketRelay,
+)
+from deferred_teleop.protocol import MessageEnvelope
+from deferred_teleop.storage import NodeStore
+from websockets.asyncio.client import connect
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN_PATH = ROOT / "protocol" / "v0" / "fixtures" / "valid" / "dummy-operation-chain.json"
+NOW = datetime(2026, 9, 4, 9, 0, tzinfo=UTC)
+
+
+def _messages() -> list[MessageEnvelope]:
+    raw = json.loads(CHAIN_PATH.read_text(encoding="utf-8"))["messages"]
+    return [MessageEnvelope.model_validate_json(json.dumps(item)) for item in raw]
+
+
+def _delivery_signature(link: DeterministicLink) -> list[tuple[float, str, str]]:
+    return [
+        (item.delivery_time, item.destination, item.frame.stable_id)
+        for item in link.deliver_due(now=10_000.0)
+    ]
+
+
+def test_fixed_seed_and_profile_produce_identical_schedule_and_metrics() -> None:
+    profile = FaultProfile(
+        one_way_delay_seconds=2.0,
+        jitter_distribution="uniform",
+        jitter_seconds=0.5,
+        duplicate_probability=0.5,
+        reorder_window_seconds=1.0,
+        seed=20260904,
+    )
+    links = [DeterministicLink(profile, wall_epoch=NOW) for _ in range(2)]
+
+    for link in links:
+        for envelope in _messages()[:4]:
+            link.submit("mission", LinkFrame.for_envelope(envelope), now=3.0)
+
+    assert _delivery_signature(links[0]) == _delivery_signature(links[1])
+    assert links[0].metrics == links[1].metrics
+
+
+def test_scripted_schedule_controls_delay_duplicates_and_reordering() -> None:
+    first, second = _messages()[-2:]
+    profile = FaultProfile(
+        seed=1,
+        scripted={
+            str(first.message_id): ScriptedDelivery(delay_seconds=2.0, duplicates=0),
+            str(second.message_id): ScriptedDelivery(delay_seconds=0.5, duplicates=2),
+        },
+    )
+    link = DeterministicLink(profile, wall_epoch=NOW)
+
+    assert link.submit("mission", LinkFrame.for_envelope(first), now=1.0) == 1
+    assert link.submit("mission", LinkFrame.for_envelope(second), now=1.0) == 3
+    delivered = link.deliver_due(now=10.0)
+
+    assert [item.frame.stable_id for item in delivered] == [
+        str(second.message_id),
+        str(second.message_id),
+        str(second.message_id),
+        str(first.message_id),
+    ]
+    assert [item.delivery_time for item in delivered] == pytest.approx(
+        [1.5, 1.500001, 1.500002, 3.0]
+    )
+    assert link.metrics["duplicates_injected"] == 2
+
+
+def test_blackout_defers_delivery_without_real_waiting() -> None:
+    link = DeterministicLink(
+        FaultProfile(one_way_delay_seconds=1.0, blackout_intervals=((0.0, 10.0),)),
+        wall_epoch=NOW,
+    )
+    link.submit("mission", LinkFrame.for_envelope(_messages()[0]), now=0.0)
+
+    assert link.deliver_due(now=9.999) == []
+    assert link.status(now=5.0)["blackout"] is True
+    assert link.status(now=5.0)["blackout_deferrals"] == 1
+    assert len(link.deliver_due(now=10.0)) == 1
+
+
+def test_duplicate_envelope_reaches_receiver_but_store_deduplicates(tmp_path: Path) -> None:
+    envelope = _messages()[0]
+    link = DeterministicLink(
+        FaultProfile(scripted={str(envelope.message_id): ScriptedDelivery(duplicates=1)}),
+        wall_epoch=NOW,
+    )
+    assert link.submit("mission", LinkFrame.for_envelope(envelope), now=0.0) == 2
+
+    with (
+        NodeStore(tmp_path / "field.sqlite3") as field_store,
+        NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+    ):
+        mission_store.enqueue(envelope)
+        accepted = [
+            field_store.receive(item.frame.envelope, received_at=NOW)
+            for item in link.deliver_due(now=1.0)
+            if item.frame.envelope is not None
+        ]
+        assert accepted == [True, False]
+        assert len(field_store.inspect_inbox()) == 1
+
+        # The receiver emits its ACK only after the durable inbox write above.
+        link.submit("field", LinkFrame.for_ack(envelope.message_id), now=1.0)
+        returned_ack = link.deliver_due(now=1.0)[0].frame
+        assert returned_ack.acknowledged_message_id == envelope.message_id
+        assert mission_store.acknowledge(envelope.message_id, acked_at=NOW)
+        assert mission_store.pending_outbox(now=NOW + timedelta(seconds=1)) == []
+
+
+def test_duplicate_ack_is_idempotent_at_durable_outbox(tmp_path: Path) -> None:
+    envelope = _messages()[0]
+    ack = LinkFrame.for_ack(envelope.message_id)
+    link = DeterministicLink(
+        FaultProfile(scripted={ack.stable_id: ScriptedDelivery(duplicates=1)}),
+        wall_epoch=NOW,
+    )
+    link.submit("field", ack, now=0.0)
+
+    with NodeStore(tmp_path / "mission.sqlite3") as store:
+        store.enqueue(envelope)
+        results = [
+            store.acknowledge(item.frame.acknowledged_message_id, acked_at=NOW)
+            for item in link.deliver_due(now=1.0)
+            if item.frame.acknowledged_message_id is not None
+        ]
+        assert results == [True, False]
+        assert store.pending_outbox(now=NOW + timedelta(seconds=1)) == []
+
+
+def test_control_lane_is_not_starved_by_low_bandwidth_payload() -> None:
+    envelope = _messages()[0].model_copy(update={"source_id": "m" * 4_000})
+    data = LinkFrame.for_envelope(envelope)
+    ack = LinkFrame.for_ack(uuid4())
+    link = DeterministicLink(
+        FaultProfile(bandwidth_bytes_per_second=100.0),
+        wall_epoch=NOW,
+    )
+
+    link.submit("mission", data, now=0.0)
+    link.submit("mission", ack, now=0.0)
+    delivered_early = link.deliver_due(now=2.0)
+
+    assert [item.frame.kind for item in delivered_early] == ["ack"]
+    assert link.status(now=2.0)["queued_deliveries"] == 1
+    assert link.metrics["bytes_transmitted"] == len(ack.to_json().encode("utf-8"))
+    assert [item.frame.kind for item in link.deliver_due(now=100.0)] == ["envelope"]
+
+
+def test_expired_messages_and_full_queue_are_audited() -> None:
+    envelope = _messages()[0].model_copy(update={"expires_at": NOW + timedelta(seconds=1)})
+    expired = DeterministicLink(
+        FaultProfile(one_way_delay_seconds=2.0),
+        wall_epoch=NOW,
+    )
+    assert expired.submit("mission", LinkFrame.for_envelope(envelope), now=0.0) == 0
+    assert expired.metrics["expired"] == 1
+
+    capacity = DeterministicLink(
+        FaultProfile(queue_capacity=1, duplicate_probability=1.0),
+        wall_epoch=NOW,
+    )
+    assert capacity.submit("mission", LinkFrame.for_envelope(_messages()[0]), now=0.0) == 1
+    assert capacity.metrics["dropped_capacity"] == 1
+    assert capacity.metrics["duplicates_injected"] == 0
+
+
+def test_in_memory_transport_is_a_substitutable_bidirectional_port() -> None:
+    async def scenario() -> None:
+        mission, field = InMemoryTransport.pair()
+        envelope = _messages()[0]
+
+        await mission.send(envelope)
+        received = await field.receive()
+        assert received.envelope == envelope
+        await field.acknowledge(envelope.message_id)
+        acknowledgement = await mission.receive()
+        assert acknowledgement.acknowledged_message_id == envelope.message_id
+        assert mission.health()["sent"] == 1
+        assert field.health()["received"] == 1
+
+    asyncio.run(scenario())
+
+
+def test_link_crash_cannot_erase_endpoint_pending_outbox(tmp_path: Path) -> None:
+    database = tmp_path / "mission.sqlite3"
+    envelope = _messages()[0]
+    with NodeStore(database) as store:
+        store.enqueue(envelope)
+        first_link = DeterministicLink(
+            FaultProfile(one_way_delay_seconds=100.0),
+            wall_epoch=NOW,
+        )
+        first_link.submit("mission", LinkFrame.for_envelope(envelope), now=0.0)
+        assert first_link.status(now=0.0)["queued_deliveries"] == 1
+
+    # The volatile first link is discarded here, modelling a process crash.
+    with NodeStore(database) as restarted:
+        assert restarted.pending_outbox(now=NOW + timedelta(seconds=1)) == [envelope]
+        replacement_link = DeterministicLink(FaultProfile(), wall_epoch=NOW)
+        replacement_link.submit("mission", LinkFrame.for_envelope(envelope), now=0.0)
+        recovered = replacement_link.deliver_due(now=0.0)[0].frame.envelope
+        assert recovered == envelope
+        with NodeStore(tmp_path / "field.sqlite3") as field_store:
+            assert field_store.receive(recovered, received_at=NOW + timedelta(seconds=1))
+
+
+def test_websocket_relay_connects_separate_python_processes() -> None:
+    async def wait_for_connection(
+        relay: WebSocketRelay, side: str, process: asyncio.subprocess.Process
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while asyncio.get_running_loop().time() < deadline:
+            if relay.health()[f"{side}_connections"]:
+                return
+            if process.returncode is not None:
+                stdout, stderr = await process.communicate()
+                raise AssertionError((stdout + stderr).decode())
+            await asyncio.sleep(0.05)
+        raise AssertionError(f"{side} subprocess did not connect")
+
+    async def scenario() -> None:
+        relay = WebSocketRelay(FaultProfile(one_way_delay_seconds=0.01))
+        await relay.start()
+        envelope = _messages()[0]
+        encoded = LinkFrame.for_envelope(envelope).to_json()
+        receiver_code = (
+            "import asyncio,sys\n"
+            "from websockets.asyncio.client import connect\n"
+            "async def main():\n"
+            " async with connect(f'ws://127.0.0.1:{sys.argv[1]}') as ws:\n"
+            "  print(await ws.recv(), flush=True)\n"
+            "asyncio.run(main())\n"
+        )
+        sender_code = (
+            "import asyncio,sys\n"
+            "from websockets.asyncio.client import connect\n"
+            "async def main():\n"
+            " async with connect(f'ws://127.0.0.1:{sys.argv[1]}') as ws:\n"
+            "  await ws.send(sys.argv[2])\n"
+            "  await asyncio.sleep(0.05)\n"
+            "asyncio.run(main())\n"
+        )
+        receiver = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            receiver_code,
+            str(relay.field_port),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            await wait_for_connection(relay, "field", receiver)
+            sender = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                sender_code,
+                str(relay.mission_port),
+                encoded,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            sender_stdout, sender_stderr = await asyncio.wait_for(sender.communicate(), 5.0)
+            receiver_stdout, receiver_stderr = await asyncio.wait_for(receiver.communicate(), 5.0)
+            assert sender.returncode == 0, (sender_stdout + sender_stderr).decode()
+            assert receiver.returncode == 0, (receiver_stdout + receiver_stderr).decode()
+            assert LinkFrame.from_json(receiver_stdout.decode().strip()).envelope == envelope
+            async with connect(f"ws://127.0.0.1:{relay.mission_port}"):
+                pass
+            health = relay.health()
+            assert health["delivered"] == 1
+            assert health["reconnect_count"] == 1
+            assert {
+                "queued_deliveries",
+                "next_delivery_time",
+                "duplicates_injected",
+                "blackout",
+                "blackout_deferrals",
+                "bytes_transmitted",
+                "reconnect_count",
+            } <= health.keys()
+        finally:
+            if receiver.returncode is None:
+                receiver.kill()
+                await receiver.wait()
+            await relay.close()
+
+    asyncio.run(scenario())
+
+
+def test_repository_profiles_load_without_real_time_waits() -> None:
+    reliable = FaultProfile.from_toml(ROOT / "profiles" / "reliable-short-delay.toml")
+    blackout = FaultProfile.from_toml(ROOT / "profiles" / "15min-blackout.toml")
+
+    assert reliable.one_way_delay_seconds == 0.05
+    assert blackout.blackout_intervals == ((60.0, 960.0),)
+    assert blackout.blackout_intervals[0][1] - blackout.blackout_intervals[0][0] == 900.0


### PR DESCRIPTION
## Problem

M1 lacked the non-authoritative development link needed to prove delayed, duplicated, reordered and interrupted delivery between Mission and Field.

Closes #7
Part of #4

## Approach

- add a deterministic virtual-time scheduler with seeded delay, jitter, duplication, reordering, blackout, bandwidth and capacity faults;
- carry both strict `dtt/0` envelopes and ACK frames through the same link;
- provide a substitutable in-memory port and a two-listener WebSocket relay for separate Python processes;
- keep link queues explicitly volatile while durable endpoint inbox/outbox state remains authoritative;
- reserve a bandwidth lane for ACK/control traffic and expose structured queue, delivery, blackout, byte and reconnect metrics;
- add reliable and 15-minute-blackout TOML profiles plus ADR 0004.

## Authority and safety impact

- Robot authority impact: none; no Robot Runtime or actuation path is added.
- Field authority impact: none; the link transports frames and never acknowledges for Field.
- Mission authority impact: none; Mission retains its durable outbox until a returned ACK is applied.
- Hardware path enabled or changed: no.

## Protocol or public API impact

The experimental `dtt/0` envelope schema is unchanged. This adds an internal link-frame wrapper (envelope or ACK), `FaultProfile`, `DeterministicLink`, `InMemoryTransport`, `WebSocketRelay`, and the `dtt-link` CLI. WebSocket is development-only and is not a production transport decision.

## Validation

- [x] Linked issue
- [x] Tests added or updated
- [x] `pytest` passes: 34 tests
- [x] `ruff check .` passes
- [x] Generated schemas remain current
- [x] Dummy link path works without hardware, including two separate Python client processes
- [x] Hardware remains disabled by default
- [x] Safety and trust assumptions reviewed in ADR 0004
- [x] Unreal build result recorded, when applicable: not applicable; no tracked Unreal changes
- [x] Visible evidence attached, when applicable: not applicable; no Unreal/VR/hardware change
- [x] Documentation/status matrix updated
- [x] Third-party provenance and licences reviewed; `websockets` is BSD-3-Clause and recorded in notices

## Known limitations

- The relay queue is intentionally in-memory and may be lost when the link process stops; endpoint retry is the recovery mechanism.
- Authentication, encryption/key management, DTN BP, QUIC, media/blob transport, Unreal integration and robot integration are out of scope.
- Long-delay tests advance virtual time and do not wait 15 real minutes in CI.
