### PR TITLE
fix(mission): scope selected-operation views to compatible evidence

### DIFF
--- a/docs/m1/MISSION_OPERATION_SELECTION.md
+++ b/docs/m1/MISSION_OPERATION_SELECTION.md
@@ -1,0 +1,34 @@
+# M1 Mission operation selection
+
+The Mission view represents one selected operation. The legacy `view()` response and the
+strict `mission.view_state` response use the same deterministic selector so that a caller
+cannot see an intent from one operation together with observations from another one.
+
+The selected intent is the `operation.intent` envelope in the Mission outbox with the greatest
+`created_at`; a tied timestamp is resolved by the greatest `message_id`. This ordering comes
+from envelope data and does not depend on receipt order. Every `operation_id` must map to one
+`correlation_id`, and every correlation used by an intent must identify one operation. A mapping
+with more than one value is an explicit `MissionViewSelectionError`; the view does not guess.
+
+Once the correlation is selected, projections are limited to inbox envelopes with that
+correlation. The selected snapshot is the greatest `world_revision`, then `observed_at`,
+`produced_at`, and `message_id`. The selected forecast is the greatest `produced_at`, then
+`predicted_for` and `message_id`. Terminal events are limited to terminal states and ordered by
+`occurred_at`, `contract_revision`, and `message_id`; a same-rank conflict between terminal
+states yields no terminal result rather than selecting `SUCCEEDED` by accident. Contradictory
+terminal states for the same contract revision, or anywhere in the selected operation, likewise
+yield no terminal result; repeated `SUCCEEDED` terminal delivery remains valid. A later
+non-terminal event cannot hide a selected terminal event.
+
+The confirmed robot is the selected intent's `preferred_executor`; a snapshot containing only
+another robot does not become confirmed evidence. The forecast must identify that executor and,
+when a confirmed state exists, use the same spatial frame and calibration before an arrival belief
+is exposed. An incompatible forecast therefore produces no arrival sample or prediction manifest.
+The operator target uses the dummy pose only when it is comparable with the selected snapshot frame
+and calibration; with no confirmed snapshot it remains the pending target branch for the selected
+intent.
+
+This is correlation scoping, not full world coherence or lineage validation. In particular, the
+M1 golden session intentionally combines its world-revision-2 snapshot with its world-revision-1
+forecast. A future invalidation and lineage policy must decide when a newer snapshot invalidates
+an otherwise valid forecast; this selector does not make that decision.

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
@@ -63,6 +63,28 @@ DUMMY_PHASES = (
     "RETRACTING",
     "SUCCEEDED",
 )
+
+
+class MissionViewSelectionError(ValueError):
+    """The Mission inbox/outbox cannot identify one operation unambiguously."""
+
+
+@dataclass(frozen=True)
+class _MissionViewSelection:
+    intent: MessageEnvelope | None
+    snapshot: MessageEnvelope | None
+    forecast: MessageEnvelope | None
+    terminal: MessageEnvelope | None
+
+
+@dataclass(frozen=True)
+class _MissionViewProjection:
+    estimated_arrival_at: datetime | None
+    confirmed: ConfirmedStateView | None
+    arrival: ArrivalBeliefView | None
+    target: TargetBranchView | None
+    trajectory: tuple[TimedTrajectorySample, ...]
+    manifests: tuple[PredictionManifest, ...]
 
 
 class Clock(Protocol):
