### PR TITLE
feat(runtime): complete the M1 delayed-dummy vertical slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **A research prototype for delay-tolerant, VR-mediated shared autonomy with remote robots.**
 
-> **Status:** M0 public foundation complete. No runnable release is available yet; the first
-> runnable target is the M1 delay-tolerant dummy.
+> **Status:** M0 public foundation complete. The M1 delay-tolerant dummy is now a runnable
+> development slice; no physical robot path is enabled.
 
 Deferred Teleoperation explores how an operator can express a spatial and linguistic intent from a delayed representation of a remote environment, while an autonomous field site grounds, assigns, executes, adapts, or holds that intent without depending on a real-time round trip.
 
@@ -27,7 +27,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Architecture and authority model | Defined, still experimental |
 | Public Python package | M0 foundation complete |
 | Unreal Engine plugin | M0 skeleton; locally verified with UE 5.8.2 on Windows |
-| Delay-tolerant dummy | M1 in progress: protocol, durable store and link emulator implemented |
+| Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | SO-101 twin | Planned for M2 |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
@@ -81,6 +81,23 @@ The emulator queue is intentionally volatile and never acknowledges on behalf of
 Durable endpoint outboxes retain messages for retry until a receiver persists the envelope and
 its ACK returns.
 See [ADR 0004](docs/adr/0004-deterministic-development-link.md).
+
+Run the complete nominal M1 path with four local processes:
+
+```bash
+dtt-demo delayed-dummy --profile short-visible-delay
+```
+
+Run the deterministic fault/reconnect proof with:
+
+```bash
+dtt-demo delayed-dummy --profile short-visible-fault --restart-mission-after-admission
+```
+
+See the [M1 delayed-dummy guide](docs/m1/DELAYED_DUMMY.md) for the expected evidence,
+manual four-terminal launch, online Mission queries, and offline causal-history inspection.
+The runtime authority and recovery boundaries are recorded in
+[ADR 0005](docs/adr/0005-m1-delayed-dummy-runtime.md).
 
 The Unreal host project and plugin skeleton live under `unreal/DeferredTeleopDemo`. See [the Unreal bootstrap notes](unreal/README.md). GitHub CI does not compile Unreal; the M0 skeleton was therefore verified locally with Unreal Engine 5.8.2 on Windows.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,8 @@ bootstrap pull request. The first runnable release target remains M1.
 
 First runnable release target.
 