@@ -151,6 +173,309 @@ def evidence(
         model_version="dummy-constant-velocity-v1"
         if provenance in {ProvenanceKind.PREDICTED, ProvenanceKind.SIMULATED}
         else None,
+    )
+
+
+def _message_id_key(message: MessageEnvelope) -> str:
+    """Return the stable final tie-break key used by Mission projections."""
+
+    return str(message.message_id)
+
+
+def _select_mission_view(
+    inbox: Iterable[MessageEnvelope], outbox: Iterable[MessageEnvelope]
+) -> _MissionViewSelection:
+    """Select one operation and its correlation-scoped observations.
+
+    The helper is intentionally pure: it only inspects the supplied immutable
+    envelopes.  Storage order therefore cannot change which intent, snapshot,
+    forecast, or terminal event is projected.
+    """
+
+    inbox_messages = tuple(inbox)
+    outbox_messages = tuple(outbox)
+    intents = tuple(
+        message
+        for message in outbox_messages
+        if isinstance(message.payload, OperationIntent)
+    )
+
+    correlations_by_operation: dict[UUID, set[UUID]] = {}
+    operations_by_correlation: dict[UUID, set[UUID]] = {}
+    for message in intents:
+        operation_id = message.payload.operation_id
+        correlations_by_operation.setdefault(operation_id, set()).add(
+            message.correlation_id
+        )
+        operations_by_correlation.setdefault(message.correlation_id, set()).add(operation_id)
+
+    ambiguous_operations = {
+        operation_id: correlations
+        for operation_id, correlations in correlations_by_operation.items()
+        if len(correlations) > 1
+    }
+    if ambiguous_operations:
+        operation_id, correlations = min(
+            ambiguous_operations.items(), key=lambda item: str(item[0])
+        )
+        rendered = ", ".join(sorted(str(correlation) for correlation in correlations))
+        raise MissionViewSelectionError(
+            "ambiguous correlation_id for operation_id "
+            f"{operation_id}: {rendered}"
+        )
+
+    ambiguous_correlations = {
+        correlation_id: operation_ids
+        for correlation_id, operation_ids in operations_by_correlation.items()
+        if len(operation_ids) > 1
+    }
+    if ambiguous_correlations:
+        correlation_id, operation_ids = min(
+            ambiguous_correlations.items(), key=lambda item: str(item[0])
+        )
+        rendered = ", ".join(sorted(str(operation_id) for operation_id in operation_ids))
+        raise MissionViewSelectionError(
+            "ambiguous operation_id for correlation_id "
+            f"{correlation_id}: {rendered}"
+        )
+
+    intent = (
+        max(
+            intents,
+            key=lambda message: (message.created_at, _message_id_key(message)),
+        )
+        if intents
+        else None
+    )
+    if intent is None:
+        return _MissionViewSelection(None, None, None, None)
+
+    correlation_id = intent.correlation_id
+    snapshots = tuple(
+        message
+        for message in inbox_messages
+        if isinstance(message.payload, SiteSnapshot)
+        and message.correlation_id == correlation_id
+    )
+    forecasts = tuple(
+        message
+        for message in inbox_messages
+        if isinstance(message.payload, RobotForecast)
+        and message.correlation_id == correlation_id
+    )
+    terminal_events = tuple(
+        message
+        for message in inbox_messages
+        if isinstance(message.payload, ExecutionEvent)
+        and message.correlation_id == correlation_id
+        and message.payload.next_state in TERMINAL_STATES
+    )
+
+    snapshot = (
+        max(
+            snapshots,
+            key=lambda message: (
+                message.payload.evidence.world_revision,
+                message.payload.evidence.observed_at,
+                message.payload.evidence.produced_at,
+                _message_id_key(message),
+            ),
+        )
+        if snapshots
+        else None
+    )
+    forecast = (
+        max(
+            forecasts,
+            key=lambda message: (
+                message.payload.evidence.produced_at,
+                message.payload.predicted_for,
+                _message_id_key(message),
+            ),
+        )
+        if forecasts
+        else None
+    )
+
+    terminal: MessageEnvelope | None = None
+    if terminal_events:
+        terminal_states_by_contract: dict[tuple[UUID, int], set[ContractState]] = {}
+        for message in terminal_events:
+            key = (
+                message.payload.contract_id,
+                message.payload.contract_revision,
+            )
+            terminal_states_by_contract.setdefault(key, set()).add(
+                message.payload.next_state
+            )
+        if any(len(states) > 1 for states in terminal_states_by_contract.values()) or len(
+            {message.payload.next_state for message in terminal_events}
+        ) > 1:
+            return _MissionViewSelection(intent, snapshot, forecast, None)
+
+        latest_terminal_key = max(
+            (
+                message.payload.occurred_at,
+                message.payload.contract_revision,
+            )
+            for message in terminal_events
+        )
+        latest_terminals = tuple(
+            message
+            for message in terminal_events
+            if (
+                message.payload.occurred_at,
+                message.payload.contract_revision,
+            )
+            == latest_terminal_key
+        )
+        terminal_states = {message.payload.next_state for message in latest_terminals}
+        if len(terminal_states) == 1:
+            terminal = max(
+                latest_terminals,
+                key=lambda message: (
+                    message.payload.occurred_at,
+                    message.payload.contract_revision,
+                    _message_id_key(message),
+                ),
+            )
+
+    return _MissionViewSelection(intent, snapshot, forecast, terminal)
+
+
+def _select_snapshot_robot(
+    snapshot: SiteSnapshot, preferred_robot_id: str
+) -> RobotState | None:
+    """Choose a stable robot observation from the selected snapshot."""
+
+    if not snapshot.robot_states:
+        return None
+    candidates = tuple(
+        state for state in snapshot.robot_states if state.robot_id == preferred_robot_id
+    )
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda state: (
+            state.evidence.world_revision,
+            state.evidence.observed_at,
+            state.evidence.produced_at,
+            state.robot_id,
+        ),
+    )
+
+
+def _project_mission_view(
+    selection: _MissionViewSelection, configured_one_way_delay: float
+) -> _MissionViewProjection:
+    """Build shared typed projections for legacy and strict Mission views."""
+
+    intent = selection.intent
+    snapshot = selection.snapshot.payload if selection.snapshot is not None else None
+    forecast = selection.forecast.payload if selection.forecast is not None else None
+    estimated_arrival_at = (
+        intent.created_at + timedelta(seconds=configured_one_way_delay)
+        if intent is not None
+        else None
+    )
+
+    confirmed_robot = (
+        _select_snapshot_robot(snapshot, intent.payload.preferred_executor)
+        if snapshot is not None and intent is not None
+        else None
+    )
+    confirmed = (
+        ConfirmedStateView(
+            site_id=snapshot.site_id,
+            robot_id=confirmed_robot.robot_id,
+            pose=confirmed_robot.pose,
+            evidence=confirmed_robot.evidence,
+        )
+        if snapshot is not None and confirmed_robot is not None
+        else None
+    )
+
+    forecast_compatible = forecast is not None and intent is not None and (
+        forecast.robot_id == intent.payload.preferred_executor
+        and (
+            confirmed is None
+            or (
+                forecast.robot_id == confirmed.robot_id
+                and forecast.predicted_pose.frame == confirmed.pose.frame
+            )
+        )
+    )
+    arrival = (
+        ArrivalBeliefView(
+            robot_id=forecast.robot_id,
+            pose=forecast.predicted_pose,
+            predicted_for=forecast.predicted_for,
+            estimated_intent_arrival_at=estimated_arrival_at,
+            link_one_way_delay_seconds=configured_one_way_delay,
+            evidence=forecast.evidence,
+        )
+        if forecast is not None and forecast_compatible
+        else None
+    )
+
+    target: TargetBranchView | None = None
+    if intent is not None:
+        target_pose = dummy_pose(pressed=True)
+        if confirmed is None or target_pose.frame == confirmed.pose.frame:
+            target = TargetBranchView(
+                entity_id=intent.payload.selector.entity_id,
+                pose=target_pose,
+                evidence=evidence(
+                    "mission-operator-1",
+                    intent.created_at,
+                    ProvenanceKind.OPERATOR_ASSERTED,
+                    world_revision=snapshot.evidence.world_revision if snapshot else 1,
+                    fresh_for_seconds=60.0,
+                ),
+            )
+
+    trajectory: list[TimedTrajectorySample] = []
+    if confirmed is not None:
+        trajectory.append(
+            TimedTrajectorySample(
+                sample_time=confirmed.evidence.observed_at,
+                pose=confirmed.pose,
+                source=TrajectorySampleSource.CONFIRMED_STATE,
+                provenance=confirmed.evidence.provenance,
+            )
+        )
+    if arrival is not None:
+        trajectory.append(
+            TimedTrajectorySample(
+                sample_time=arrival.predicted_for,
+                pose=arrival.pose,
+                source=TrajectorySampleSource.ARRIVAL_BELIEF,
+                provenance=arrival.evidence.provenance,
+            )
+        )
+
+    manifests: tuple[PredictionManifest, ...] = ()
+    if selection.forecast is not None and arrival is not None:
+        manifests = (
+            PredictionManifest(
+                manifest_id=uuid5(
+                    NAMESPACE_URL, f"dtt-manifest:{selection.forecast.message_id}"
+                ),
+                site_id="dummy-site-1",
+                forecast_ids=(selection.forecast.message_id,),
+                generated_for_world_revision=forecast.evidence.world_revision,
+                evidence=forecast.evidence,
+            ),
+        )
+
+    return _MissionViewProjection(
+        estimated_arrival_at=estimated_arrival_at,
+        confirmed=confirmed,
+        arrival=arrival,
+        target=target,
+        trajectory=tuple(trajectory),
+        manifests=manifests,
     )
 
 
@@ -278,65 +603,52 @@ class MissionService(RuntimeService):
 
     def view(self) -> dict[str, Any]:
         inbox = self.store.inbox_messages()
-        outbox = self.store.outbox_messages()
-        intents = [message for message in outbox if isinstance(message.payload, OperationIntent)]
-        snapshots = [message for message in inbox if isinstance(message.payload, SiteSnapshot)]
-        forecasts = [message for message in inbox if isinstance(message.payload, RobotForecast)]
-        events = [message for message in inbox if isinstance(message.payload, ExecutionEvent)]
-        terminal = next(
-            (
-                message
-                for message in reversed(events)
-                if message.payload.next_state in TERMINAL_STATES
-            ),
-            None,
-        )
-        intent = intents[-1] if intents else None
-        forecast = forecasts[-1] if forecasts else None
-        estimated_arrival_at = (
-            intent.created_at + timedelta(seconds=self.configured_one_way_delay)
-            if intent
-            else None
-        )
-        manifest: PredictionManifest | None = None
-        if forecast is not None:
-            manifest = PredictionManifest(
-                manifest_id=uuid5(NAMESPACE_URL, f"dtt-manifest:{forecast.message_id}"),
-                site_id="dummy-site-1",
-                forecast_ids=(forecast.message_id,),
-                generated_for_world_revision=forecast.payload.evidence.world_revision,
-                evidence=forecast.payload.evidence,
-            )
+        selection = _select_mission_view(inbox, self.store.outbox_messages())
+        projection = _project_mission_view(selection, self.configured_one_way_delay)
+        intent = selection.intent
+        snapshot = selection.snapshot.payload if selection.snapshot is not None else None
+        forecast = selection.forecast.payload if selection.forecast is not None else None
+        manifest = projection.manifests[0] if projection.manifests else None
         return {
             "node_id": self.factory.node_id,
             "operation_id": str(intent.payload.operation_id) if intent else None,
             "correlation_id": str(intent.correlation_id) if intent else None,
-            "estimated_arrival_at": estimated_arrival_at.isoformat()
-            if estimated_arrival_at
+            "estimated_arrival_at": projection.estimated_arrival_at.isoformat()
+            if projection.estimated_arrival_at
             else None,
-            "confirmed_state": snapshots[-1].payload.model_dump(mode="json")
-            if snapshots
+            "confirmed_state": snapshot.model_dump(mode="json")
+            if snapshot is not None and projection.confirmed is not None
             else None,
             "arrival_belief": {
-                **forecast.payload.model_dump(mode="json"),
-                "estimated_intent_arrival_at": estimated_arrival_at.isoformat()
-                if estimated_arrival_at
+                **forecast.model_dump(mode="json"),
+                "estimated_intent_arrival_at": projection.estimated_arrival_at.isoformat()
+                if projection.estimated_arrival_at
                 else None,
                 "link_one_way_delay_seconds": self.configured_one_way_delay,
             }
-            if forecast
+            if forecast is not None and projection.arrival is not None
             else None,
             "prediction_manifest": manifest.model_dump(mode="json") if manifest else None,
-            "target_branch": {
-                "condition": "button effect succeeds",
-                "entity_id": intent.payload.selector.entity_id,
-                "requested_state": "PRESSED",
-                "provenance": ProvenanceKind.OPERATOR_ASSERTED.value,
-            }
-            if intent
-            else None,
-            "terminal_state": terminal.payload.next_state.value if terminal else None,
-            "terminal_contract_id": str(terminal.payload.contract_id) if terminal else None,
+            "target_branch": (
+                {
+                    "condition": projection.target.condition,
+                    "entity_id": projection.target.entity_id,
+                    "requested_state": projection.target.requested_state,
+                    "provenance": projection.target.evidence.provenance.value,
+                }
+                if projection.target is not None
+                else None
+            ),
+            "terminal_state": (
+                selection.terminal.payload.next_state.value
+                if selection.terminal is not None
+                else None
+            ),
+            "terminal_contract_id": (
+                str(selection.terminal.payload.contract_id)
+                if selection.terminal is not None
+                else None
+            ),
             "received_message_count": len(inbox),
         }
 
@@ -344,101 +656,9 @@ class MissionService(RuntimeService):
         """Build the strict, presentation-neutral snapshot consumed by Unreal."""
 
         inbox = self.store.inbox_messages()