+Status: **runnable development slice implemented; milestone validation in progress**
+
 ```text
 OperationIntent(PressButton)
 -> one-node OperationPlan

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,11 +33,14 @@ The exact commands, environment and visible evidence are recorded on bootstrap p
 - deterministic in-memory and two-sided WebSocket link emulator;
 - seeded delay, jitter, duplication, reordering, blackout, bandwidth and capacity profiles;
 - transport-level ACK frames, observability metrics and virtual-time fault tests.
+- separate Mission, Field and dummy-Robot processes with independent durable stores;
+- constrained Field grounding, one-node planning, assignment and local execution contract;
+- deterministic six-phase dummy skill with an effect-once journal boundary;
+- confirmed, predicted-arrival and operator-target Mission projections with explicit provenance;
+- one-command nominal and fault/reconnect demonstrations plus causal-history inspection.
 
 ## Planned, not implemented
 
-- runnable Mission, Field and dummy Robot process orchestration;
-- end-to-end delayed dummy execution and reconciliation;
 - Unreal VR visualization;
 - SO-101 geometry, kinematics or hardware integration;
 - Simulation Worker;

--- a/docs/adr/0005-m1-delayed-dummy-runtime.md
+++ b/docs/adr/0005-m1-delayed-dummy-runtime.md
@@ -1,0 +1,86 @@
+# ADR 0005: M1 delayed-dummy runtime authority and recovery
+
+- Status: Proposed for M1
+- Date: 2026-09-04
+
+## Context
+
+The M1 vertical slice must exercise the canonical semantic path without Unreal, robot
+hardware, or a real-time Mission connection. It must also make three different kinds of
+state visible without conflating them: Field-confirmed state, predicted arrival state, and
+the outcome requested by the operator.
+
+At-least-once delivery means transport deduplication alone is insufficient. A repeated
+intent must not create a second accepted operation, and a repeated contract must not cause
+a second effect. Conversely, Field and Robot must keep making safe local progress while
+Mission is disconnected.
+
+## Decision
+
+M1 runs four independent Python processes:
+
+```text
+operator / demo CLI
+-> Mission
+-> deterministic delayed link
+-> Field
+-> dummy Robot
+```
+
+Mission, Field, and Robot each own a separate SQLite database. The link remains the
+volatile, non-authoritative test instrument defined by ADR 0004. Every receiver persists an
+envelope before returning its ACK, and every sender retains an outbox record until that ACK
+returns.
+
+Mission creates and durably submits one constrained `PressButton` `OperationIntent`. Its
+read model keeps the following representations separate:
+
+- **Confirmed State:** the last measured `SiteSnapshot` received from Field;
+- **Arrival Belief:** the `RobotForecast` and deterministic `PredictionManifest`, both
+  explicitly `PREDICTED`;
+- **Target Branch:** the requested button outcome, explicitly `OPERATOR_ASSERTED`.
+
+Field binds only the known `dummy-button-1` fixture. Before admission it validates expiry,
+the whitelist, selected executor, approval policy, capability, and contract revision. A
+valid intent yields one `GroundedOperation`, one-node `OperationPlan`, `TaskAssignment`, and
+revision-1 `ExecutionContract`. An expired or unsupported intent yields an explicit
+`RECEIVED -> HELD` event and is never sent to Robot. Once admitted, Field has no dependency
+on Mission availability.
+
+The dummy Robot exposes only the typed `PRESS_BUTTON` capability. It durably relates an
+assignment and contract, records dispatch before execution, and advances through:
+
+```text
+VALIDATING
+-> APPROACHING
+-> CONTACTING
+-> VERIFYING_EFFECT
+-> RETRACTING
+-> SUCCEEDED
+```
+
+Each phase records `safe_to_interrupt` metadata. The injectable clock makes phase tests
+deterministic. For the dummy backend, the effect counter, terminal result, and terminal
+event share one SQLite transaction keyed by `press:{operation_id}:{revision}`. A semantic
+duplicate contract therefore replays the durable terminal result without incrementing the
+effect counter. This is an effect-once guarantee for the database-backed dummy only; it is
+not a claim that a future physical action can be exactly-once.
+
+`dtt-demo delayed-dummy` supervises all four processes with isolated stores. The
+`short-visible-delay` profile demonstrates the nominal path. `short-visible-fault` adds
+seeded delay, jitter, duplication, reordering, and a short blackout. The optional Mission
+restart demonstration proves that Field and Robot finish locally and Mission reconciles
+from retained endpoint outboxes after reconnecting. `dtt-inspect` aggregates the causal
+history across the three authoritative stores.
+
+## Consequences
+
+- M1 has a runnable, observable vertical slice without Unreal or physical hardware.
+- Mission disconnection does not revoke admitted Field work.
+- Message identity and semantic operation/contract identity are deduplicated separately.
+- Dependency reordering is retryable without an unbounded poison-message loop.
+- Structured logs and durable histories expose IDs, ACKs, phases, the single dummy effect,
+  and final reconciliation.
+
+Target ambiguity, reassignment, multi-robot coordination, real geometry, learned planning,
+scanning, physical cancellation, and hardware safety remain outside this decision.

--- a/docs/m1/DELAYED_DUMMY.md
+++ b/docs/m1/DELAYED_DUMMY.md
@@ -1,0 +1,62 @@
+# M1 delayed-dummy demonstration
+
+This development demonstration runs the complete M1 semantic path with four separate local
+processes and no hardware.
+
+## One-command proof
+
+Install the package from the repository, then run the nominal profile:
+
+```bash
+python -m pip install -e ".[dev]"
+dtt-demo delayed-dummy --profile short-visible-delay
+```
+
+The final `demo.completed` record reports the operation and contract IDs, estimated arrival,
+all dummy phases, effect counter, final reconciliation, three provenance labels, and a ready
+to run `dtt-inspect` command. Success requires `effect_counter: 1` and
+`terminal_state: SUCCEEDED`.
+
+Run the fault and recovery proof with:
+
+```bash
+dtt-demo delayed-dummy --profile short-visible-fault --restart-mission-after-admission
+```
+
+This profile deterministically injects delay, jitter, duplication, reordering, and a short
+blackout. The supervisor stops Mission after Field admission, waits for the Robot effect,
+then restarts Mission on the same database. Field and Robot do not restart or wait for
+Mission to finish the admitted contract.
+
+By default the supervisor creates a retained temporary data directory and prints its path.
+Use `--data-dir PATH` to select an empty directory. The three files `mission.db`, `field.db`,
+and `robot.db` are deliberately separate; the link has no authoritative store.
+
+## Manual four-terminal launch
+
+From an activated environment, start these commands in order, one per terminal:
+
+```bash
+dtt-link --mission-listen 127.0.0.1:8765 --field-listen 127.0.0.1:8766 --profile profiles/short-visible-delay.toml
+dtt-robot-dummy --db .dtt-demo/robot.db --listen 127.0.0.1:8771
+dtt-field --db .dtt-demo/field.db --link ws://127.0.0.1:8766 --robot ws://127.0.0.1:8771
+dtt-mission --db .dtt-demo/mission.db --link ws://127.0.0.1:8765 --api 127.0.0.1:8770 --one-way-delay 0.15
+```
+
+In a fifth terminal, submit and inspect the operation:
+
+```bash
+dtt-operator submit-press-button
+dtt-operator view
+dtt-operator causal-history --correlation-id CORRELATION_ID
+dtt-inspect causal-history --data-dir .dtt-demo --correlation-id CORRELATION_ID
+```
+
+The online Mission history contains what Mission knows. The offline inspector aggregates
+Mission, Field, and Robot records, so it also shows assignment and contract delivery.
+
+## Scope and safety
+
+Only the database-backed dummy effect is enabled. No Unreal project, physical robot,
+actuator, learned policy, or hardware interface is loaded by these commands. Stop the four
+processes with the normal terminal interrupt when finished.

--- a/profiles/short-visible-delay.toml
+++ b/profiles/short-visible-delay.toml
@@ -1,0 +1,10 @@
+[profile]
+one_way_delay_seconds = 0.15
+jitter_distribution = "none"
+jitter_seconds = 0.0
+duplicate_probability = 0.0
+reorder_window_seconds = 0.0
+blackout_intervals = []
+bandwidth_bytes_per_second = 1000000.0
+queue_capacity = 1000
+seed = 8

--- a/profiles/short-visible-fault.toml
+++ b/profiles/short-visible-fault.toml
@@ -1,0 +1,10 @@
+[profile]
+one_way_delay_seconds = 0.12
+jitter_distribution = "uniform"
+jitter_seconds = 0.03
+duplicate_probability = 0.75
+reorder_window_seconds = 0.08
+blackout_intervals = [[0.35, 0.70]]
+bandwidth_bytes_per_second = 1000000.0
+queue_capacity = 1000
+seed = 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
 
 [project.scripts]
 dtt-link = "deferred_teleop.link:main"
+dtt-mission = "deferred_teleop.node:mission_main"
+dtt-field = "deferred_teleop.node:field_main"
+dtt-robot-dummy = "deferred_teleop.node:robot_main"
+dtt-operator = "deferred_teleop.operator:main"
+dtt-demo = "deferred_teleop.demo:main"
+dtt-inspect = "deferred_teleop.inspect:main"
 
 [project.optional-dependencies]
 dev = [

--- a/python/src/deferred_teleop/demo.py
+++ b/python/src/deferred_teleop/demo.py
@@ -1,0 +1,376 @@
+"""One-command subprocess supervisor for the M1 delayed-dummy demonstration."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import socket
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from deferred_teleop.storage import NodeStore
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PROFILE_ALIASES = {
+    "short-visible-delay": REPOSITORY_ROOT / "profiles" / "short-visible-delay.toml",
+    "short-visible-fault": REPOSITORY_ROOT / "profiles" / "short-visible-fault.toml",
+}
+
+
+def _emit(event: str, fields: Mapping[str, Any]) -> None:
+    print(json.dumps({"event": event, **fields}, separators=(",", ":"), sort_keys=True), flush=True)
+
+
+def _unused_ports(count: int) -> tuple[int, ...]:
+    listeners: list[socket.socket] = []
+    try:
+        for _ in range(count):
+            listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            listener.bind(("127.0.0.1", 0))
+            listeners.append(listener)
+        return tuple(int(listener.getsockname()[1]) for listener in listeners)
+    finally:
+        for listener in listeners:
+            listener.close()
+
+
+def _resolve_profile(value: str) -> Path:
+    alias = value.removesuffix(".toml")
+    path = PROFILE_ALIASES.get(alias, Path(value))
+    if not path.is_file():
+        choices = ", ".join(sorted(PROFILE_ALIASES))
+        raise argparse.ArgumentTypeError(f"profile not found; use a path or one of: {choices}")
+    return path.resolve()
+
+
+class ManagedProcess:
+    def __init__(
+        self,
+        name: str,
+        process: asyncio.subprocess.Process,
+        *,
+        show_logs: bool,
+    ) -> None:
+        self.name = name
+        self.process = process
+        self.show_logs = show_logs
+        self.events: dict[str, list[dict[str, Any]]] = {}
+        self._signals: dict[str, asyncio.Event] = {}
+        self._visible_delivery_events: set[tuple[str, str]] = set()
+        self._reader_task = asyncio.create_task(self._read_output())
+
+    @classmethod
+    async def start(
+        cls,
+        name: str,
+        command: Sequence[str],
+        *,
+        show_logs: bool,
+    ) -> ManagedProcess:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=REPOSITORY_ROOT,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        return cls(name, process, show_logs=show_logs)
+
+    async def _read_output(self) -> None:
+        assert self.process.stdout is not None
+        while raw := await self.process.stdout.readline():
+            line = raw.decode(errors="replace").rstrip()
+            try:
+                fields = json.loads(line)
+            except json.JSONDecodeError:
+                if self.show_logs:
+                    print(f"[{self.name}] {line}", flush=True)
+                continue
+            if not isinstance(fields, dict):
+                continue
+            event = fields.get("event")
+            if isinstance(event, str):
+                self.events.setdefault(event, []).append(fields)
+                self._signals.setdefault(event, asyncio.Event()).set()
+            if self.show_logs:
+                output_event = event if isinstance(event, str) else "process.output"
+                message_id = fields.get("message_id")
+                delivery_key = (output_event, str(message_id))
+                repeated_delivery = output_event.startswith("node.") and message_id is not None
+                polling_log = (
+                    output_event == "mission.api_request" and fields.get("command") == "view"
+                )
+                if not polling_log and (
+                    not repeated_delivery or delivery_key not in self._visible_delivery_events
+                ):
+                    _emit(output_event, {"process": self.name, **fields})
+                if repeated_delivery:
+                    self._visible_delivery_events.add(delivery_key)
+
+    async def wait_event(self, event: str, *, timeout: float) -> dict[str, Any]:
+        if not self.events.get(event):
+            try:
+                await asyncio.wait_for(
+                    self._signals.setdefault(event, asyncio.Event()).wait(),
+                    timeout=timeout,
+                )
+            except TimeoutError as error:
+                return_code = self.process.returncode
+                detail = f" (process exited {return_code})" if return_code is not None else ""
+                raise RuntimeError(f"{self.name} did not emit {event}{detail}") from error
+        return self.events[event][-1]
+
+    async def stop(self) -> None:
+        self.show_logs = False
+        if self.process.returncode is None:
+            self.process.terminate()
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=3.0)
+            except TimeoutError:
+                self.process.kill()
+                await self.process.wait()
+        await asyncio.gather(self._reader_task, return_exceptions=True)
+
+
+async def _mission_request(port: int, request: Mapping[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write((json.dumps(request, separators=(",", ":")) + "\n").encode())
+    await writer.drain()
+    response = json.loads(await asyncio.wait_for(reader.readline(), timeout=2.0))
+    writer.close()
+    await writer.wait_closed()
+    if not response.get("ok"):
+        command = request.get("command")
+        raise RuntimeError(f"Mission API rejected {command}: {response.get('error')}")
+    return response
+
+
+async def _wait_for_terminal(port: int, *, timeout: float) -> dict[str, Any]:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            response = await _mission_request(port, {"command": "view"})
+        except (ConnectionError, OSError):
+            await asyncio.sleep(0.05)
+            continue
+        view = response["view"]
+        if view["terminal_state"] is not None and view["confirmed_state"] is not None:
+            return view
+        await asyncio.sleep(0.05)
+    raise TimeoutError("the delayed dummy did not reconcile before the demo timeout")
+
+
+def _effect_counter(robot_db: Path) -> int:
+    with NodeStore(robot_db) as store:
+        return sum(int(row["effect_count"]) for row in store.inspect_execution_journal())
+
+
+def _prepare_data_dir(value: Path | None) -> Path:
+    path = value.resolve() if value is not None else Path(tempfile.mkdtemp(prefix="dtt-demo-"))
+    path.mkdir(parents=True, exist_ok=True)
+    occupied = [
+        path / name
+        for name in ("mission.db", "field.db", "robot.db")
+        if (path / name).exists()
+    ]
+    if occupied:
+        raise RuntimeError("the demo data directory already contains a node database")
+    return path
+
+
+async def _run_delayed_dummy(args: argparse.Namespace) -> None:
+    data_dir = _prepare_data_dir(args.data_dir)
+    mission_db = data_dir / "mission.db"
+    field_db = data_dir / "field.db"
+    robot_db = data_dir / "robot.db"
+    mission_link_port, field_link_port, robot_port, api_port = _unused_ports(4)
+    retry = str(args.retry_interval)
+    python = sys.executable
+    processes: list[ManagedProcess] = []
+    mission: ManagedProcess | None = None
+
+    async def start(name: str, command: Sequence[str], event: str) -> ManagedProcess:
+        child = await ManagedProcess.start(name, command, show_logs=not args.quiet)
+        processes.append(child)
+        await child.wait_event(event, timeout=args.timeout)
+        return child
+
+    link_command = (
+        python,
+        "-m",
+        "deferred_teleop.link",
+        "--mission-listen",
+        f"127.0.0.1:{mission_link_port}",
+        "--field-listen",
+        f"127.0.0.1:{field_link_port}",
+        "--profile",
+        str(args.profile),
+        "--status-interval",
+        "1",
+    )
+    robot_command = (
+        python,
+        "-m",
+        "deferred_teleop.node",
+        "robot",
+        "--db",
+        str(robot_db),
+        "--listen",
+        f"127.0.0.1:{robot_port}",
+        "--phase-duration",
+        str(args.phase_duration),
+        "--retry-interval",
+        retry,
+    )
+    field_command = (
+        python,
+        "-m",
+        "deferred_teleop.node",
+        "field",
+        "--db",
+        str(field_db),
+        "--link",
+        f"ws://127.0.0.1:{field_link_port}",
+        "--robot",
+        f"ws://127.0.0.1:{robot_port}",
+        "--retry-interval",
+        retry,
+    )
+    mission_command = (
+        python,
+        "-m",
+        "deferred_teleop.node",
+        "mission",
+        "--db",
+        str(mission_db),
+        "--link",
+        f"ws://127.0.0.1:{mission_link_port}",
+        "--api",
+        f"127.0.0.1:{api_port}",
+        "--one-way-delay",
+        str(args.one_way_delay),
+        "--retry-interval",
+        retry,
+    )
+
+    _emit(
+        "demo.started",
+        {
+            "data_dir": str(data_dir),
+            "profile": str(args.profile),
+            "processes": ["link", "mission", "field", "robot"],
+        },
+    )
+    try:
+        link = await start("link", link_command, "dtt-link.started")
+        robot = await start("robot", robot_command, "robot.started")
+        field = await start("field", field_command, "field.started")
+        mission = await start("mission", mission_command, "mission.started")
+        _emit(
+            "demo.processes_ready",
+            {
+                "pids": {
+                    "link": link.process.pid,
+                    "mission": mission.process.pid,
+                    "field": field.process.pid,
+                    "robot": robot.process.pid,
+                },
+                "stores": {
+                    "mission": str(mission_db),
+                    "field": str(field_db),
+                    "robot": str(robot_db),
+                },
+            },
+        )
+        submitted = await _mission_request(
+            api_port,
+            {
+                "command": "submit_press_button",
+                "entity_id": "dummy-button-1",
+                "executor_id": "dummy-robot-1",
+            },
+        )
+        _emit(
+            "demo.operation_submitted",
+            {
+                "operation_id": submitted["operation_id"],
+                "correlation_id": submitted["correlation_id"],
+            },
+        )
+
+        if args.restart_mission_after_admission:
+            admitted = await field.wait_event("field.operation_admitted", timeout=args.timeout)
+            _emit(
+                "demo.mission_stopped_after_admission",
+                {"contract_id": admitted["contract_id"]},
+            )
+            await mission.stop()
+            processes.remove(mission)
+            await robot.wait_event("robot.effect_committed", timeout=args.timeout)
+            mission = await start("mission-restarted", mission_command, "mission.started")
+            _emit("demo.mission_restarted", {"database": str(mission_db)})
+
+        view = await _wait_for_terminal(api_port, timeout=args.timeout)
+        phases = [item["phase"] for item in robot.events.get("robot.phase", [])]
+        effect_counter = _effect_counter(robot_db)
+        _emit(
+            "demo.completed",
+            {
+                "operation_id": submitted["operation_id"],
+                "contract_id": view["terminal_contract_id"],
+                "estimated_arrival_at": view["estimated_arrival_at"],
+                "phases": phases,
+                "effect_counter": effect_counter,
+                "terminal_state": view["terminal_state"],
+                "confirmed_provenance": view["confirmed_state"]["evidence"]["provenance"],
+                "arrival_provenance": view["arrival_belief"]["evidence"]["provenance"],
+                "target_provenance": view["target_branch"]["provenance"],
+                "mission_restarted": args.restart_mission_after_admission,
+                "inspect_command": (
+                    f'dtt-inspect causal-history --data-dir "{data_dir}" '
+                    f'--correlation-id {submitted["correlation_id"]}'
+                ),
+            },
+        )
+        if effect_counter != 1 or view["terminal_state"] != "SUCCEEDED":
+            raise RuntimeError("demo invariant failed: expected one successful dummy effect")
+    finally:
+        for child in reversed(processes):
+            await child.stop()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="demo", required=True)
+    delayed = subparsers.add_parser("delayed-dummy")
+    delayed.add_argument(
+        "--profile",
+        type=_resolve_profile,
+        default=_resolve_profile("short-visible-delay"),
+    )
+    delayed.add_argument("--data-dir", type=Path)
+    delayed.add_argument("--restart-mission-after-admission", action="store_true")
+    delayed.add_argument("--phase-duration", type=float, default=0.1)
+    delayed.add_argument("--one-way-delay", type=float, default=0.15)
+    delayed.add_argument("--retry-interval", type=float, default=0.05)
+    delayed.add_argument("--timeout", type=float, default=15.0)
+    delayed.add_argument("--quiet", action="store_true", help=argparse.SUPPRESS)
+    delayed.set_defaults(run=_run_delayed_dummy)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    if min(args.phase_duration, args.one_way_delay, args.retry_interval, args.timeout) <= 0:
+        raise SystemExit("durations and timeout must be positive")
+    try:
+        asyncio.run(args.run(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/deferred_teleop/inspect.py
+++ b/python/src/deferred_teleop/inspect.py
@@ -1,0 +1,66 @@
+"""Read-only causal-history inspector for M1 node databases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from uuid import UUID
+
+
+def _causal_history(data_dir: Path, correlation_id: UUID) -> list[dict[str, object]]:
+    history: list[dict[str, object]] = []
+    for node, filename in (("mission", "mission.db"), ("field", "field.db"), ("robot", "robot.db")):
+        database = data_dir / filename
+        if not database.is_file():
+            raise FileNotFoundError(database)
+        connection = sqlite3.connect(f"{database.resolve().as_uri()}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        try:
+            rows = connection.execute(
+                """
+                SELECT 'inbox' AS direction, message_id, received_at AS stored_at,
+                       payload_type, payload_json
+                FROM inbox WHERE correlation_id = ?
+                UNION ALL
+                SELECT 'outbox' AS direction, message_id, created_at AS stored_at,
+                       json_extract(payload_json, '$.message_type') AS payload_type, payload_json
+                FROM outbox WHERE correlation_id = ?
+                ORDER BY stored_at, message_id
+                """,
+                (str(correlation_id), str(correlation_id)),
+            ).fetchall()
+        finally:
+            connection.close()
+        for raw in rows:
+            row = dict(raw)
+            payload = json.loads(str(row.pop("payload_json")))
+            history.append({"node": node, **row, "envelope": payload})
+    return sorted(
+        history,
+        key=lambda item: (str(item["stored_at"]), str(item["message_id"]), str(item["node"])),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    causal = subparsers.add_parser("causal-history")
+    causal.add_argument("--data-dir", type=Path, required=True)
+    causal.add_argument("--correlation-id", type=UUID, required=True)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            {
+                "correlation_id": str(args.correlation_id),
+                "history": _causal_history(args.data_dir, args.correlation_id),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/deferred_teleop/link.py
+++ b/python/src/deferred_teleop/link.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Protocol
 from uuid import UUID
 
 from websockets.asyncio.server import Server, ServerConnection, serve
+from websockets.exceptions import ConnectionClosed
 
 from deferred_teleop.protocol import MessageEnvelope
 
@@ -406,6 +407,8 @@ class WebSocketRelay:
                 if not isinstance(encoded, str):
                     raise ValueError("binary frames are not supported")
                 self.link.submit(side, LinkFrame.from_json(encoded), now=self._now())
+        except ConnectionClosed:
+            pass
         finally:
             self._connections[side].discard(connection)
 

--- a/python/src/deferred_teleop/node.py
+++ b/python/src/deferred_teleop/node.py
@@ -1,0 +1,382 @@
+"""Executable Mission, Field and dummy-Robot processes for the M1 runtime slice."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Collection, Mapping
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.asyncio.server import ServerConnection, serve
+
+from deferred_teleop.link import LinkFrame
+from deferred_teleop.runtime import (
+    DummyRobotService,
+    EnvelopeFactory,
+    FieldService,
+    MissionService,
+    RuntimeService,
+    SystemClock,
+)
+from deferred_teleop.storage import NodeStore
+
+
+class JsonLogger:
+    def __init__(self, node_id: str) -> None:
+        self.node_id = node_id
+
+    def __call__(self, event: str, fields: Mapping[str, Any]) -> None:
+        print(
+            json.dumps(
+                {"event": event, "node_id": self.node_id, **fields},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+
+async def _run_socket_connection(
+    connection: ClientConnection | ServerConnection,
+    service: RuntimeService,
+    *,
+    destinations: Collection[str],
+    retry_interval: float,
+    logger: JsonLogger,
+) -> None:
+    async def receive_frames() -> None:
+        async for encoded in connection:
+            if not isinstance(encoded, str):
+                raise ValueError("binary frames are not supported")
+            frame = LinkFrame.from_json(encoded)
+            if frame.kind == "ack" and frame.acknowledged_message_id is not None:
+                try:
+                    changed = service.store.acknowledge(
+                        frame.acknowledged_message_id,
+                        acked_at=service.clock.now(),
+                    )
+                except KeyError:
+                    changed = False
+                logger(
+                    "node.ack_received",
+                    {
+                        "message_id": str(frame.acknowledged_message_id),
+                        "changed": changed,
+                    },
+                )
+                continue
+            if frame.kind != "envelope" or frame.envelope is None:
+                raise ValueError("incomplete envelope frame")
+            envelope = frame.envelope
+            is_new = service.store.receive(envelope, received_at=service.clock.now())
+            await connection.send(LinkFrame.for_ack(envelope.message_id).to_json())
+            logger(
+                "node.ack_sent",
+                {
+                    "message_id": str(envelope.message_id),
+                    "duplicate": not is_new,
+                },
+            )
+            if is_new:
+                await service.handle(envelope)
+
+    async def send_pending() -> None:
+        while True:
+            now = service.clock.now()
+            for envelope in service.store.pending_outbox(now=now):
+                if envelope.destination_id not in destinations:
+                    continue
+                service.store.record_attempt(
+                    envelope.message_id,
+                    next_attempt_at=now + timedelta(seconds=retry_interval),
+                )
+                await connection.send(LinkFrame.for_envelope(envelope).to_json())
+                logger(
+                    "node.message_sent",
+                    {
+                        "message_id": str(envelope.message_id),
+                        "message_type": envelope.message_type,
+                        "destination_id": envelope.destination_id,
+                    },
+                )
+            await asyncio.sleep(min(0.05, retry_interval / 2))
+
+    tasks = {
+        asyncio.create_task(receive_frames()),
+        asyncio.create_task(send_pending()),
+    }
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+    for task in done:
+        task.result()
+
+
+async def _connect_forever(
+    uri: str,
+    service: RuntimeService,
+    *,
+    destinations: Collection[str],
+    retry_interval: float,
+    logger: JsonLogger,
+    connection_name: str,
+) -> None:
+    while True:
+        try:
+            async with connect(
+                uri,
+                open_timeout=2.0,
+                ping_interval=10.0,
+                ping_timeout=10.0,
+            ) as connection:
+                logger("node.connected", {"connection": connection_name, "uri": uri})
+                await _run_socket_connection(
+                    connection,
+                    service,
+                    destinations=destinations,
+                    retry_interval=retry_interval,
+                    logger=logger,
+                )
+        except asyncio.CancelledError:
+            raise
+        except (OSError, TimeoutError, ValueError) as error:
+            logger(
+                "node.disconnected",
+                {"connection": connection_name, "error": type(error).__name__},
+            )
+        await asyncio.sleep(retry_interval)
+
+
+async def _mission_api_handler(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    service: MissionService,
+    logger: JsonLogger,
+) -> None:
+    try:
+        raw = await asyncio.wait_for(reader.readline(), timeout=5.0)
+        request = json.loads(raw)
+        command = request.get("command")
+        if command == "submit_press_button":
+            intent = service.submit_press_button(
+                entity_id=request.get("entity_id", "dummy-button-1"),
+                executor_id=request.get("executor_id", "dummy-robot-1"),
+                expires_in_seconds=request.get("expires_in_seconds", 60.0),
+            )
+            response: dict[str, Any] = {
+                "ok": True,
+                "message_id": str(intent.message_id),
+                "operation_id": str(intent.payload.operation_id),
+                "correlation_id": str(intent.correlation_id),
+            }
+        elif command == "view":
+            response = {"ok": True, "view": service.view()}
+        elif command == "causal_history":
+            correlation_id = UUID(request["correlation_id"])
+            response = {"ok": True, "history": service.store.causal_history(correlation_id)}
+        else:
+            response = {"ok": False, "error": "unknown-command"}
+    except (KeyError, TypeError, ValueError, TimeoutError) as error:
+        response = {"ok": False, "error": type(error).__name__}
+    writer.write((json.dumps(response, separators=(",", ":")) + "\n").encode())
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+    logger("mission.api_request", {"command": command if "command" in locals() else None})
+
+
+def _parse_address(value: str) -> tuple[str, int]:
+    host, separator, port_text = value.rpartition(":")
+    if not separator or not host:
+        raise argparse.ArgumentTypeError("address must be HOST:PORT")
+    try:
+        port = int(port_text)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("port must be an integer") from error
+    if not 0 <= port <= 65_535:
+        raise argparse.ArgumentTypeError("port must be between 0 and 65535")
+    return host, port
+
+
+async def run_mission(args: argparse.Namespace) -> None:
+    clock = SystemClock()
+    logger = JsonLogger(args.node_id)
+    with NodeStore(args.db) as store:
+        service = MissionService(
+            store,
+            EnvelopeFactory(args.node_id, clock),
+            configured_one_way_delay=args.one_way_delay,
+            emit=logger,
+        )
+        recovered = await service.recover()
+        api = await asyncio.start_server(
+            lambda reader, writer: _mission_api_handler(reader, writer, service, logger),
+            *args.api,
+        )
+        api_port = int(api.sockets[0].getsockname()[1]) if api.sockets else 0
+        logger(
+            "mission.started",
+            {
+                "api_host": args.api[0],
+                "api_port": api_port,
+                "database": str(Path(args.db).resolve()),
+                "recovered_inbox": recovered,
+            },
+        )
+        async with api:
+            await _connect_forever(
+                args.link,
+                service,
+                destinations={"field-1"},
+                retry_interval=args.retry_interval,
+                logger=logger,
+                connection_name="delayed-link",
+            )
+
+
+async def run_field(args: argparse.Namespace) -> None:
+    clock = SystemClock()
+    logger = JsonLogger(args.node_id)
+    with NodeStore(args.db) as store:
+        service = FieldService(
+            store,
+            EnvelopeFactory(args.node_id, clock),
+            mission_id=args.mission_id,
+            robot_id=args.robot_id,
+            emit=logger,
+        )
+        recovered = await service.recover()
+        logger(
+            "field.started",
+            {"database": str(Path(args.db).resolve()), "recovered_inbox": recovered},
+        )
+        await asyncio.gather(
+            _connect_forever(
+                args.link,
+                service,
+                destinations={args.mission_id},
+                retry_interval=args.retry_interval,
+                logger=logger,
+                connection_name="delayed-link",
+            ),
+            _connect_forever(
+                args.robot,
+                service,
+                destinations={args.robot_id},
+                retry_interval=args.retry_interval,
+                logger=logger,
+                connection_name="dummy-robot",
+            ),
+        )
+
+
+async def run_robot(args: argparse.Namespace) -> None:
+    clock = SystemClock()
+    logger = JsonLogger(args.node_id)
+    with NodeStore(args.db) as store:
+        service = DummyRobotService(
+            store,
+            EnvelopeFactory(args.node_id, clock),
+            field_id=args.field_id,
+            phase_duration=args.phase_duration,
+            emit=logger,
+        )
+        recovered = await service.recover()
+
+        async def handler(connection: ServerConnection) -> None:
+            await _run_socket_connection(
+                connection,
+                service,
+                destinations={args.field_id},
+                retry_interval=args.retry_interval,
+                logger=logger,
+            )
+
+        server = await serve(handler, *args.listen)
+        port = int(server.sockets[0].getsockname()[1]) if server.sockets else 0
+        logger(
+            "robot.started",
+            {
+                "listen_host": args.listen[0],
+                "listen_port": port,
+                "database": str(Path(args.db).resolve()),
+                "capabilities": service.capabilities,
+                "effect_counter": service.effect_counter,
+                "recovered_inbox": recovered,
+            },
+        )
+        async with server:
+            await server.serve_forever()
+
+
+def _add_common_node_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--retry-interval", type=float, default=0.2)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="process", required=True)
+
+    mission = subparsers.add_parser("mission")
+    _add_common_node_arguments(mission)
+    mission.add_argument("--node-id", default="mission-1")
+    mission.add_argument("--link", required=True)
+    mission.add_argument("--api", type=_parse_address, default=("127.0.0.1", 8770))
+    mission.add_argument("--one-way-delay", type=float, default=0.05)
+    mission.set_defaults(run=run_mission)
+
+    field = subparsers.add_parser("field")
+    _add_common_node_arguments(field)
+    field.add_argument("--node-id", default="field-1")
+    field.add_argument("--mission-id", default="mission-1")
+    field.add_argument("--robot-id", default="dummy-robot-1")
+    field.add_argument("--link", required=True)
+    field.add_argument("--robot", required=True)
+    field.set_defaults(run=run_field)
+
+    robot = subparsers.add_parser("robot")
+    _add_common_node_arguments(robot)
+    robot.add_argument("--node-id", default="dummy-robot-1")
+    robot.add_argument("--field-id", default="field-1")
+    robot.add_argument("--listen", type=_parse_address, default=("127.0.0.1", 8771))
+    robot.add_argument("--phase-duration", type=float, default=0.05)
+    robot.set_defaults(run=run_robot)
+    return parser
+
+
+def _run_entry(arguments: list[str]) -> None:
+    args = _build_parser().parse_args(arguments)
+    if args.retry_interval <= 0:
+        raise SystemExit("--retry-interval must be positive")
+    try:
+        asyncio.run(args.run(args))
+    except KeyboardInterrupt:
+        pass
+
+
+def mission_main() -> None:
+    _run_entry(["mission", *sys.argv[1:]])
+
+
+def field_main() -> None:
+    _run_entry(["field", *sys.argv[1:]])
+
+
+def robot_main() -> None:
+    _run_entry(["robot", *sys.argv[1:]])
+
+
+def main() -> None:
+    _run_entry(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/deferred_teleop/operator.py
+++ b/python/src/deferred_teleop/operator.py
@@ -1,0 +1,68 @@
+"""Local control/read client for a running M1 Mission process."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+
+def _parse_address(value: str) -> tuple[str, int]:
+    host, separator, port_text = value.rpartition(":")
+    if not separator or not host:
+        raise argparse.ArgumentTypeError("address must be HOST:PORT")
+    try:
+        return host, int(port_text)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("port must be an integer") from error
+
+
+async def _request(address: tuple[str, int], request: Mapping[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.open_connection(*address)
+    writer.write((json.dumps(request, separators=(",", ":")) + "\n").encode())
+    await writer.drain()
+    response = json.loads(await reader.readline())
+    writer.close()
+    await writer.wait_closed()
+    return response
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api", type=_parse_address, default=("127.0.0.1", 8770))
+    commands = parser.add_subparsers(dest="command", required=True)
+    submit = commands.add_parser("submit-press-button")
+    submit.add_argument("--entity-id", default="dummy-button-1")
+    submit.add_argument("--executor-id", default="dummy-robot-1")
+    submit.add_argument("--expires-in-seconds", type=float, default=60.0)
+    commands.add_parser("view")
+    history = commands.add_parser("causal-history")
+    history.add_argument("--correlation-id", type=UUID, required=True)
+    args = parser.parse_args()
+
+    if args.command == "submit-press-button":
+        request: dict[str, Any] = {
+            "command": "submit_press_button",
+            "entity_id": args.entity_id,
+            "executor_id": args.executor_id,
+            "expires_in_seconds": args.expires_in_seconds,
+        }
+    elif args.command == "causal-history":
+        request = {
+            "command": "causal_history",
+            "correlation_id": str(args.correlation_id),
+        }
+    else:
+        request = {"command": "view"}
+
+    response = asyncio.run(_request(args.api, request))
+    print(json.dumps(response, indent=2, sort_keys=True))
+    if not response.get("ok"):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -1,0 +1,919 @@
+"""M1 delayed-dummy domain services shared by the executable node processes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
+
+from deferred_teleop.protocol import (
+    ApprovalPolicy,
+    ContractState,
+    EntitySelector,
+    EvidenceMetadata,
+    ExecutionContract,
+    ExecutionEvent,
+    GroundedOperation,
+    MessageEnvelope,
+    OperationIntent,
+    OperationPlan,
+    OperationState,
+    OperationType,
+    Pose,
+    PredictionManifest,
+    ProvenanceKind,
+    Quaternion,
+    RobotForecast,
+    RobotState,
+    SiteSnapshot,
+    SpatialFrame,
+    TaskAssignment,
+    TaskNode,
+    Vector3,
+    WireModel,
+)
+from deferred_teleop.storage import NodeStore
+
+TERMINAL_STATES = frozenset(
+    {
+        ContractState.SUCCEEDED,
+        ContractState.FAILED,
+        ContractState.HELD,
+        ContractState.CANCELLED,
+    }
+)
+DUMMY_PHASES = (
+    "VALIDATING",
+    "APPROACHING",
+    "CONTACTING",
+    "VERIFYING_EFFECT",
+    "RETRACTING",
+    "SUCCEEDED",
+)
+
+
+class Clock(Protocol):
+    def now(self) -> datetime: ...
+
+    async def sleep(self, seconds: float) -> None: ...
+
+
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+    async def sleep(self, seconds: float) -> None:
+        import asyncio
+
+        await asyncio.sleep(seconds)
+
+
+EventSink = Callable[[str, Mapping[str, Any]], None]
+
+
+def _ignore_event(_event: str, _fields: Mapping[str, Any]) -> None:
+    return None
+
+
+@dataclass
+class EnvelopeFactory:
+    node_id: str
+    clock: Clock
+    boot_id: UUID = field(default_factory=uuid4)
+    uuid_factory: Callable[[], UUID] = uuid4
+    _sequence: int = 0
+
+    def make(
+        self,
+        message_type: str,
+        destination_id: str,
+        correlation_id: UUID,
+        payload: WireModel,
+        *,
+        causation_id: UUID | None = None,
+        expires_at: datetime | None = None,
+        message_id: UUID | None = None,
+        created_at: datetime | None = None,
+    ) -> MessageEnvelope:
+        self._sequence += 1
+        timestamp = created_at or self.clock.now() + timedelta(microseconds=self._sequence)
+        return MessageEnvelope(
+            message_id=message_id or self.uuid_factory(),
+            message_type=message_type,
+            source_id=self.node_id,
+            source_boot_id=self.boot_id,
+            source_sequence=self._sequence,
+            destination_id=destination_id,
+            correlation_id=correlation_id,
+            causation_id=causation_id,
+            created_at=timestamp,
+            expires_at=expires_at,
+            payload=payload,
+        )
+
+
+def dummy_pose(*, pressed: bool = False) -> Pose:
+    return Pose(
+        position=Vector3(x=0.4, y=0.1, z=0.18 if pressed else 0.2),
+        orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+        frame=SpatialFrame(frame_id="field-world", calibration_version="dummy-cal-1"),
+    )
+
+
+def evidence(
+    source_id: str,
+    now: datetime,
+    provenance: ProvenanceKind,
+    *,
+    world_revision: int,
+    fresh_for_seconds: float = 30.0,
+) -> EvidenceMetadata:
+    return EvidenceMetadata(
+        source_ids=(source_id,),
+        observed_at=now,
+        produced_at=now,
+        provenance=provenance,
+        world_revision=world_revision,
+        fresh_until=now + timedelta(seconds=fresh_for_seconds),
+        model_version="dummy-constant-velocity-v1"
+        if provenance in {ProvenanceKind.PREDICTED, ProvenanceKind.SIMULATED}
+        else None,
+    )
+
+
+class RuntimeService:
+    def __init__(
+        self,
+        store: NodeStore,
+        factory: EnvelopeFactory,
+        *,
+        emit: EventSink = _ignore_event,
+    ) -> None:
+        self.store = store
+        self.factory = factory
+        self.clock = factory.clock
+        self.emit = emit
+
+    async def handle(self, envelope: MessageEnvelope) -> None:
+        claimed = self.store.claim_inbox(envelope.message_id)
+        if claimed is not None:
+            await self.process_claimed(claimed)
+            # Give one older retryable dependency failure another chance whenever
+            # fresh input arrives, without allowing a poison record to busy-loop.
+            retry = self.store.claim_next_inbox()
+            if retry is not None:
+                await self.process_claimed(retry)
+
+    async def recover(self) -> int:
+        recovered = self.store.recover_interrupted_processing()
+        claimable = sum(
+            row["processing_state"] in {"RECEIVED", "FAILED"}
+            for row in self.store.inspect_inbox()
+        )
+        # First prefer never-attempted input, then make one bounded retry pass for
+        # dependency failures whose prerequisite may have just been recovered.
+        for _ in range(claimable * 2):
+            envelope = self.store.claim_next_inbox()
+            if envelope is None:
+                break
+            await self.process_claimed(envelope)
+        return recovered
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        raise NotImplementedError
+
+
+class MissionService(RuntimeService):
+    def __init__(
+        self,
+        store: NodeStore,
+        factory: EnvelopeFactory,
+        *,
+        configured_one_way_delay: float,
+        emit: EventSink = _ignore_event,
+    ) -> None:
+        super().__init__(store, factory, emit=emit)
+        self.configured_one_way_delay = configured_one_way_delay
+
+    def submit_press_button(
+        self,
+        *,
+        entity_id: str = "dummy-button-1",
+        executor_id: str = "dummy-robot-1",
+        expires_in_seconds: float | None = 60.0,
+    ) -> MessageEnvelope:
+        operation_id = self.factory.uuid_factory()
+        now = self.clock.now()
+        intent = self.factory.make(
+            "operation.intent",
+            "field-1",
+            operation_id,
+            OperationIntent(
+                operation_id=operation_id,
+                operation_type=OperationType.PRESS_BUTTON,
+                selector=EntitySelector(entity_id=entity_id),
+                preferred_executor=executor_id,
+                approval_policy=ApprovalPolicy.AUTO_IF_WHITELISTED,
+                state=OperationState.SUBMITTED,
+            ),
+            expires_at=now + timedelta(seconds=expires_in_seconds)
+            if expires_in_seconds is not None
+            else None,
+        )
+        self.store.enqueue(intent)
+        self.emit(
+            "mission.operation_submitted",
+            {
+                "operation_id": str(operation_id),
+                "message_id": str(intent.message_id),
+                "estimated_arrival_at": (
+                    intent.created_at + timedelta(seconds=self.configured_one_way_delay)
+                ).isoformat(),
+            },
+        )
+        return intent
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"mission-view:{envelope.message_type}",
+        )
+        fields: dict[str, Any] = {
+            "message_id": str(envelope.message_id),
+            "message_type": envelope.message_type,
+            "correlation_id": str(envelope.correlation_id),
+        }
+        if isinstance(envelope.payload, ExecutionEvent):
+            fields["contract_id"] = str(envelope.payload.contract_id)
+            fields["state"] = envelope.payload.next_state.value
+        self.emit("mission.confirmed_message", fields)
+
+    def view(self) -> dict[str, Any]:
+        inbox = self.store.inbox_messages()
+        outbox = self.store.outbox_messages()
+        intents = [message for message in outbox if isinstance(message.payload, OperationIntent)]
+        snapshots = [message for message in inbox if isinstance(message.payload, SiteSnapshot)]
+        forecasts = [message for message in inbox if isinstance(message.payload, RobotForecast)]
+        events = [message for message in inbox if isinstance(message.payload, ExecutionEvent)]
+        terminal = next(
+            (
+                message
+                for message in reversed(events)
+                if message.payload.next_state in TERMINAL_STATES
+            ),
+            None,
+        )
+        intent = intents[-1] if intents else None
+        forecast = forecasts[-1] if forecasts else None
+        estimated_arrival_at = (
+            intent.created_at + timedelta(seconds=self.configured_one_way_delay)
+            if intent
+            else None
+        )
+        manifest: PredictionManifest | None = None
+        if forecast is not None:
+            manifest = PredictionManifest(
+                manifest_id=uuid5(NAMESPACE_URL, f"dtt-manifest:{forecast.message_id}"),
+                site_id="dummy-site-1",
+                forecast_ids=(forecast.message_id,),
+                generated_for_world_revision=forecast.payload.evidence.world_revision,
+                evidence=forecast.payload.evidence,
+            )
+        return {
+            "node_id": self.factory.node_id,
+            "operation_id": str(intent.payload.operation_id) if intent else None,
+            "correlation_id": str(intent.correlation_id) if intent else None,
+            "estimated_arrival_at": estimated_arrival_at.isoformat()
+            if estimated_arrival_at
+            else None,
+            "confirmed_state": snapshots[-1].payload.model_dump(mode="json")
+            if snapshots
+            else None,
+            "arrival_belief": {
+                **forecast.payload.model_dump(mode="json"),
+                "estimated_intent_arrival_at": estimated_arrival_at.isoformat()
+                if estimated_arrival_at
+                else None,
+                "link_one_way_delay_seconds": self.configured_one_way_delay,
+            }
+            if forecast
+            else None,
+            "prediction_manifest": manifest.model_dump(mode="json") if manifest else None,
+            "target_branch": {
+                "condition": "button effect succeeds",
+                "entity_id": intent.payload.selector.entity_id,
+                "requested_state": "PRESSED",
+                "provenance": ProvenanceKind.OPERATOR_ASSERTED.value,
+            }
+            if intent
+            else None,
+            "terminal_state": terminal.payload.next_state.value if terminal else None,
+            "terminal_contract_id": str(terminal.payload.contract_id) if terminal else None,
+            "received_message_count": len(inbox),
+        }
+
+
+class FieldService(RuntimeService):
+    def __init__(
+        self,
+        store: NodeStore,
+        factory: EnvelopeFactory,
+        *,
+        mission_id: str = "mission-1",
+        robot_id: str = "dummy-robot-1",
+        emit: EventSink = _ignore_event,
+    ) -> None:
+        super().__init__(store, factory, emit=emit)
+        self.mission_id = mission_id
+        self.robot_id = robot_id
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        if isinstance(envelope.payload, OperationIntent):
+            self._process_intent(envelope)
+            return
+        if isinstance(envelope.payload, (ExecutionEvent, RobotState, RobotForecast)):
+            self._process_robot_message(envelope)
+            return
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"field-ignored:{envelope.message_type}",
+        )
+
+    def _process_intent(self, envelope: MessageEnvelope) -> None:
+        intent = envelope.payload
+        assert isinstance(intent, OperationIntent)
+        prior_contract = next(
+            (
+                message
+                for message in self.store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+                and message.payload.operation_id == intent.operation_id
+            ),
+            None,
+        )
+        if prior_contract is not None:
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"duplicate-operation:{prior_contract.payload.contract_id}",
+            )
+            self.emit(
+                "field.operation_duplicate",
+                {
+                    "operation_id": str(intent.operation_id),
+                    "contract_id": str(prior_contract.payload.contract_id),
+                },
+            )
+            return
+
+        now = self.clock.now()
+        operation_id = intent.operation_id
+        initial_snapshot = self.factory.make(
+            "site.snapshot",
+            self.mission_id,
+            envelope.correlation_id,
+            SiteSnapshot(
+                site_id="dummy-site-1",
+                entities=("dummy-button-1",),
+                robot_states=(),
+                evidence=evidence(
+                    "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=1
+                ),
+            ),
+            causation_id=envelope.message_id,
+        )
+        grounded = self.factory.make(
+            "operation.grounded",
+            self.mission_id,
+            envelope.correlation_id,
+            GroundedOperation(
+                operation_id=operation_id,
+                target_entity_id=intent.selector.entity_id,
+                target_pose=dummy_pose(),
+                state=OperationState.ADMITTED,
+                evidence=evidence(
+                    "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=1
+                ),
+            ),
+            causation_id=envelope.message_id,
+        )
+        task_id = self.factory.uuid_factory()
+        plan = self.factory.make(
+            "operation.plan",
+            self.mission_id,
+            envelope.correlation_id,
+            OperationPlan(
+                plan_id=self.factory.uuid_factory(),
+                operation_id=operation_id,
+                tasks=(
+                    TaskNode(
+                        task_id=task_id,
+                        skill=OperationType.PRESS_BUTTON,
+                        target_entity_id=intent.selector.entity_id,
+                    ),
+                ),
+            ),
+            causation_id=grounded.message_id,
+        )
+        assignment = self.factory.make(
+            "task.assignment",
+            self.robot_id,
+            envelope.correlation_id,
+            TaskAssignment(
+                assignment_id=self.factory.uuid_factory(),
+                plan_id=plan.payload.plan_id,
+                task_id=task_id,
+                executor_id=self.robot_id,
+            ),
+            causation_id=plan.message_id,
+        )
+        contract = self.factory.make(
+            "execution.contract",
+            self.robot_id,
+            envelope.correlation_id,
+            ExecutionContract(
+                contract_id=self.factory.uuid_factory(),
+                contract_revision=1,
+                operation_id=operation_id,
+                assignment_id=assignment.payload.assignment_id,
+                state=ContractState.RECEIVED,
+            ),
+            causation_id=assignment.message_id,
+        )
+
+        hold_reason: str | None = None
+        if envelope.expires_at is not None and now >= envelope.expires_at:
+            hold_reason = "expired"
+        elif intent.selector.entity_id != "dummy-button-1":
+            hold_reason = "selector-not-whitelisted"
+        elif intent.preferred_executor != self.robot_id:
+            hold_reason = "executor-unavailable"
+        elif intent.operation_type is not OperationType.PRESS_BUTTON:
+            hold_reason = "capability-unavailable"
+        elif intent.approval_policy is not ApprovalPolicy.AUTO_IF_WHITELISTED:
+            hold_reason = "approval-policy-denied"
+        elif contract.payload.contract_revision != 1:
+            hold_reason = "unsupported-contract-revision"
+
+        if hold_reason is not None:
+            held_contract = contract.model_copy(
+                update={
+                    "destination_id": self.mission_id,
+                    "causation_id": envelope.message_id,
+                }
+            )
+            held_event = self.factory.make(
+                "execution.event",
+                self.mission_id,
+                envelope.correlation_id,
+                ExecutionEvent(
+                    event_id=self.factory.uuid_factory(),
+                    contract_id=contract.payload.contract_id,
+                    contract_revision=1,
+                    previous_state=ContractState.RECEIVED,
+                    next_state=ContractState.HELD,
+                    occurred_at=now,
+                ),
+                causation_id=held_contract.message_id,
+            )
+            outgoing = (held_contract, held_event)
+            result = f"held-{hold_reason}:{contract.payload.contract_id}"
+            event_name = "field.operation_held"
+        else:
+            outgoing = (initial_snapshot, grounded, plan, assignment, contract)
+            result = f"admitted:{contract.payload.contract_id}"
+            event_name = "field.operation_admitted"
+
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=now,
+            handler_result_reference=result,
+            outgoing=outgoing,
+        )
+        self.emit(
+            event_name,
+            {
+                "operation_id": str(operation_id),
+                "contract_id": str(contract.payload.contract_id),
+                "hold_reason": hold_reason,
+            },
+        )
+
+    def _process_robot_message(self, envelope: MessageEnvelope) -> None:
+        now = self.clock.now()
+        forwarded = self.factory.make(
+            envelope.message_type,
+            self.mission_id,
+            envelope.correlation_id,
+            envelope.payload,
+            causation_id=envelope.message_id,
+        )
+        outgoing: list[MessageEnvelope] = [forwarded]
+        if (
+            isinstance(envelope.payload, ExecutionEvent)
+            and envelope.payload.next_state in TERMINAL_STATES
+        ):
+            robot_state = next(
+                (
+                    message.payload
+                    for message in reversed(self.store.inbox_messages())
+                    if isinstance(message.payload, RobotState)
+                ),
+                RobotState(
+                    robot_id=self.robot_id,
+                    pose=dummy_pose(pressed=True),
+                    evidence=evidence(
+                        "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
+                    ),
+                ),
+            )
+            snapshot = self.factory.make(
+                "site.snapshot",
+                self.mission_id,
+                envelope.correlation_id,
+                SiteSnapshot(
+                    site_id="dummy-site-1",
+                    entities=("dummy-button-1",),
+                    robot_states=(robot_state,),
+                    evidence=evidence(
+                        "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
+                    ),
+                ),
+                causation_id=envelope.message_id,
+            )
+            outgoing.append(snapshot)
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=now,
+            handler_result_reference=f"forwarded:{forwarded.message_id}",
+            outgoing=outgoing,
+        )
+        fields: dict[str, Any] = {
+            "message_id": str(envelope.message_id),
+            "message_type": envelope.message_type,
+        }
+        if isinstance(envelope.payload, ExecutionEvent):
+            fields["state"] = envelope.payload.next_state.value
+        self.emit("field.robot_message", fields)
+
+
+class DummyRobotService(RuntimeService):
+    def __init__(
+        self,
+        store: NodeStore,
+        factory: EnvelopeFactory,
+        *,
+        field_id: str = "field-1",
+        phase_duration: float = 0.05,
+        emit: EventSink = _ignore_event,
+    ) -> None:
+        super().__init__(store, factory, emit=emit)
+        self.field_id = field_id
+        self.phase_duration = phase_duration
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return (OperationType.PRESS_BUTTON.value,)
+
+    @property
+    def effect_counter(self) -> int:
+        return sum(int(row["effect_count"]) for row in self.store.inspect_execution_journal())
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        if isinstance(envelope.payload, TaskAssignment):
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"assignment:{envelope.payload.assignment_id}",
+            )
+            self.emit(
+                "robot.assignment_received",
+                {"assignment_id": str(envelope.payload.assignment_id)},
+            )
+            return
+        if isinstance(envelope.payload, ExecutionContract):
+            await self._process_contract(envelope)
+            return
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"robot-ignored:{envelope.message_type}",
+        )
+
+    async def _process_contract(self, envelope: MessageEnvelope) -> None:
+        contract = envelope.payload
+        assert isinstance(contract, ExecutionContract)
+        assignment = next(
+            (
+                message.payload
+                for message in self.store.inbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+                and message.payload.assignment_id == contract.assignment_id
+            ),
+            None,
+        )
+        if assignment is None:
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": "assignment-not-yet-persisted", "retryable": True},
+            )
+            self.emit(
+                "robot.contract_held",
+                {"contract_id": str(contract.contract_id), "reason": "missing-assignment"},
+            )
+            return
+
+        hold_reason: str | None = None
+        if assignment.executor_id != self.factory.node_id:
+            hold_reason = "assignment-addressed-to-different-executor"
+        elif contract.contract_revision != 1:
+            hold_reason = "unsupported-contract-revision"
+        if hold_reason is not None:
+            held_event = self._transition(
+                envelope,
+                ContractState.RECEIVED,
+                ContractState.HELD,
+                ordinal=1,
+            )
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"held:{hold_reason}:{contract.contract_id}",
+                outgoing=(held_event,),
+            )
+            self.emit(
+                "robot.contract_held",
+                {"contract_id": str(contract.contract_id), "reason": hold_reason},
+            )
+            return
+
+        effect_key = f"press:{contract.operation_id}:{contract.contract_revision}"
+        accepted_now = self.store.accept_contract(
+            contract_id=contract.contract_id,
+            contract_revision=contract.contract_revision,
+            operation_id=contract.operation_id,
+            task_id=assignment.task_id,
+            effect_key=effect_key,
+            accepted_at=self.clock.now(),
+        )
+        journal = self._journal(contract)
+        if journal["state"] in {state.value for state in TERMINAL_STATES}:
+            self._enqueue_terminal_replay(envelope, journal)
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"terminal-replay:{contract.contract_id}",
+            )
+            return
+
+        if accepted_now:
+            self._enqueue_transition(
+                envelope,
+                ContractState.RECEIVED,
+                ContractState.ACCEPTED,
+                ordinal=1,
+            )
+        if journal["state"] == ContractState.ACCEPTED.value:
+            self.store.record_dispatch(
+                contract.contract_id,
+                contract.contract_revision,
+                recorded_at=self.clock.now(),
+            )
+            self._enqueue_transition(
+                envelope,
+                ContractState.ACCEPTED,
+                ContractState.DISPATCH_RECORDED,
+                ordinal=2,
+            )
+            invocation_id = uuid5(
+                NAMESPACE_URL,
+                f"dtt-skill:{contract.contract_id}:{contract.contract_revision}",
+            )
+            invocation = {
+                "invocation_id": str(invocation_id),
+                "skill": OperationType.PRESS_BUTTON.value,
+                "target_entity_id": "dummy-button-1",
+            }
+            self.store.append_execution_audit(
+                contract.contract_id,
+                contract.contract_revision,
+                event_type="skill-invocation",
+                metadata=invocation,
+                recorded_at=self.clock.now(),
+            )
+            self.emit(
+                "robot.skill_invoked",
+                {"contract_id": str(contract.contract_id), **invocation},
+            )
+
+        self._enqueue_transition(
+            envelope,
+            ContractState.DISPATCH_RECORDED,
+            ContractState.RUNNING,
+            ordinal=3,
+        )
+        self._enqueue_telemetry(envelope)
+        for phase in DUMMY_PHASES[:-1]:
+            now = self.clock.now()
+            self.store.append_execution_audit(
+                contract.contract_id,
+                contract.contract_revision,
+                event_type="dummy-skill-phase",
+                metadata={
+                    "phase": phase,
+                    "safe_to_interrupt": phase not in {"CONTACTING", "VERIFYING_EFFECT"},
+                },
+                recorded_at=now,
+            )
+            self.emit(
+                "robot.phase",
+                {
+                    "contract_id": str(contract.contract_id),
+                    "phase": phase,
+                    "safe_to_interrupt": phase not in {"CONTACTING", "VERIFYING_EFFECT"},
+                },
+            )
+            await self.clock.sleep(self.phase_duration)
+
+        terminal_event = self._transition(
+            envelope,
+            ContractState.RUNNING,
+            ContractState.SUCCEEDED,
+            ordinal=4,
+        )
+        committed = self.store.commit_dummy_effect(
+            contract.contract_id,
+            contract.contract_revision,
+            terminal_state=ContractState.SUCCEEDED,
+            terminal_result={
+                "effect_key": effect_key,
+                "button": "dummy-button-1",
+                "button_state": "PRESSED",
+                "effect_counter": self.effect_counter + 1,
+            },
+            occurred_at=self.clock.now(),
+            terminal_event=terminal_event,
+        )
+        self.store.append_execution_audit(
+            contract.contract_id,
+            contract.contract_revision,
+            event_type="dummy-skill-phase",
+            metadata={"phase": "SUCCEEDED", "safe_to_interrupt": True},
+            recorded_at=self.clock.now(),
+        )
+        self.emit(
+            "robot.phase",
+            {
+                "contract_id": str(contract.contract_id),
+                "phase": "SUCCEEDED",
+                "safe_to_interrupt": True,
+            },
+        )
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"terminal:{contract.contract_id}",
+        )
+        self.emit(
+            "robot.effect_committed",
+            {
+                "contract_id": str(contract.contract_id),
+                "effect_counter": self.effect_counter,
+                "committed": committed,
+            },
+        )
+
+    def _journal(self, contract: ExecutionContract) -> dict[str, Any]:
+        return next(
+            row
+            for row in self.store.inspect_execution_journal()
+            if row["contract_id"] == str(contract.contract_id)
+            and row["contract_revision"] == contract.contract_revision
+        )
+
+    def _transition(
+        self,
+        cause: MessageEnvelope,
+        previous: ContractState,
+        next_state: ContractState,
+        *,
+        ordinal: int,
+    ) -> MessageEnvelope:
+        contract = cause.payload
+        assert isinstance(contract, ExecutionContract)
+        stable = f"{contract.contract_id}:{contract.contract_revision}:{next_state.value}"
+        event_id = uuid5(NAMESPACE_URL, f"dtt-event:{stable}")
+        message_id = uuid5(NAMESPACE_URL, f"dtt-envelope:{stable}")
+        occurred_at = cause.created_at + timedelta(milliseconds=ordinal)
+        return self.factory.make(
+            "execution.event",
+            self.field_id,
+            cause.correlation_id,
+            ExecutionEvent(
+                event_id=event_id,
+                contract_id=contract.contract_id,
+                contract_revision=contract.contract_revision,
+                previous_state=previous,
+                next_state=next_state,
+                occurred_at=occurred_at,
+            ),
+            causation_id=cause.message_id,
+            message_id=message_id,
+            created_at=occurred_at,
+        )
+
+    def _enqueue_transition(
+        self,
+        cause: MessageEnvelope,
+        previous: ContractState,
+        next_state: ContractState,
+        *,
+        ordinal: int,
+    ) -> None:
+        self._enqueue_if_absent(
+            self._transition(cause, previous, next_state, ordinal=ordinal)
+        )
+
+    def _enqueue_if_absent(self, envelope: MessageEnvelope) -> bool:
+        if any(
+            existing.message_id == envelope.message_id
+            for existing in self.store.outbox_messages()
+        ):
+            return False
+        return self.store.enqueue(envelope)
+
+    def _enqueue_telemetry(self, cause: MessageEnvelope) -> None:
+        now = self.clock.now()
+        state = self.factory.make(
+            "robot.state",
+            self.field_id,
+            cause.correlation_id,
+            RobotState(
+                robot_id=self.factory.node_id,
+                pose=dummy_pose(),
+                evidence=evidence(
+                    self.factory.node_id,
+                    now,
+                    ProvenanceKind.MEASURED,
+                    world_revision=1,
+                ),
+            ),
+            message_id=uuid5(NAMESPACE_URL, f"dtt-state:{cause.payload.contract_id}"),
+            created_at=cause.created_at + timedelta(milliseconds=5),
+        )
+        forecast_time = now + timedelta(seconds=max(1.0, self.phase_duration * len(DUMMY_PHASES)))
+        forecast = self.factory.make(
+            "robot.forecast",
+            self.field_id,
+            cause.correlation_id,
+            RobotForecast(
+                robot_id=self.factory.node_id,
+                predicted_pose=dummy_pose(pressed=True),
+                predicted_for=forecast_time,
+                evidence=evidence(
+                    self.factory.node_id,
+                    now,
+                    ProvenanceKind.PREDICTED,
+                    world_revision=1,
+                ),
+            ),
+            causation_id=cause.message_id,
+            message_id=uuid5(NAMESPACE_URL, f"dtt-forecast:{cause.payload.contract_id}"),
+            created_at=cause.created_at + timedelta(milliseconds=6),
+        )
+        self._enqueue_if_absent(state)
+        self._enqueue_if_absent(forecast)
+
+    def _enqueue_terminal_replay(
+        self, cause: MessageEnvelope, journal: Mapping[str, Any]
+    ) -> None:
+        contract = cause.payload
+        assert isinstance(contract, ExecutionContract)
+        terminal = ContractState(str(journal["state"]))
+        replay_id = uuid5(NAMESPACE_URL, f"dtt-replay:{cause.message_id}:{terminal.value}")
+        replay = self.factory.make(
+            "execution.event",
+            self.field_id,
+            cause.correlation_id,
+            ExecutionEvent(
+                event_id=replay_id,
+                contract_id=contract.contract_id,
+                contract_revision=contract.contract_revision,
+                previous_state=ContractState.RUNNING,
+                next_state=terminal,
+                occurred_at=datetime.fromisoformat(
+                    str(journal["terminal_at"]).replace("Z", "+00:00")
+                ),
+            ),
+            causation_id=cause.message_id,
+            message_id=uuid5(NAMESPACE_URL, f"dtt-replay-envelope:{replay_id}"),
+        )
+        self.store.enqueue(replay)
+        self.emit(
+            "robot.terminal_replayed",
+            {"contract_id": str(contract.contract_id), "state": terminal.value},
+        )

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -310,7 +310,8 @@ class NodeStore:
                 """
                 SELECT message_id, payload_json FROM inbox
                 WHERE processing_state IN ('RECEIVED', 'FAILED')
-                ORDER BY received_at, message_id LIMIT 1
+                ORDER BY CASE processing_state WHEN 'RECEIVED' THEN 0 ELSE 1 END,
+                         received_at, message_id LIMIT 1
                 """
             ).fetchone()
             if row is None:
@@ -322,6 +323,29 @@ class NodeStore:
                 WHERE message_id = ?
                 """,
                 (row["message_id"],),
+            )
+            return envelope
+
+    def claim_inbox(self, message_id: UUID) -> MessageEnvelope | None:
+        """Claim one known inbox message, or return None if it is no longer claimable."""
+
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT payload_json FROM inbox
+                WHERE message_id = ? AND processing_state IN ('RECEIVED', 'FAILED')
+                """,
+                (str(message_id),),
+            ).fetchone()
+            if row is None:
+                return None
+            envelope = self._decode_envelope("inbox", str(message_id), row["payload_json"])
+            connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'PROCESSING', error_json = NULL
+                WHERE message_id = ?
+                """,
+                (str(message_id),),
             )
             return envelope
 
@@ -598,6 +622,28 @@ class NodeStore:
         return self._rows(
             "SELECT * FROM execution_journal ORDER BY contract_id, contract_revision"
         )
+
+    def inbox_messages(self) -> list[MessageEnvelope]:
+        """Return validated inbox envelopes for recovery and read-model reconstruction."""
+
+        rows = self._connection.execute(
+            "SELECT message_id, payload_json FROM inbox ORDER BY received_at, message_id"
+        ).fetchall()
+        return [
+            self._decode_envelope("inbox", row["message_id"], row["payload_json"])
+            for row in rows
+        ]
+
+    def outbox_messages(self) -> list[MessageEnvelope]:
+        """Return validated outbox envelopes, including acknowledged records."""
+
+        rows = self._connection.execute(
+            "SELECT message_id, payload_json FROM outbox ORDER BY created_at, message_id"
+        ).fetchall()
+        return [
+            self._decode_envelope("outbox", row["message_id"], row["payload_json"])
+            for row in rows
+        ]
 
     def causal_history(self, correlation_id: UUID) -> list[dict[str, Any]]:
         rows = self._connection.execute(

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from deferred_teleop.inspect import _causal_history
+
+
+@pytest.mark.parametrize(
+    ("profile", "restart_mission"),
+    (
+        ("short-visible-delay", False),
+        ("short-visible-fault", True),
+    ),
+)
+def test_delayed_dummy_runs_as_four_processes_and_reconciles(
+    tmp_path: Path,
+    profile: str,
+    restart_mission: bool,
+) -> None:
+    data_dir = tmp_path / profile
+    command = [
+        sys.executable,
+        "-m",
+        "deferred_teleop.demo",
+        "delayed-dummy",
+        "--profile",
+        profile,
+        "--data-dir",
+        str(data_dir),
+        "--phase-duration",
+        "0.01",
+        "--retry-interval",
+        "0.01",
+        "--timeout",
+        "10",
+        "--quiet",
+    ]
+    if restart_mission:
+        command.append("--restart-mission-after-admission")
+
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    events = [json.loads(line) for line in completed.stdout.splitlines()]
+    ready = next(item for item in events if item["event"] == "demo.processes_ready")
+    result = next(item for item in events if item["event"] == "demo.completed")
+    assert len(set(ready["pids"].values())) == 4
+    assert len(set(ready["stores"].values())) == 3
+    assert all((data_dir / f"{node}.db").is_file() for node in ("mission", "field", "robot"))
+    assert result["terminal_state"] == "SUCCEEDED"
+    assert result["effect_counter"] == 1
+    assert result["phases"] == [
+        "VALIDATING",
+        "APPROACHING",
+        "CONTACTING",
+        "VERIFYING_EFFECT",
+        "RETRACTING",
+        "SUCCEEDED",
+    ]
+    assert result["confirmed_provenance"] == "MEASURED"
+    assert result["arrival_provenance"] == "PREDICTED"
+    assert result["target_provenance"] == "OPERATOR_ASSERTED"
+    assert result["mission_restarted"] is restart_mission
+
+    history = _causal_history(data_dir, UUID(result["operation_id"]))
+    message_types = {item["payload_type"] for item in history}
+    assert {
+        "operation.intent",
+        "operation.grounded",
+        "operation.plan",
+        "task.assignment",
+        "execution.contract",
+        "execution.event",
+        "robot.state",
+        "robot.forecast",
+        "site.snapshot",
+    } <= message_types

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,434 @@
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+from deferred_teleop.protocol import (
+    ContractState,
+    EntitySelector,
+    ExecutionContract,
+    ExecutionEvent,
+    ProvenanceKind,
+    TaskAssignment,
+)
+from deferred_teleop.runtime import (
+    DUMMY_PHASES,
+    DummyRobotService,
+    EnvelopeFactory,
+    FieldService,
+    MissionService,
+)
+from deferred_teleop.storage import NodeStore
+
+
+@dataclass
+class VirtualClock:
+    current: datetime = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+    sleeps: list[float] = field(default_factory=list)
+
+    def now(self) -> datetime:
+        return self.current
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.current += timedelta(seconds=seconds)
+
+
+class CrashOnSleepClock(VirtualClock):
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        raise RuntimeError("injected process crash")
+
+
+async def _deliver(service, envelope) -> bool:
+    is_new = service.store.receive(envelope, received_at=service.clock.now())
+    if is_new:
+        await service.handle(envelope)
+    return is_new
+
+
+def test_complete_domain_slice_survives_mission_disconnect_and_reconstructs(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        events: list[tuple[str, dict]] = []
+
+        def record(event: str, fields) -> None:
+            events.append((event, dict(fields)))
+
+        mission_path = tmp_path / "mission.sqlite3"
+        with (
+            NodeStore(mission_path) as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+            NodeStore(tmp_path / "robot.sqlite3") as robot_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=15.0,
+                emit=record,
+            )
+            field_service = FieldService(
+                field_store,
+                EnvelopeFactory("field-1", clock),
+                emit=record,
+            )
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=2.0,
+                emit=record,
+            )
+
+            intent = mission.submit_press_button()
+            assert await _deliver(field_service, intent)
+            field_to_robot = [
+                message
+                for message in field_store.pending_outbox(now=clock.now() + timedelta(seconds=1))
+                if message.destination_id == "dummy-robot-1"
+            ]
+            assert [type(message.payload) for message in field_to_robot] == [
+                TaskAssignment,
+                ExecutionContract,
+            ]
+            for message in field_to_robot:
+                assert await _deliver(robot, message)
+
+            # Mission is deliberately not running while Field and Robot complete the effect.
+            for message in robot_store.pending_outbox(now=clock.now() + timedelta(seconds=1)):
+                assert await _deliver(field_service, message)
+            assert robot.effect_counter == 1
+            assert clock.sleeps == [2.0] * (len(DUMMY_PHASES) - 1)
+
+            pending_for_mission = [
+                message
+                for message in field_store.pending_outbox(now=clock.now() + timedelta(seconds=1))
+                if message.destination_id == "mission-1"
+            ]
+            assert pending_for_mission
+
+        with NodeStore(mission_path) as restarted_store:
+            restarted = MissionService(
+                restarted_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=15.0,
+                emit=record,
+            )
+            with NodeStore(tmp_path / "field.sqlite3") as field_store:
+                for message in field_store.pending_outbox(
+                    now=clock.now() + timedelta(seconds=1)
+                ):
+                    if message.destination_id == "mission-1":
+                        await _deliver(restarted, message)
+
+            view = restarted.view()
+            assert view["operation_id"] == str(intent.payload.operation_id)
+            assert view["terminal_state"] == ContractState.SUCCEEDED.value
+            assert view["confirmed_state"]["evidence"]["provenance"] == "MEASURED"
+            assert view["arrival_belief"]["evidence"]["provenance"] == "PREDICTED"
+            assert view["arrival_belief"]["link_one_way_delay_seconds"] == 15.0
+            assert view["arrival_belief"]["estimated_intent_arrival_at"] == view[
+                "estimated_arrival_at"
+            ]
+            assert view["prediction_manifest"]["evidence"]["provenance"] == "PREDICTED"
+            assert view["target_branch"]["provenance"] == ProvenanceKind.OPERATOR_ASSERTED
+            assert any(event == "field.operation_admitted" for event, _ in events)
+            assert any(event == "robot.skill_invoked" for event, _ in events)
+            assert any(event == "robot.effect_committed" for event, _ in events)
+
+    asyncio.run(scenario())
+
+
+def test_semantic_duplicate_intent_and_contract_do_not_duplicate_effect(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+            NodeStore(tmp_path / "robot.sqlite3") as robot_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            field_service = FieldService(
+                field_store,
+                EnvelopeFactory("field-1", clock),
+            )
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=0.0,
+            )
+            intent = mission.submit_press_button()
+            await _deliver(field_service, intent)
+            duplicate_intent = intent.model_copy(
+                update={"message_id": uuid4(), "source_sequence": intent.source_sequence + 1}
+            )
+            await _deliver(field_service, duplicate_intent)
+            contracts = [
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            ]
+            assert len(contracts) == 1
+
+            assignment = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+            )
+            await _deliver(robot, assignment)
+            await _deliver(robot, contracts[0])
+            duplicate_contract = contracts[0].model_copy(
+                update={"message_id": uuid4(), "source_sequence": contracts[0].source_sequence + 1}
+            )
+            await _deliver(robot, duplicate_contract)
+
+            assert robot.effect_counter == 1
+            terminal_events = [
+                message
+                for message in robot_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+                and message.payload.next_state is ContractState.SUCCEEDED
+            ]
+            assert len(terminal_events) == 2
+
+    asyncio.run(scenario())
+
+
+def test_expired_operation_is_explicitly_held_and_never_dispatched(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=10.0,
+            )
+            field_service = FieldService(
+                field_store,
+                EnvelopeFactory("field-1", clock),
+            )
+            intent = mission.submit_press_button(expires_in_seconds=1.0)
+            clock.current += timedelta(seconds=2)
+            await _deliver(field_service, intent)
+
+            outgoing = field_store.outbox_messages()
+            held = next(
+                message.payload
+                for message in outgoing
+                if isinstance(message.payload, ExecutionEvent)
+            )
+            assert held.previous_state is ContractState.RECEIVED
+            assert held.next_state is ContractState.HELD
+            assert not any(message.destination_id == "dummy-robot-1" for message in outgoing)
+
+    asyncio.run(scenario())
+
+
+def test_non_whitelisted_target_is_held_before_grounding(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        events: list[tuple[str, dict]] = []
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            field_service = FieldService(
+                field_store,
+                EnvelopeFactory("field-1", clock),
+                emit=lambda event, fields: events.append((event, dict(fields))),
+            )
+            original = mission.submit_press_button()
+            unknown = original.model_copy(
+                update={
+                    "payload": original.payload.model_copy(
+                        update={"selector": EntitySelector(entity_id="unknown-button")}
+                    )
+                }
+            )
+            await _deliver(field_service, unknown)
+
+            outgoing = field_store.outbox_messages()
+            assert not any(message.message_type == "operation.grounded" for message in outgoing)
+            assert not any(message.destination_id == "dummy-robot-1" for message in outgoing)
+            assert any(
+                event == "field.operation_held"
+                and fields["hold_reason"] == "selector-not-whitelisted"
+                for event, fields in events
+            )
+
+    asyncio.run(scenario())
+
+
+def test_robot_retries_contract_when_assignment_arrives_after_it(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+            NodeStore(tmp_path / "robot.sqlite3") as robot_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            field_service = FieldService(field_store, EnvelopeFactory("field-1", clock))
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=0.0,
+            )
+            await _deliver(field_service, mission.submit_press_button())
+            assignment = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+            )
+            contract = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+
+            await _deliver(robot, contract)
+            assert robot.effect_counter == 0
+            await _deliver(robot, assignment)
+            assert robot.effect_counter == 1
+            assert all(
+                row["processing_state"] == "PROCESSED"
+                for row in robot_store.inspect_inbox()
+            )
+
+    asyncio.run(scenario())
+
+
+def test_robot_holds_unsupported_contract_revision(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+            NodeStore(tmp_path / "robot.sqlite3") as robot_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            field_service = FieldService(field_store, EnvelopeFactory("field-1", clock))
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=0.0,
+            )
+            await _deliver(field_service, mission.submit_press_button())
+            assignment = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+            )
+            contract = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            revision_two = contract.model_copy(
+                update={
+                    "message_id": uuid4(),
+                    "source_sequence": contract.source_sequence + 1,
+                    "payload": contract.payload.model_copy(update={"contract_revision": 2}),
+                }
+            )
+
+            await _deliver(robot, assignment)
+            await _deliver(robot, revision_two)
+            assert robot.effect_counter == 0
+            held = next(
+                message.payload
+                for message in robot_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+            )
+            assert held.previous_state is ContractState.RECEIVED
+            assert held.next_state is ContractState.HELD
+
+    asyncio.run(scenario())
+
+
+def test_robot_recovers_after_crash_during_skill_without_duplicate_effect(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = CrashOnSleepClock()
+        robot_path = tmp_path / "robot.sqlite3"
+        with (
+            NodeStore(tmp_path / "mission.sqlite3") as mission_store,
+            NodeStore(tmp_path / "field.sqlite3") as field_store,
+        ):
+            mission = MissionService(
+                mission_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            field_service = FieldService(field_store, EnvelopeFactory("field-1", clock))
+            await _deliver(field_service, mission.submit_press_button())
+            assignment = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+            )
+            contract = next(
+                message
+                for message in field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+
+        with NodeStore(robot_path) as robot_store:
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=1.0,
+            )
+            await _deliver(robot, assignment)
+            try:
+                await _deliver(robot, contract)
+            except RuntimeError as error:
+                assert str(error) == "injected process crash"
+            else:
+                raise AssertionError("the injected crash was not reached")
+            contract_row = next(
+                row
+                for row in robot_store.inspect_inbox()
+                if row["payload_type"] == "execution.contract"
+            )
+            assert contract_row["processing_state"] == "PROCESSING"
+            assert robot.effect_counter == 0
+
+        recovered_clock = VirtualClock(current=clock.current)
+        with NodeStore(robot_path) as recovered_store:
+            recovered_robot = DummyRobotService(
+                recovered_store,
+                EnvelopeFactory("dummy-robot-1", recovered_clock),
+                phase_duration=0.0,
+            )
+            assert await recovered_robot.recover() == 1
+            assert recovered_robot.effect_counter == 1
+            assert all(
+                row["processing_state"] == "PROCESSED"
+                for row in recovered_store.inspect_inbox()
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Closes #8
Parent milestone: #4

## Problem

M1 had protocol models, durable endpoint storage and a deterministic delayed link, but no runnable Mission → Field → dummy Robot slice proving autonomous completion and delayed reconciliation.

## Approach

- add separate Mission, Field and dummy-Robot processes with independent SQLite stores;
- ground the known button, build a one-node plan/assignment/contract, validate admission, and dispatch locally;
- execute an audited six-phase dummy skill with an effect-once journal key and durable terminal replay;
- keep Confirmed State, Arrival Belief and Target Branch separate with MEASURED, PREDICTED and OPERATOR_ASSERTED provenance;
- add operator, one-command demo and read-only causal-history CLIs;
- add nominal and seeded fault profiles, including Mission stop/restart after Field admission;
- document the authority/recovery decision and the manual four-terminal proof.

## Authority and safety impact

- Robot authority impact: the dummy Robot owns local skill phases, interruption metadata and the database-backed dummy effect.
- Field authority impact: Field owns binding, admission, the operational snapshot, assignment and the active contract; admitted work does not depend on Mission connectivity.
- Mission authority impact: Mission owns operator intent and delayed/projection read models only.
- Hardware path enabled or changed: no.

## Protocol or public API impact

The wire version remains experimental `dtt/0`; no schema changes are introduced. New development commands are `dtt-mission`, `dtt-field`, `dtt-robot-dummy`, `dtt-operator`, `dtt-demo`, and `dtt-inspect`. The existing store gains exact inbox claiming plus validated inbox/outbox readers; no database migration is required.

## Validation

- [x] Linked issue
- [x] Tests added or updated
- [x] `pytest` passes: 43 tests on local Python 3.12
- [x] `ruff check .` passes
- [x] Generated schemas remain current
- [x] Nominal four-process dummy path completes with one effect
- [x] Fault profile completes after Mission is stopped post-admission and restarted
- [x] Duplicate intent/contract, expiry, unsupported revision, dependency reorder and mid-skill crash are covered
- [x] Hardware remains disabled by default
- [x] Safety and trust assumptions reviewed in ADR 0005
- [x] Unreal build: not applicable; no Unreal files changed
- [x] Documentation/status matrix updated
- [x] Third-party provenance and licences reviewed; no dependency added

## Known limitations

This is a local development slice with a database-backed dummy effect. It does not claim exactly-once behavior for future physical actions. Target ambiguity, reassignment, multi-robot coordination, real geometry, learned planning/scanning, physical cancellation, Unreal integration and hardware remain out of scope.