-        outbox = self.store.outbox_messages()
-        intents = [message for message in outbox if isinstance(message.payload, OperationIntent)]
-        snapshots = [message for message in inbox if isinstance(message.payload, SiteSnapshot)]
-        forecasts = [message for message in inbox if isinstance(message.payload, RobotForecast)]
-        events = [message for message in inbox if isinstance(message.payload, ExecutionEvent)]
-        terminal = next(
-            (
-                message
-                for message in reversed(events)
-                if message.payload.next_state in TERMINAL_STATES
-            ),
-            None,
-        )
-        intent = intents[-1] if intents else None
-        snapshot = snapshots[-1].payload if snapshots else None
-        confirmed_robot = snapshot.robot_states[-1] if snapshot and snapshot.robot_states else None
-        forecast_envelope = forecasts[-1] if forecasts else None
-        forecast = forecast_envelope.payload if forecast_envelope else None
-        estimated_arrival_at = (
-            intent.created_at + timedelta(seconds=self.configured_one_way_delay)
-            if intent
-            else None
-        )
-
-        confirmed = (
-            ConfirmedStateView(
-                site_id=snapshot.site_id,
-                robot_id=confirmed_robot.robot_id,
-                pose=confirmed_robot.pose,
-                evidence=confirmed_robot.evidence,
-            )
-            if snapshot is not None and confirmed_robot is not None
-            else None
-        )
-        arrival = (
-            ArrivalBeliefView(
-                robot_id=forecast.robot_id,
-                pose=forecast.predicted_pose,
-                predicted_for=forecast.predicted_for,
-                estimated_intent_arrival_at=estimated_arrival_at,
-                link_one_way_delay_seconds=self.configured_one_way_delay,
-                evidence=forecast.evidence,
-            )
-            if forecast is not None
-            else None
-        )
-        target = (
-            TargetBranchView(
-                entity_id=intent.payload.selector.entity_id,
-                pose=dummy_pose(pressed=True),
-                evidence=evidence(
-                    "mission-operator-1",
-                    intent.created_at,
-                    ProvenanceKind.OPERATOR_ASSERTED,
-                    world_revision=snapshot.evidence.world_revision if snapshot else 1,
-                    fresh_for_seconds=60.0,
-                ),
-            )
-            if intent is not None
-            else None
-        )
-
-        trajectory: list[TimedTrajectorySample] = []
-        if confirmed is not None:
-            trajectory.append(
-                TimedTrajectorySample(
-                    sample_time=confirmed.evidence.observed_at,
-                    pose=confirmed.pose,
-                    source=TrajectorySampleSource.CONFIRMED_STATE,
-                    provenance=confirmed.evidence.provenance,
-                )
-            )
-        if arrival is not None:
-            trajectory.append(
-                TimedTrajectorySample(
-                    sample_time=arrival.predicted_for,
-                    pose=arrival.pose,
-                    source=TrajectorySampleSource.ARRIVAL_BELIEF,
-                    provenance=arrival.evidence.provenance,
-                )
-            )
-
-        manifests: tuple[PredictionManifest, ...] = ()
-        if forecast_envelope is not None:
-            manifests = (
-                PredictionManifest(
-                    manifest_id=uuid5(
-                        NAMESPACE_URL, f"dtt-manifest:{forecast_envelope.message_id}"
-                    ),
-                    site_id="dummy-site-1",
-                    forecast_ids=(forecast_envelope.message_id,),
-                    generated_for_world_revision=forecast.evidence.world_revision,
-                    evidence=forecast.evidence,
-                ),
-            )
+        selection = _select_mission_view(inbox, self.store.outbox_messages())
+        projection = _project_mission_view(selection, self.configured_one_way_delay)
+        intent = selection.intent
 
         self._view_sequence += 1
         return MissionViewState(
@@ -449,16 +669,24 @@ class MissionService(RuntimeService):
                 mission_to_field=self._link_connection_state,
                 changed_at=self._link_status_changed_at,
             ),
-            confirmed_state=confirmed,
-            arrival_belief=arrival,
-            target_branch=target,
-            trajectory_forecasts=tuple(trajectory),
-            prediction_manifests=manifests,
+            confirmed_state=projection.confirmed,
+            arrival_belief=projection.arrival,
+            target_branch=projection.target,
+            trajectory_forecasts=projection.trajectory,
+            prediction_manifests=projection.manifests,
             status=MissionViewStatus(
                 operation_id=intent.payload.operation_id if intent else None,
                 correlation_id=intent.correlation_id if intent else None,
-                terminal_state=terminal.payload.next_state if terminal else None,
-                terminal_contract_id=terminal.payload.contract_id if terminal else None,
+                terminal_state=(
+                    selection.terminal.payload.next_state
+                    if selection.terminal is not None
+                    else None
+                ),
+                terminal_contract_id=(
+                    selection.terminal.payload.contract_id
+                    if selection.terminal is not None
+                    else None
+                ),
                 received_message_count=len(inbox),
             ),
         )

--- a/tests/test_mission_view.py
+++ b/tests/test_mission_view.py
@@ -1,11 +1,36 @@
 import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 import pytest
 from deferred_teleop.mission_view import MissionViewState
 from deferred_teleop.node import JsonLogger, _mission_view_handler
-from deferred_teleop.runtime import EnvelopeFactory, FieldService, MissionService
+from deferred_teleop.protocol import (
+    ApprovalPolicy,
+    ContractState,
+    EntitySelector,
+    ExecutionEvent,
+    MessageEnvelope,
+    OperationIntent,
+    OperationState,
+    OperationType,
+    Pose,
+    ProvenanceKind,
+    RobotForecast,
+    RobotState,
+    SiteSnapshot,
+    SpatialFrame,
+    Vector3,
+)
+from deferred_teleop.runtime import (
+    EnvelopeFactory,
+    FieldService,
+    MissionService,
+    MissionViewSelectionError,
+    dummy_pose,
+    evidence,
+)
 from deferred_teleop.storage import NodeStore
 from pydantic import ValidationError
 from websockets.asyncio.client import connect
@@ -26,6 +51,157 @@ class VirtualClock:
 async def _deliver(service, envelope) -> None:
     assert service.store.receive(envelope, received_at=service.clock.now())
     await service.handle(envelope)
+
+
+def _id(label: str) -> UUID:
+    return uuid5(NAMESPACE_URL, f"dtt-mission-view-test:{label}")
+
+
+def _intent(
+    factory: EnvelopeFactory,
+    *,
+    operation_id: UUID,
+    correlation_id: UUID,
+    created_at: datetime,
+    message_id: UUID,
+    entity_id: str,
+) -> MessageEnvelope:
+    return factory.make(
+        "operation.intent",
+        "field-1",
+        correlation_id,
+        OperationIntent(
+            operation_id=operation_id,
+            operation_type=OperationType.PRESS_BUTTON,
+            selector=EntitySelector(entity_id=entity_id),
+            preferred_executor="dummy-robot-1",
+            approval_policy=ApprovalPolicy.AUTO_IF_WHITELISTED,
+            state=OperationState.SUBMITTED,
+        ),
+        message_id=message_id,
+        created_at=created_at,
+    )
+
+
+def _evidence_at(
+    source_id: str,
+    observed_at: datetime,
+    provenance: ProvenanceKind,
+    *,
+    world_revision: int,
+    produced_at: datetime | None = None,
+):
+    produced = produced_at or observed_at
+    return evidence(
+        source_id,
+        observed_at,
+        provenance,
+        world_revision=world_revision,
+    ).model_copy(
+        update={
+            "produced_at": produced,
+            "fresh_until": produced + timedelta(seconds=30),
+        }
+    )
+
+
+def _snapshot(
+    factory: EnvelopeFactory,
+    *,
+    correlation_id: UUID,
+    message_id: UUID,
+    observed_at: datetime,
+    world_revision: int = 1,
+    produced_at: datetime | None = None,
+    robot_id: str = "dummy-robot-1",
+    pose: Pose | None = None,
+):
+    snapshot_evidence = _evidence_at(
+        "field-test",
+        observed_at,
+        ProvenanceKind.MEASURED,
+        world_revision=world_revision,
+        produced_at=produced_at,
+    )
+    robot = RobotState(
+        robot_id=robot_id,
+        pose=pose or dummy_pose(),
+        evidence=snapshot_evidence,
+    )
+    return factory.make(
+        "site.snapshot",
+        "mission-1",
+        correlation_id,
+        SiteSnapshot(
+            site_id="dummy-site-1",
+            entities=("dummy-button-1",),
+            robot_states=(robot,),
+            evidence=snapshot_evidence,
+        ),
+        causation_id=_id(f"snapshot-cause:{message_id}"),
+        message_id=message_id,
+        created_at=observed_at,
+    )
+
+
+def _forecast(
+    factory: EnvelopeFactory,
+    *,
+    correlation_id: UUID,
+    message_id: UUID,
+    produced_at: datetime,
+    predicted_for: datetime | None = None,
+    robot_id: str = "dummy-robot-1",
+    pose: Pose | None = None,
+):
+    forecast_evidence = _evidence_at(
+        robot_id,
+        produced_at,
+        ProvenanceKind.PREDICTED,
+        world_revision=1,
+    )
+    return factory.make(
+        "robot.forecast",
+        "mission-1",
+        correlation_id,
+        RobotForecast(
+            robot_id=robot_id,
+            predicted_pose=pose or dummy_pose(pressed=True),
+            predicted_for=predicted_for or produced_at + timedelta(seconds=1),
+            evidence=forecast_evidence,
+        ),
+        causation_id=_id(f"forecast-cause:{message_id}"),
+        message_id=message_id,
+        created_at=produced_at,
+    )
+
+
+def _terminal(
+    factory: EnvelopeFactory,
+    *,
+    correlation_id: UUID,
+    message_id: UUID,
+    contract_id: UUID,
+    occurred_at: datetime,
+    contract_revision: int = 1,
+    state: ContractState = ContractState.SUCCEEDED,
+):
+    return factory.make(
+        "execution.event",
+        "mission-1",
+        correlation_id,
+        ExecutionEvent(
+            event_id=_id(f"terminal-event:{message_id}"),
+            contract_id=contract_id,
+            contract_revision=contract_revision,
+            previous_state=ContractState.RUNNING,
+            next_state=state,
+            occurred_at=occurred_at,
+        ),
+        causation_id=_id(f"terminal-cause:{message_id}"),
+        message_id=message_id,
+        created_at=occurred_at,
+    )
 
 
 def test_mission_view_keeps_confirmed_arrival_and_target_distinct(tmp_path: Path) -> None:
@@ -102,5 +278,776 @@ def test_mission_view_websocket_publishes_strict_frames(tmp_path: Path) -> None:
                 second = MissionViewState.model_validate_json(await connection.recv())
                 assert first.source_sequence == 1
                 assert second.source_sequence == 2
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_scopes_late_previous_operation_after_new_submission(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(
+                store,
+                factory,
+                configured_one_way_delay=5.0,
+            )
+            operation_a = _id("operation-a")
+            correlation_a = _id("correlation-a")
+            intent_a = _intent(
+                factory,
+                operation_id=operation_a,
+                correlation_id=correlation_a,
+                created_at=clock.now(),
+                message_id=_id("intent-a"),
+                entity_id="button-A",
+            )
+            store.enqueue(intent_a)
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_a,
+                    message_id=_id("snapshot-a-early"),
+                    observed_at=clock.now(),
+                    world_revision=1,
+                ),
+            )
+
+            clock.current += timedelta(seconds=1)
+            operation_b = _id("operation-b")
+            correlation_b = _id("correlation-b")
+            intent_b = _intent(
+                factory,
+                operation_id=operation_b,
+                correlation_id=correlation_b,
+                created_at=clock.now(),
+                message_id=_id("intent-b"),
+                entity_id="button-B",
+            )
+            store.enqueue(intent_b)
+
+            before_b_proof = mission.view_state()
+            assert before_b_proof.status.operation_id == operation_b
+            assert before_b_proof.status.correlation_id == correlation_b
+            assert before_b_proof.target_branch is not None
+            assert before_b_proof.target_branch.entity_id == "button-B"
+            assert before_b_proof.confirmed_state is None
+            assert before_b_proof.arrival_belief is None
+            assert before_b_proof.trajectory_forecasts == ()
+            assert before_b_proof.prediction_manifests == ()
+
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_b,
+                    message_id=_id("snapshot-b"),
+                    observed_at=clock.now(),
+                    world_revision=2,
+                ),
+            )
+            await _deliver(
+                mission,
+                _forecast(
+                    factory,
+                    correlation_id=correlation_b,
+                    message_id=_id("forecast-b"),
+                    produced_at=clock.now(),
+                ),
+            )
+            terminal_b = _terminal(
+                factory,
+                correlation_id=correlation_b,
+                message_id=_id("terminal-b"),
+                contract_id=_id("contract-b"),
+                occurred_at=clock.now(),
+            )
+            await _deliver(mission, terminal_b)
+
+            # These A observations arrive after B has become visible. They must
+            # not replace any B projection, even when their evidence is newer.
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_a,
+                    message_id=_id("snapshot-a-late"),
+                    observed_at=clock.now() + timedelta(seconds=30),
+                    world_revision=99,
+                ),
+            )
+            await _deliver(
+                mission,
+                _forecast(
+                    factory,
+                    correlation_id=correlation_a,
+                    message_id=_id("forecast-a-late"),
+                    produced_at=clock.now() + timedelta(seconds=30),
+                ),
+            )
+            await _deliver(
+                mission,
+                _terminal(
+                    factory,
+                    correlation_id=correlation_a,
+                    message_id=_id("terminal-a-late"),
+                    contract_id=_id("contract-a-late"),
+                    occurred_at=clock.now() + timedelta(seconds=30),
+                ),
+            )
+
+            state = mission.view_state()
+            assert state.status.operation_id == operation_b
+            assert state.status.correlation_id == correlation_b
+            assert state.target_branch is not None
+            assert state.target_branch.entity_id == "button-B"
+            assert state.confirmed_state is not None
+            assert state.arrival_belief is not None
+            assert state.status.terminal_state is ContractState.SUCCEEDED
+            assert state.status.terminal_contract_id == _id("contract-b")
+            assert all(
+                sample.pose == state.confirmed_state.pose
+                for sample in state.trajectory_forecasts[:1]
+            )
+            assert state.prediction_manifests[0].forecast_ids == (_id("forecast-b"),)
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_selection_is_reception_order_independent_and_survives_restart(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_path = tmp_path / "mission.db"
+        operation_id = _id("restart-operation")
+        correlation_id = _id("restart-correlation")
+        with NodeStore(mission_path) as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(
+                store,
+                factory,
+                configured_one_way_delay=0.0,
+            )
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id("restart-intent"),
+                    entity_id="button-restart",
+                )
+            )
+            early_snapshot = _snapshot(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("restart-snapshot-rev1"),
+                observed_at=clock.now() + timedelta(seconds=10),
+                world_revision=1,
+            )
+            latest_snapshot = _snapshot(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("restart-snapshot-rev2"),
+                observed_at=clock.now() + timedelta(seconds=1),
+                world_revision=2,
+                pose=dummy_pose().model_copy(
+                    update={"position": Vector3(x=0.8, y=0.1, z=0.18)}
+                ),
+            )
+            early_forecast = _forecast(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("restart-forecast-early"),
+                produced_at=clock.now() + timedelta(seconds=2),
+                pose=dummy_pose(pressed=True).model_copy(
+                    update={"position": Vector3(x=0.6, y=0.1, z=0.18)}
+                ),
+            )
+            latest_forecast = _forecast(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("restart-forecast-latest"),
+                produced_at=clock.now() + timedelta(seconds=3),
+                pose=dummy_pose(pressed=True).model_copy(
+                    update={"position": Vector3(x=0.7, y=0.1, z=0.18)}
+                ),
+            )
+            terminal = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("restart-terminal"),
+                contract_id=_id("restart-contract"),
+                occurred_at=clock.now() + timedelta(seconds=4),
+            )
+            nonterminal_after_terminal = factory.make(
+                "execution.event",
+                "mission-1",
+                correlation_id,
+                ExecutionEvent(
+                    event_id=_id("restart-running-event"),
+                    contract_id=_id("restart-contract"),
+                    contract_revision=1,
+                    previous_state=ContractState.DISPATCH_RECORDED,
+                    next_state=ContractState.RUNNING,
+                    occurred_at=clock.now() + timedelta(seconds=5),
+                ),
+                causation_id=_id("restart-running-cause"),
+                message_id=_id("restart-running"),
+                created_at=clock.now() + timedelta(seconds=5),
+            )
+
+            # Deliberately invert evidence delivery order.
+            for message in (
+                nonterminal_after_terminal,
+                latest_forecast,
+                early_snapshot,
+                terminal,
+                early_forecast,
+                latest_snapshot,
+            ):
+                await _deliver(mission, message)
+
+            first = mission.view_state()
+            assert first.confirmed_state is not None
+            assert first.confirmed_state.pose.position.x == 0.8
+            assert first.arrival_belief is not None
+            assert first.arrival_belief.pose.position.x == 0.7
+            assert first.status.terminal_state is ContractState.SUCCEEDED
+
+        with NodeStore(mission_path) as restarted_store:
+            restarted = MissionService(
+                restarted_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            second = restarted.view_state()
+            assert second.model_dump(mode="json") == first.model_dump(mode="json")
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_uses_message_id_for_same_time_ties(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            operation_a = UUID("00000000-0000-0000-0000-000000000001")
+            operation_b = UUID("00000000-0000-0000-0000-000000000002")
+            correlation_a = UUID("00000000-0000-0000-0000-000000000011")
+            correlation_b = UUID("00000000-0000-0000-0000-000000000012")
+            intent_a = _intent(
+                factory,
+                operation_id=operation_a,
+                correlation_id=correlation_a,
+                created_at=clock.now(),
+                message_id=UUID("00000000-0000-0000-0000-000000000101"),
+                entity_id="button-A",
+            )
+            intent_b = _intent(
+                factory,
+                operation_id=operation_b,
+                correlation_id=correlation_b,
+                created_at=clock.now(),
+                message_id=UUID("00000000-0000-0000-0000-000000000102"),
+                entity_id="button-B",
+            )
+            store.enqueue(intent_a)
+            store.enqueue(intent_b)
+            tie_time = clock.now()
+            low_snapshot = _snapshot(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000111"),
+                observed_at=tie_time,
+                world_revision=2,
+                pose=dummy_pose().model_copy(
+                    update={"position": Vector3(x=0.1, y=0.1, z=0.18)}
+                ),
+            )
+            high_snapshot = _snapshot(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000112"),
+                observed_at=tie_time,
+                world_revision=2,
+                pose=dummy_pose().model_copy(
+                    update={"position": Vector3(x=0.9, y=0.1, z=0.18)}
+                ),
+            )
+            low_forecast = _forecast(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000121"),
+                produced_at=tie_time,
+                pose=dummy_pose(pressed=True).model_copy(
+                    update={"position": Vector3(x=0.2, y=0.1, z=0.18)}
+                ),
+            )
+            high_forecast = _forecast(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000122"),
+                produced_at=tie_time,
+                pose=dummy_pose(pressed=True).model_copy(
+                    update={"position": Vector3(x=0.8, y=0.1, z=0.18)}
+                ),
+            )
+            low_terminal = _terminal(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000131"),
+                contract_id=UUID("00000000-0000-0000-0000-000000000141"),
+                occurred_at=tie_time,
+            )
+            high_terminal = _terminal(
+                factory,
+                correlation_id=correlation_b,
+                message_id=UUID("00000000-0000-0000-0000-000000000132"),
+                contract_id=UUID("00000000-0000-0000-0000-000000000142"),
+                occurred_at=tie_time,
+            )
+            for message in (
+                high_terminal,
+                low_snapshot,
+                high_forecast,
+                low_terminal,
+                high_snapshot,
+                low_forecast,
+            ):
+                await _deliver(mission, message)
+
+            state = mission.view_state()
+            assert state.status.operation_id == operation_b
+            assert state.confirmed_state is not None
+            assert state.confirmed_state.pose.position.x == 0.9
+            assert state.arrival_belief is not None
+            assert state.arrival_belief.pose.position.x == 0.8
+            assert state.status.terminal_contract_id == UUID(
+                "00000000-0000-0000-0000-000000000142"
+            )
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_rejects_ambiguous_operation_correlation(tmp_path: Path) -> None:
+    clock = VirtualClock()
+    with NodeStore(tmp_path / "mission.db") as store:
+        factory = EnvelopeFactory("mission-1", clock)
+        operation_id = _id("ambiguous-operation")
+        store.enqueue(
+            _intent(
+                factory,
+                operation_id=operation_id,
+                correlation_id=_id("ambiguous-correlation-a"),
+                created_at=clock.now(),
+                message_id=_id("ambiguous-intent-a"),
+                entity_id="button-A",
+            )
+        )
+        store.enqueue(
+            _intent(
+                factory,
+                operation_id=operation_id,
+                correlation_id=_id("ambiguous-correlation-b"),
+                created_at=clock.now() + timedelta(seconds=1),
+                message_id=_id("ambiguous-intent-b"),
+                entity_id="button-B",
+            )
+        )
+        service = MissionService(store, factory, configured_one_way_delay=0.0)
+        with pytest.raises(MissionViewSelectionError, match="correlation_id"):
+            service.view_state()
+        with pytest.raises(MissionViewSelectionError, match="correlation_id"):
+            service.view()
+
+
+@pytest.mark.parametrize("mismatch", ["robot", "frame", "calibration"])
+def test_mission_view_drops_incompatible_forecast_artifacts(
+    tmp_path: Path, mismatch: str
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(
+                store,
+                factory,
+                configured_one_way_delay=0.0,
+            )
+            operation_id = _id(f"mismatch-operation:{mismatch}")
+            correlation_id = _id(f"mismatch-correlation:{mismatch}")
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id(f"mismatch-intent:{mismatch}"),
+                    entity_id="button-mismatch",
+                )
+            )
+            confirmed_pose = dummy_pose()
+            forecast_pose = dummy_pose(pressed=True)
+            forecast_robot_id = "dummy-robot-1"
+            if mismatch == "robot":
+                forecast_robot_id = "other-robot"
+            elif mismatch == "frame":
+                forecast_pose = forecast_pose.model_copy(
+                    update={
+                        "frame": confirmed_pose.frame.model_copy(
+                            update={"frame_id": "other-world"}
+                        )
+                    }
+                )
+            else:
+                forecast_pose = forecast_pose.model_copy(
+                    update={
+                        "frame": confirmed_pose.frame.model_copy(
+                            update={"calibration_version": "other-cal-1"}
+                        )
+                    }
+                )
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id(f"mismatch-snapshot:{mismatch}"),
+                    observed_at=clock.now(),
+                    pose=confirmed_pose,
+                ),
+            )
+            await _deliver(
+                mission,
+                _forecast(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id(f"mismatch-forecast:{mismatch}"),
+                    produced_at=clock.now(),
+                    robot_id=forecast_robot_id,
+                    pose=forecast_pose,
+                ),
+            )
+
+            state = mission.view_state()
+            assert state.confirmed_state is not None
+            assert state.target_branch is not None
+            assert state.arrival_belief is None
+            assert state.prediction_manifests == ()
+            assert [sample.source for sample in state.trajectory_forecasts] == [
+                "CONFIRMED_STATE"
+            ]
+            view = mission.view()
+            assert view["confirmed_state"] is not None
+            assert view["arrival_belief"] is None
+            assert view["prediction_manifest"] is None
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_drops_forecast_for_unexpected_robot_before_or_without_snapshot(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "before-snapshot.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            operation_id = _id("unexpected-before-operation")
+            correlation_id = _id("unexpected-before-correlation")
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id("unexpected-before-intent"),
+                    entity_id="button-unexpected-before",
+                )
+            )
+            await _deliver(
+                mission,
+                _forecast(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id("unexpected-before-forecast"),
+                    produced_at=clock.now(),
+                    robot_id="other-robot",
+                ),
+            )
+            state = mission.view_state()
+            assert state.confirmed_state is None
+            assert state.arrival_belief is None
+            assert state.target_branch is not None
+            assert state.trajectory_forecasts == ()
+            assert state.prediction_manifests == ()
+
+        with NodeStore(tmp_path / "other-robot-snapshot.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            operation_id = _id("unexpected-snapshot-operation")
+            correlation_id = _id("unexpected-snapshot-correlation")
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id("unexpected-snapshot-intent"),
+                    entity_id="button-unexpected-snapshot",
+                )
+            )
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id("unexpected-snapshot"),
+                    observed_at=clock.now(),
+                    robot_id="other-robot",
+                ),
+            )
+            await _deliver(
+                mission,
+                _forecast(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id("unexpected-snapshot-forecast"),
+                    produced_at=clock.now(),
+                    robot_id="other-robot",
+                ),
+            )
+            state = mission.view_state()
+            assert state.confirmed_state is None
+            assert state.arrival_belief is None
+            assert state.target_branch is not None
+            assert state.trajectory_forecasts == ()
+            assert state.prediction_manifests == ()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("reverse_delivery", [False, True])
+def test_mission_view_suppresses_conflicting_terminal_states_across_restart(
+    tmp_path: Path, reverse_delivery: bool
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_path = tmp_path / "mission.db"
+        operation_id = _id(f"terminal-conflict-operation:{reverse_delivery}")
+        correlation_id = _id(f"terminal-conflict-correlation:{reverse_delivery}")
+        with NodeStore(mission_path) as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id(f"terminal-conflict-intent:{reverse_delivery}"),
+                    entity_id="button-terminal-conflict",
+                )
+            )
+            contract_id = _id(f"terminal-conflict-contract:{reverse_delivery}")
+            succeeded = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id(f"terminal-conflict-succeeded:{reverse_delivery}"),
+                contract_id=contract_id,
+                occurred_at=clock.now() + timedelta(seconds=1),
+                state=ContractState.SUCCEEDED,
+            )
+            failed = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id(f"terminal-conflict-failed:{reverse_delivery}"),
+                contract_id=contract_id,
+                occurred_at=clock.now() + timedelta(seconds=2),
+                state=ContractState.FAILED,
+            )
+            messages = (failed, succeeded) if reverse_delivery else (succeeded, failed)
+            for message in messages:
+                await _deliver(mission, message)
+            first = mission.view_state()
+            assert first.status.terminal_state is None
+            assert first.status.terminal_contract_id is None
+
+        with NodeStore(mission_path) as restarted_store:
+            restarted = MissionService(
+                restarted_store,
+                EnvelopeFactory("mission-1", clock),
+                configured_one_way_delay=0.0,
+            )
+            second = restarted.view_state()
+            assert second.status.terminal_state is None
+            assert second.status.terminal_contract_id is None
+            assert second.model_dump(mode="json") == first.model_dump(mode="json")
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_allows_same_state_terminal_replay_with_newer_timestamp(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            operation_id = _id("terminal-replay-operation")
+            correlation_id = _id("terminal-replay-correlation")
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id("terminal-replay-intent"),
+                    entity_id="button-terminal-replay",
+                )
+            )
+            contract_id = _id("terminal-replay-contract")
+            first_terminal = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("terminal-replay-first"),
+                contract_id=contract_id,
+                occurred_at=clock.now() + timedelta(seconds=1),
+            )
+            replay = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("terminal-replay-later"),
+                contract_id=contract_id,
+                occurred_at=clock.now() + timedelta(seconds=2),
+            )
+            await _deliver(mission, replay)
+            await _deliver(mission, first_terminal)
+            state = mission.view_state()
+            assert state.status.terminal_state is ContractState.SUCCEEDED
+            assert state.status.terminal_contract_id == contract_id
+            assert state.status.operation_id == operation_id
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_hides_target_when_snapshot_frame_is_not_comparable(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=0.0)
+            operation_id = _id("target-frame-operation")
+            correlation_id = _id("target-frame-correlation")
+            store.enqueue(
+                _intent(
+                    factory,
+                    operation_id=operation_id,
+                    correlation_id=correlation_id,
+                    created_at=clock.now(),
+                    message_id=_id("target-frame-intent"),
+                    entity_id="button-target-frame",
+                )
+            )
+            incompatible_pose = dummy_pose().model_copy(
+                update={
+                    "frame": SpatialFrame(
+                        frame_id="other-world",
+                        calibration_version="other-cal-1",
+                    )
+                }
+            )
+            await _deliver(
+                mission,
+                _snapshot(
+                    factory,
+                    correlation_id=correlation_id,
+                    message_id=_id("target-frame-snapshot"),
+                    observed_at=clock.now(),
+                    pose=incompatible_pose,
+                ),
+            )
+            state = mission.view_state()
+            assert state.confirmed_state is not None
+            assert state.target_branch is None
+            assert state.trajectory_forecasts[0].source == "CONFIRMED_STATE"
+
+    asyncio.run(scenario())
+
+
+def test_mission_view_and_view_state_share_projection_semantics(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "mission.db") as store:
+            factory = EnvelopeFactory("mission-1", clock)
+            mission = MissionService(store, factory, configured_one_way_delay=2.0)
+            operation_id = _id("coherence-operation")
+            correlation_id = _id("coherence-correlation")
+            intent = _intent(
+                factory,
+                operation_id=operation_id,
+                correlation_id=correlation_id,
+                created_at=clock.now(),
+                message_id=_id("coherence-intent"),
+                entity_id="button-coherence",
+            )
+            store.enqueue(intent)
+            snapshot = _snapshot(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("coherence-snapshot"),
+                observed_at=clock.now(),
+                world_revision=2,
+            )
+            forecast = _forecast(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("coherence-forecast"),
+                produced_at=clock.now(),
+            )
+            terminal = _terminal(
+                factory,
+                correlation_id=correlation_id,
+                message_id=_id("coherence-terminal"),
+                contract_id=_id("coherence-contract"),
+                occurred_at=clock.now(),
+            )
+            for message in (forecast, terminal, snapshot):
+                await _deliver(mission, message)
+
+            view = mission.view()
+            state = mission.view_state()
+            assert view["operation_id"] == str(state.status.operation_id)
+            assert view["correlation_id"] == str(state.status.correlation_id)
+            assert view["estimated_arrival_at"] == (
+                intent.created_at + timedelta(seconds=2.0)
+            ).isoformat()
+            assert view["confirmed_state"]["site_id"] == state.confirmed_state.site_id
+            assert view["confirmed_state"]["robot_states"][-1]["pose"] == (
+                state.confirmed_state.pose.model_dump(mode="json")
+            )
+            assert view["arrival_belief"]["robot_id"] == state.arrival_belief.robot_id
+            assert view["arrival_belief"]["predicted_pose"] == (
+                state.arrival_belief.pose.model_dump(mode="json")
+            )
+            assert view["prediction_manifest"] == state.prediction_manifests[0].model_dump(
+                mode="json"
+            )
+            assert view["target_branch"]["entity_id"] == state.target_branch.entity_id
+            assert view["terminal_state"] == state.status.terminal_state.value
+            assert view["terminal_contract_id"] == str(state.status.terminal_contract_id)
+            assert [sample.source.value for sample in state.trajectory_forecasts] == [
+                "CONFIRMED_STATE",
+                "ARRIVAL_BELIEF",
+            ]
 
     asyncio.run(scenario())


### PR DESCRIPTION
After submitting operation B, delayed evidence from operation A could be displayed beside B's target. Both Mission view APIs now share a deterministic selector that scopes observations and outcomes to the selected operation's correlation and removes incompatible projections and their derived artifacts.

The change rejects ambiguous operation/correlation mappings and suppresses conflicting terminal outcomes. It is the bounded M1.7a correction: complete operation/revision/observation lineage and forecast invalidation across world revisions remain future work.

Validation: 72 Python tests pass, targeted Ruff checks pass, and the historical M1 golden session and release gate remain unchanged. Regression tests cover late A messages, reorder/restart, timestamp ties, robot/frame/calibration mismatch, and conflicting outcomes. No wire schema or Unreal source change; no physical hardware used.

Closes #29.
