### PR TITLE
docs: align roadmap with delayed-intent validation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,9 @@
 # Roadmap
 
-The roadmap is organized around runnable vertical slices. Dates are intentionally secondary to demonstrated exit criteria.
+The roadmap is organized around runnable vertical slices. Calendar dates are secondary; a
+milestone closes only when its stated evidence gate passes. The authority boundary remains:
+Mission authors and reconciles, Field admits and coordinates, and Robot executes locally and
+reports physical evidence.
 
 ## M0 — Public foundation
 
@@ -14,13 +17,11 @@ Status: **complete**
 - experimental `protocol/v0` namespace with conformance fixtures.
 
 M0 is not a release. It completed after local Unreal Engine 5.8 verification and review of the
-bootstrap pull request. The first runnable release target remains M1.
+bootstrap pull request. The first runnable release target was M1.
 
 ## M1 — Delay-tolerant dummy
 
-First runnable release target.
-
-Status: **complete for v0.1.0**
+Status: **complete for `v0.1.0` (historical)**
 
 ```text
 OperationIntent(PressButton)
@@ -31,52 +32,194 @@ OperationIntent(PressButton)
 -> ExecutionEvent
 ```
 
-The test harness will inject delay, blackout windows, duplication, reordering, retransmission and crash points. Delivery is at-least-once; application effects must be idempotent.
+The test harness injects delay, blackout windows, duplication, reordering, retransmission and
+crash points. Delivery is at-least-once; application effects are idempotent on the dummy path.
 
-The deterministic golden session and fourteen-profile adversarial matrix are implemented. Portable
-Python checks run on Linux in CI; Unreal Engine 5.8.2 was built and exercised on Windows, the
-reference Unreal platform for `v0.1.0`. This release does not claim Unreal support on Linux.
+The deterministic golden session and fourteen-profile adversarial matrix are implemented.
+Portable Python checks run on Linux in CI; Unreal Engine 5.8.2 was built and exercised on
+Windows, the reference Unreal platform for `v0.1.0`. This release proves transport, persistence,
+replay and reconciliation for the constrained dummy scenario. It does not claim that a stale
+world, an external physical effect or multiple concurrent operations are resolved correctly.
+
+## M1.7a — Bounded Mission-view selection correction
+
+Status: **complete** — [PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30)
+
+M1.7a is a small correction to the released Mission selection path. It rejects ambiguous
+operation/correlation mappings among the intents in Mission's outbox when constructing the view,
+without introducing the full lineage model or changing the `dtt/0` golden and Unreal evidence.
+Mission chooses the latest intent globally by
+`MAX(created_at, str(message_id))`, then filters the selected intent's correlation.
+
+The correlation mapping is valid only when one `operation_id` maps to one `correlation_id` and one
+`correlation_id` maps to one `operation_id`. Duplicate deliveries with the same operation and
+correlation are allowed when this mapping remains unambiguous. Distinct operation IDs sharing a
+correlation, or one operation using multiple correlations, raise the explicit
+`MissionViewSelectionError`; Mission never chooses one of the conflicting operations.
+
+The selected operation and correlation are then used as filters for its snapshot, arrival forecast
+and terminal event. A frame, calibration or robot mismatch in a snapshot, forecast or target
+projection makes that layer absent/unknown; terminal events have no frame and are not subject to a
+frame mismatch check. Mission does not fall through to another operation or fill a layer with a
+different item. This rule is intentionally bounded and deterministic.
+
+The regression suite verifies mapping validation in the selected Mission view, global latest-intent
+selection, explicit mapping errors, duplicate handling and snapshot/forecast/terminal filters.
+All 72 Python tests and CI passed with the historical `dtt/0` golden session unchanged; no Unreal
+source or wire schema changed. See the [selection contract](docs/m1/MISSION_OPERATION_SELECTION.md).
+This does not close M1.7 or establish complete multi-operation lineage.
+
+## M1.7 — Causal coherence across operations
+
+Status: **planned after M1.7a; not closed by this documentation**
+
+M1.7 extends the bounded correction into a full lineage proof before adding broader autonomy.
+Every confirmed, arrival-belief and target branch must carry enough lineage to identify the
+operation, intent revision, source observation and model/forecast assumptions that produced it.
+Mission must keep branches separate when messages arrive late, duplicated or out of order.
+
+The first fixture contains two concurrent operations, two target branches and an intervening
+model or calibration revision. The replay deliberately reorders their intents, forecasts and
+terminal events. A view either assembles causally compatible elements or exposes an explicit
+incompatibility/unknown state; it never borrows a result from another operation to complete a
+missing field.
+
+M1.7 closes only when a deterministic replay demonstrates all of the following:
+
+- no cross-operation target, forecast or terminal-result association;
+- operation and intent-revision lineage is preserved through reconnect and duplicate delivery;
+- a missing or incompatible branch remains missing or incompatible;
+- the same assertion is visible in the machine-readable evidence and Mission view.
+
+This increment is a protocol/runtime proof only. It does not require a physical robot or a
+general perception system. M1.7a is a prerequisite correction, not a substitute for this gate.
+
+## M1.8 — External effect and long-delay evidence
+
+Status: **planned**
+
+M1.8 adds the smallest deterministic proof that a recorded execution event is not itself proof
+of an external effect. A fake button device keeps an effect counter or state in storage separate
+from the Robot execution journal. The harness can stop the Robot after the device effect and
+before the journal/result write, then deliver independent evidence that is present, delayed,
+absent or ambiguous.
+
+The same fixture includes virtual-time propagation and queueing delays. A run claiming a
+fifteen-minute delay must configure and record at least 900 seconds of one-way transit; a
+900-second blackout alone is not such evidence. The run also varies direction/asymmetry and
+validity so that admission, execution and expiry are evaluated at the receiving site rather than
+inferred from a link profile name.
+
+M1.8 closes when deterministic evidence shows that:
+
+- an independently observed effect is recognized without replaying it;
+- absent or ambiguous external evidence yields `OUTCOME_UNKNOWN` (or the documented equivalent)
+  and no blind duplicate effect;
+- a long-delay run records virtual transit, local queue age, validity and the resulting decision;
+- restart and retransmission do not reset the effect identity or autonomy budget.
+
+No hardware-control path is introduced by this increment.
 
 ## M2 — Mathematical SO-101 twin in Unreal
 
 Status: **implementation in progress; M2.1 structural description complete**
+Target release: **`v0.2.0`**
 
 - textual robot description;
 - forward kinematics, Jacobian and constrained damped-least-squares IK in C++;
 - separate rigid link meshes, without a skeletal mesh;
 - Blueprint-accessible target authoring and debugging;
-- confirmed, arrival and target representations;
-- trajectory lines and temporal markers.
+- confirmed, arrival and target representations with causal provenance;
+- trajectory lines and temporal markers;
+- a `KinematicPreview` that remains a local candidate, not an execution command.
 
-## M3 — Autonomous delayed button press
+M2 is a mathematical and visualization milestone. `v0.2.0` requires no physical robot, hardware
+calibration or hardware-control path. M2 must preserve the distinction between an operator goal,
+a local kinematic preview, a Field admission and a Robot result. See the [M2 design](docs/design/M2_SO101_MATHEMATICAL_TWIN.md)
+and the [delayed-intent validation design](docs/design/DELAYED_INTENT_VALIDATION.md).
 
-First five-month success boundary.
+## M3 — Autonomous delayed button press with bounded re-anchoring
 
-- known and calibrated button fixture;
-- independently instrumented button state;
-- measured SO-101 mirror in Unreal;
-- autonomous local `PressButton` skill;
-- explicit interruption/cancellation semantics;
-- delayed operation admission, execution and reconciliation;
-- both robot-estimated and independent hardware success evidence.
+Status: **planned; complete only after M3a and M3b**
+
+M3 is the next behavioral boundary. It brings a deliberately bounded slice of the later M4/M5
+ideas into the first button experiment so that delay changes the knowledge available to the local
+decision. It does not attempt robot-agnostic generalization or open-ended autonomy.
+
+### M3a — Deterministic simulation gate
+
+M3a uses a known, instrumented two-button simulation fixture and an independently recorded fake
+external effect. Its bounded rules are:
+
+- target identity is explicit; a same-identity displacement within a declared tolerance may be
+  re-anchored and executed;
+- substitution of a visually similar button is forbidden; unresolved identity or ambiguity must
+  trigger observation, hold or an assistance request;
+- an already acquired effect is recognized according to the task's effect semantics;
+- late cancellation is represented as a request for a future decision, with explicit outcomes for
+  pre-effect cancellation, safe interruption, effect already produced and unknown result;
+- local execution consumes a durable attempt/time/action budget and can continue safely without
+  Mission connectivity;
+- Robot-estimated and independent effect evidence are reported separately;
+- the same low-level controller, budget and delay schedule are used for a fixed-skill baseline,
+  delayed 2D authoring and delayed VR authoring; the 2D and VR variants share the same bounded
+  local decision policy.
+
+The deterministic scenario/oracle matrix in the [validation design](docs/design/DELAYED_INTENT_VALIDATION.md)
+is the M3a gate. S0–S10 must pass with zero unauthorized target substitutions and zero duplicate
+effects in the simulation fixture. M3a provides simulation evidence only and makes no physical
+hardware claim.
+
+### M3b — Calibrated physical-fixture gate
+
+M3b is a separate planned gate for the first bounded physical claim. It requires:
+
+- a calibrated SO-101 and a measured mirror of its articulated state in Unreal;
+- a real two-button fixture with each button instrumented and an independent effect register;
+- the local `PressButton` skill, an independent local stop mechanism and documented conservative
+  test conditions validated before delayed trials;
+- the M3a oracles transposed to the physical fixture, with Robot evidence and independent fixture
+  evidence recorded separately for every result.
+
+M3 is complete only when M3a and M3b both pass. M3b remains planned and does not promote the
+simulation evidence or the `v0.1.0` dummy release into a hardware claim.
 
 ## M4 — Robot-agnostic intent and Field assignment
 
-Stretch goal for the first cycle.
+Status: **planned after complete M3a + M3b evidence**
 
-- VR-designated target rebound against the Field operational estimate;
+- VR-designated target rebound against the Field operational estimate beyond the two-button rule;
 - typed procedure templates and capability registry;
 - robot-independent `OperationIntent`;
 - Field grounding, assignment and deterministic validation;
-- optional non-authoritative LLM proposal adapter.
+- optional non-authoritative LLM proposal adapter, excluded from safety and acceptance oracles.
+
+The broad identity, capability and substitution problem belongs here after the bounded M3 rule has
+shown which decisions are useful. M4 does not retroactively change the `v0.1.0` contract.
 
 ## M5 — Adapt, acquire context, or hold
 
-- bounded autonomy envelope and plan revisions;
+Status: **planned after M3/M4 evidence**
+
+- bounded autonomy envelopes and plan revisions;
 - evidence ladder for context acquisition;
 - targeted world deltas and incident bundles;
-- tiered robot/Field/Mission telemetry;
-- assistance request containing selected evidence and attempted recovery.
+- tiered Robot/Field/Mission telemetry;
+- assistance requests containing selected evidence and attempted recovery.
+
+M5 generalizes the M3 hold/observe decision to broader tasks. Its future context-acquisition and
+replanning policies must retain explicit authorization, effect identity and causal lineage.
+
+## Version and evidence boundaries
+
+`v0.1.0` remains the historical M1 release. The M1.7a, M1.7, M1.8, M3a and M3b design increments do not
+retroactively add capabilities or evidence to that tag. `v0.2.0` remains the M2 target and is
+closed by mathematical, cross-language and visualization evidence; it does not require a physical
+SO-101 or claim hardware control.
+
+Every status claim in this roadmap is either marked complete with the evidence already recorded by
+the project or marked planned/in progress. A design document, fixture or proposed oracle is not
+reported as an implementation result.
 
 ## Later research tracks
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,25 @@
 # Project status
 
-This file separates what exists from what is planned.
+This file separates demonstrated behavior from design work that is planned or still in
+progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
+
+## Status at a glance
+
+| Slice | State | Evidence boundary |
+|---|---|---|
+| M0 | **Implemented** | Public foundation, protocol vocabulary, CI and Unreal module skeleton |
+| M1 | **Implemented; `v0.1.0` historical** | Delay-tolerant dummy, persistence, replay and Mission reconciliation |
+| M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
+| M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
+| M1.8 | **Planned** | Independent external-effect evidence and virtual long-delay proof |
+| M2 | **In progress; target `v0.2.0`** | M2.1 structural model is complete; FK, articulated Unreal state, IK and authoring remain |
+| M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
+| M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
+
+M1.7a, M1.7, M1.8 and the enriched M3a/M3b slices are specified in the [delayed-intent
+validation design](design/DELAYED_INTENT_VALIDATION.md). M1.7a is implemented in
+[PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30); the other new gates remain
+planned and are not established by the design document.
 
 ## Implemented in M0
 
@@ -50,6 +69,10 @@ The exact commands, environment and visible evidence are recorded on bootstrap p
 - Unreal Engine 5.8.2 validation on Windows, the reference Unreal platform for `v0.1.0`;
 - portable Python validation on Linux through GitHub CI.
 
+The [M1 release gate](m1/RELEASE_GATE.md) records the evidence for this historical release.
+It covers the constrained dummy path. It does not cover stale-world target decisions, an
+independent external effect, or concurrent-operation causal coherence.
+
 ## Implemented in M2
 
 - pinned, unmodified SO-101 structural URDF with immutable source identity and licence metadata;
@@ -57,16 +80,102 @@ The exact commands, environment and visible evidence are recorded on bootstrap p
 - explicit arm and gripper joint groups plus the `gripper_frame_link` tool frame;
 - offline source-hash, structure and generated-description drift checks on Linux and Windows.
 
+The remaining M2 work is described in the [M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md).
+Its target is `v0.2.0`; it remains a mathematical and visualization milestone and does not
+require a physical robot.
+
+## Implemented in M1.7a
+
+The [selection contract](m1/MISSION_OPERATION_SELECTION.md) documents this bounded correction.
+All 72 Python tests, Ruff and the unchanged M1 CI release gate passed in
+[PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30).
+
+- validation of the operation/correlation mapping among Mission outbox intents, with latest-intent
+  selection by `MAX(created_at, str(message_id))`;
+- distinct operation IDs sharing a correlation, or one operation using several correlations, raise
+  `MissionViewSelectionError`; duplicate delivery of one operation/correlation remains allowed;
+- snapshot, forecast and terminal-event layers filtered to the selected operation/correlation;
+- frame, calibration or robot mismatches in snapshot/forecast/target projection represented as
+  absent/unknown layers; terminal events have no frame;
+- existing `dtt/0` golden and Unreal Mission-view evidence preserved;
+- no claim of complete lineage or multi-operation coherence.
+
 ## Planned, not implemented
 
-- VR interaction and headset-specific presentation (the desktop Unreal visualization exists);
-- SO-101 forward kinematics, articulated Unreal visualization, IK and hardware integration;
-- Simulation Worker;
-- LeRobot integration;
-- learned policies or LLM planning.
+### M1.7 full lineage gate
+
+- operation/intent-revision lineage on every Mission-view branch, with compatibility checks across
+  two concurrent operations and reordered delivery;
+- explicit handling for missing or incompatible parent references;
+- deterministic machine-readable and visible evidence without cross-operation association.
+
+### M1.8 external effect and long-delay gate
+
+- a deterministic external device whose effect evidence is independent of the Robot journal;
+- crash-window recovery that recognizes an observed effect or reports an unknown result without
+  blind replay;
+- virtual-time long-delay runs that distinguish propagation from blackout, queue age, validity and
+  expiry.
+
+### Remaining M2 work
+
+- forward kinematics and Jacobian in C++;
+- constrained damped-least-squares IK with explicit status and residuals;
+- articulated Unreal link visualization and cross-language golden evidence;
+- desktop/VR target authoring and time-sampled `KinematicPreview`;
+- available provenance connecting confirmed, arrival and target branches, with missing references
+  shown explicitly and without treating a preview as an execution command; complete multi-operation
+  lineage remains the later M1.7 gate.
+
+### M3a simulation gate
+
+- known two-button simulation fixture with explicit identity and independently recorded effect
+  state;
+- S0–S10 scenario/oracle rows with exact target, action/outcome and effect-counter invariants;
+- authorized same-identity displacement, with no substitution when buttons are swapped or
+  indistinguishable;
+- observation/hold decisions for ambiguity, missing targets, obstacles and exhausted budgets;
+- already-acquired-effect and late-cancellation outcomes;
+- controlled comparison of a fixed-skill baseline, delayed 2D authoring and delayed VR authoring
+  under the same local autonomy and controller;
+- simulation evidence only; no physical-hardware claim.
+
+### M3b physical-fixture gate
+
+- calibrated SO-101 with a measured articulated mirror in Unreal;
+- real two-button fixture, independent button instrumentation and an independent effect register;
+- `PressButton` skill, independent local stop and conservative test conditions validated before
+  delayed trials;
+- M3a oracles transposed to the physical fixture, with Robot and independent fixture evidence
+  recorded separately for every result.
+
+M3 remains incomplete until both M3a and M3b pass. Neither gate is currently implemented.
+
+### Later M4/M5 work
+
+- VR target rebinding beyond the bounded two-button rule;
+- capability registry, typed procedure templates and robot-independent intent;
+- broader context acquisition, plan revision, incident bundles and assistance requests;
+- optional non-authoritative LLM proposals, excluded from the first decision oracle and safety gate;
+- Simulation Worker, LeRobot integration and learned policies.
+
+## Evidence boundary
+
+This documentation update introduces no runtime implementation or hardware path. M1.7a has the
+separate implementation and validation cited above; the broader scenario matrix remains planned.
+A milestone is complete
+only after its deterministic replay, machine-readable artifacts and visible result satisfy the
+gate in the [roadmap](../ROADMAP.md).
+
+This documentation change does not close M1.7 or M3. M3a remains a future simulation gate, and
+M3b's physical-fixture evidence is not present.
+
+`v0.1.0` remains the historical M1 tag; later planned increments do not add capabilities to it.
+`v0.2.0` remains the M2 target and makes no physical SO-101 or hardware-control claim.
 
 ## Safety status
 
-No public hardware-control path exists. Nothing in the current repository should command a physical robot.
-The M1 release gate operates entirely on the public dummy path. Unreal Engine 5.8.2 is verified on
-the reference Windows platform; `v0.1.0` does not claim Unreal support on Linux.
+No public hardware-control path exists. Nothing in the current repository should command a
+physical robot. The M1 release gate operates entirely on the public dummy path. Unreal Engine
+5.8.2 is verified on the reference Windows platform; `v0.1.0` does not claim Unreal support on
+Linux.

--- a/docs/design/DELAYED_INTENT_VALIDATION.md
+++ b/docs/design/DELAYED_INTENT_VALIDATION.md
@@ -1,0 +1,418 @@
+# Delayed intent validation
+
+Status: **M1.7a implemented; remaining gates planned**
+Scope: **M1.7a, M1.7, M1.8, M3a and M3b**
+
+Related documents: [roadmap](../../ROADMAP.md), [project status](../STATUS.md), [canonical
+terminology](../concepts/TERMINOLOGY.md), [time and provenance](../concepts/TIME_FRAMES_AND_PROVENANCE.md),
+and the [M1 release gate](../m1/RELEASE_GATE.md).
+
+## 1. Purpose and boundary
+
+M1 proves a delayed, persistent dummy path. This design specifies the next proof: an operation
+must preserve the operator's intended target when the Field estimate is old, incomplete or
+contradictory. The local decision may execute, re-anchor within an explicit allowance, acquire
+one more observation, hold, recognize an effect already present, or report an unknown result.
+
+M1.7a is a bounded correction to Mission's current selection behavior. M1.7 then tests full
+causal coherence when two operations are in flight. M1.8 tests an external effect and long
+virtual delays. M3a uses the bounded rules on a known two-button simulation fixture; M3b later
+transposes the same oracles to a calibrated physical fixture. M1.7a is implemented in
+[PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30); the remaining gates are
+planned. No physical result is claimed until M3b passes.
+
+The design keeps the existing authority boundary:
+
+```text
+Mission: author and reconcile delayed intent and views
+Field:   ground, admit and coordinate against its local estimate
+Robot:   decide and execute locally within an admitted contract; report evidence
+```
+
+The SO-101 mathematical twin can provide a local target and `KinematicPreview`, but that preview
+is not an admission, an actuator command or proof of an external effect. M2 remains the
+mathematical/visualization target `v0.2.0` and does not require hardware.
+
+## M1.7a — Bounded Mission-view selection correction
+
+M1.7a is implemented and documented in the [Mission selection contract](../m1/MISSION_OPERATION_SELECTION.md).
+Its 72-test Python suite and CI passed with the historical golden session unchanged. It is
+deliberately smaller than the full lineage work that follows:
+
+- Mission chooses the latest intent globally with `MAX(created_at, str(message_id))`, then uses
+  that intent's `correlation_id` for view filtering;
+- view construction validates the mapping among Mission outbox intents: one `operation_id` must
+  map to one `correlation_id` and one `correlation_id` to one `operation_id`; this is not a global
+  protocol invariant enforced by Field or Robot;
+- duplicate deliveries with the same operation and correlation are allowed when the mapping is
+  unambiguous;
+- distinct operation IDs sharing a correlation, or one operation using several correlations, raise
+  `MissionViewSelectionError`; Mission never chooses one conflicting operation;
+- the selected operation and correlation filter snapshot, arrival forecast and terminal event; a
+  layer from another operation is never a fallback;
+- a `frame_id`, calibration-reference or `robot_id` mismatch in snapshot, forecast or target
+  projection makes the affected layer absent or unknown; terminal events have no frame and are not
+  subject to a frame mismatch check;
+- the existing `dtt/0` golden fixture and Unreal Mission-view behavior remain regression checks;
+- no complete lineage schema or multi-operation interpretation is claimed by this correction.
+
+M1.7a therefore establishes a stable bounded invariant; it does not close the full M1.7 gate.
+
+## 2. Hypothesis and controlled comparison
+
+At equal local autonomy, an intent that carries target identity, explicit adaptation limits and
+causal evidence should produce more conforming outcomes under stale-world changes, with no
+unauthorized substitutions or duplicate effects.
+
+The first comparison is the M3a simulation gate. It uses the same fixture, virtual-time schedule,
+Field decision table, Robot controller, retry budget and evidence recorder for every condition:
+
+| Variant | Difference under test |
+|---|---|
+| Fixed-skill baseline | A delayed fixed target is sent to the same local skill; no intent re-anchoring |
+| Delayed 2D authoring | The bounded intent is authored and reviewed in the desktop interface |
+| Delayed VR authoring | The same bounded intent is authored and reviewed in VR |
+| Optional prediction ablation | The same 2D or VR intent is shown without the arrival projection |
+
+The fixed-skill row is an explicit ablation of intent re-anchoring; it keeps the low-level Robot
+controller, timing and budget unchanged. The 2D and VR rows use the same bounded local decision
+policy and differ only in authoring/presentation. This keeps an interface comparison from adding
+autonomy by accident.
+
+The optional prediction ablation is descriptive and does not change the M3a correctness oracle.
+No variant receives extra autonomy because it uses VR, a preview or a prediction. Report at least
+conforming outcome rate, unauthorized adaptation, duplicate effect count, necessary and
+unnecessary holds, assistance requests, operator active time, end-to-end reconciliation delay and
+bytes per useful result.
+
+## 3. Minimal logical contract
+
+The following is a test vocabulary and semantic contract, not a frozen wire schema. Existing
+`OperationIntent`, `GroundedOperation`, `ExecutionContract` and `ExecutionEvent` types may carry
+these fields through their normal versioning rules.
+
+### 3.1 Delayed intent
+
+```text
+DelayedIntent
+- operation_id
+- intent_revision
+- target
+- reference_observation
+- requested_effect
+- allowed_adaptation
+- validity
+- cancellation_policy
+```
+
+The fields have these minimum meanings:
+
+```text
+target
+- target_identity          # stable fixture identity, for example button-A
+- target_role              # optional descriptive role; never a substitute identity
+
+reference_observation
+- observation_id
+- world_revision
+- observed_at
+- frame_id
+
+requested_effect
+- effect_id                # stable across retries and plan revisions
+- kind                     # PRESS_ONCE for this experiment
+
+allowed_adaptation
+- same_identity_only = true
+- max_displacement_m
+- substitution = FORBIDDEN
+
+validity
+- not_before
+- expires_at
+- max_local_duration
+
+cancellation_policy
+- cancellation_is_a_request = true
+- safe_interruption = required
+```
+
+`effect_id` identifies the requested external effect; a delivery or execution attempt has a
+separate attempt identity. Revising a plan or receiving a duplicate envelope must not create a
+new effect identity. The fixture's distance tolerance is declared before the run and is applied
+to the same target identity only.
+
+### 3.2 Observation and decision
+
+The receiving side records the observation it actually had, rather than copying the hidden
+fixture truth into a decision:
+
+```text
+Observation
+- observation_id
+- world_revision
+- observed_at
+- entities[]                # identity, role, pose, visibility and source evidence
+- source_ids
+- model_reference
+- calibration_reference    # explicit unavailable value is allowed in the simulated phase
+```
+
+Each decision is explainable and tied to one operation revision:
+
+```text
+LocalDecision
+- decision_id
+- operation_id
+- intent_revision
+- basis_observation_ids[]
+- target_identity          # absent when identity is unresolved
+- action
+- reason_code
+- budget_before
+- budget_after
+```
+
+Allowed actions for this experiment are `EXECUTE`, `REANCHOR_EXECUTE`,
+`ACQUIRE_OBSERVATION`, `HOLD`, `RECOGNIZE_EFFECT` and `CANCEL`. A hold can request assistance;
+it never silently becomes an execution.
+
+### 3.3 Independent effect evidence and outcome
+
+The fake button device has state or a monotonic effect counter stored independently of the Robot
+execution journal:
+
+```text
+EffectEvidence
+- effect_id
+- device_id
+- evidence_observation_id
+- device_counter_or_state
+- status                    # PRESENT, ABSENT, AMBIGUOUS or UNAVAILABLE
+- observed_at
+- provenance
+```
+
+The minimum outcome vocabulary distinguishes a physical result from a decision to stop looking:
+
+```text
+SUCCEEDED
+RECOGNIZED_ALREADY_EFFECTIVE
+CANCELLED_BEFORE_EFFECT
+INTERRUPTED_SAFE
+OUTCOME_UNKNOWN
+REJECTED_IDENTITY
+REJECTED_UNAUTHORIZED_DISPLACEMENT
+REJECTED_EXPIRED
+HELD_AMBIGUOUS
+```
+
+Robot-estimated completion, independent `EffectEvidence` and the final `Outcome` remain separate
+records. A missing terminal message or a released button does not prove that no press occurred.
+
+## 4. Causal bundle and authority rules
+
+Every Mission view branch and every decision evidence bundle is keyed by the following lineage:
+
+```text
+CausalBundle
+- operation_id
+- intent_revision
+- source_observation_id
+- source_world_revision
+- grounding_reference
+- forecast_reference       # optional; required only for an arrival projection
+- model_reference
+- calibration_reference
+- decision_reference
+- contract_revision
+- effect_id
+- effect_evidence_refs[]
+- outcome_reference
+```
+
+The rules are:
+
+1. A target, arrival forecast and terminal event may be assembled only when their operation,
+   intent revision and parent references are compatible.
+2. A late, duplicate or reordered event is idempotent by its semantic identity and cannot attach
+   to a different operation because it arrived last.
+3. A missing or incompatible parent remains missing or incompatible. Mission exposes `UNKNOWN`
+   or `INCOMPATIBLE_CONTEXT` instead of borrowing a value from another operation.
+4. A new world, model or calibration revision invalidates only descendants that cite it. It does
+   not silently rewrite an unrelated operation.
+5. Field's admission authorizes a bounded contract; it is not independent proof that the physical
+   effect happened. Robot may refuse or hold when local evidence violates the contract.
+6. A cancellation delivered after admission is a request for a future local decision. It cannot
+   erase an effect already produced or reset a consumed budget.
+
+The hidden fixture truth and device counter are recorded independently of Mission, Field and
+Robot. The decision process receives only the observations scheduled for that condition, so an
+oracle cannot pass by reading a test-only world state.
+
+## 5. Deterministic local decision policy
+
+The first implementation uses a small explicit table. It does not require an LLM, a learned
+policy, dense reconstruction or a generic robot adapter.
+
+| Local condition | Required action/outcome | Forbidden behavior |
+|---|---|---|
+| Same identity, within the recorded reference tolerance | `EXECUTE`; use the observed pose | Selecting another entity because it is closer |
+| Same identity displaced within `max_displacement_m` | `REANCHOR_EXECUTE` and record the displacement | Treating the displacement as permission to change identity |
+| Same identity displaced beyond the allowance | `HOLD` or `REJECTED_UNAUTHORIZED_DISPLACEMENT` | Executing on an unapproved pose |
+| Two compatible-looking buttons or unresolved identity | `ACQUIRE_OBSERVATION`, then `HELD_AMBIGUOUS` if unresolved | Guessing from proximity, appearance or arrival order |
+| Target absent, occluded or observation too old to support the rule | `ACQUIRE_OBSERVATION` or `HOLD` | Inventing a measured pose from a forecast |
+| Independent evidence says `effect_id` is already present | `RECOGNIZE_EFFECT` / `RECOGNIZED_ALREADY_EFFECTIVE` | Pressing again |
+| Contact or attempt occurred but independent evidence is absent/ambiguous | `OUTCOME_UNKNOWN` and no blind retry | Reporting success from the Robot journal alone |
+| Cancellation received before effect | `CANCEL` / `CANCELLED_BEFORE_EFFECT` | Starting the cancelled effect |
+| Cancellation received during execution | Stop at the next safe boundary; report `INTERRUPTED_SAFE`, effect already produced, or unknown | Claiming that the request stopped a past effect |
+| Cancellation received after effect | Report effect already produced or unknown | Reversing or hiding the effect as compensation |
+| Validity expired before admission | `REJECTED_EXPIRED` | Dispatching an expired intent |
+| Obstacle, local safety violation or exhausted durable budget | `HOLD` with reason and evidence | Resetting a budget after restart or revision |
+
+`EXECUTE` and `REANCHOR_EXECUTE` are permitted only for the target identity in the intent. For
+the two-button fixture, swapping A and B is therefore a negative identity test even when the
+buttons have identical geometry and role labels.
+
+## 6. Scenario and oracle matrix
+
+The matrix is deterministic: each row fixes the initial fixture, event schedule, virtual clocks,
+message order and expected oracle. A row passes only when the action, target identity, outcome,
+effect counter and causal references match the stated result.
+
+| ID | Slice | Injected condition | Expected oracle | Required invariant |
+|---|---|---|---|---|
+| A1 | M1.7a | Two distinct operation IDs in Mission's outbox share one `correlation_id` | `MissionViewSelectionError`; assemble no Mission view | Reject the ambiguous mapping during view construction |
+| A2 | M1.7a | One operation ID in Mission's outbox is presented with more than one `correlation_id` | `MissionViewSelectionError`; assemble no Mission view | Reject the ambiguous mapping during view construction |
+| A3 | M1.7a | The selected operation/correlation has a frame, calibration or robot mismatch in snapshot, forecast or target projection; its terminal event is otherwise valid | Mark only the affected projection layer absent/unknown; filter the terminal event by operation/correlation | Terminal events have no frame; no incompatible projection is borrowed |
+| A4 | M1.7a | Valid operations use distinct correlations; envelopes are delivered out of order | Select the intent with global `MAX(created_at, str(message_id))`, then filter only its correlation | Selection is independent of arrival order |
+| A5 | M1.7a | Duplicate envelopes repeat one unambiguous operation/correlation mapping | Select that operation/correlation without an error | Same operation/correlation duplicates remain idempotent |
+| C1 | M1.7 | Operations A and B are admitted; intents, forecasts and terminal events arrive in reverse order | Two independent bundles, each reconciled to its own operation | No target/forecast/result cross-association |
+| C2 | M1.7 | Duplicate delivery and reconnect occur after a model or calibration revision | Same decision identity after replay; incompatible descendants remain explicit | No duplicate decision or borrowed latest state |
+| S0 | M3a | Button A is unchanged from the reference observation | `EXECUTE` A; `SUCCEEDED` after independent effect evidence | Exactly one `effect_id` and one counter increment |
+| S1 | M3a | Button A moves within the declared authorized displacement | `REANCHOR_EXECUTE` A; `SUCCEEDED` | Same identity is retained; displacement is recorded |
+| S2 | M3a | Buttons A and B exchange positions while the intent names A; the bounded follow-up observation cannot distinguish them | `HELD_AMBIGUOUS` | Zero unauthorized substitution and zero B effect |
+| S3 | M3a | A is hidden or identity evidence remains ambiguous | `HELD_AMBIGUOUS` after the bounded observation attempt | No guessed target and no effect |
+| S4 | M3a/M1.8 | Independent device counter shows A's `effect_id` already present before arrival | `RECOGNIZED_ALREADY_EFFECTIVE` | Counter is not incremented a second time |
+| S5 | M1.8 | Robot causes the device effect, then stops before journal/result persistence; evidence later says `PRESENT` | `RECOGNIZED_ALREADY_EFFECTIVE` | Recovery does not replay the effect |
+| S6 | M1.8 | Same crash window, but evidence is `AMBIGUOUS` or `UNAVAILABLE` | `OUTCOME_UNKNOWN`; hold for controlled evidence | No blind retry and no false success |
+| S7 | M3a | Cancellation arrives before contact/effect | `CANCELLED_BEFORE_EFFECT` | No effect for the cancelled `effect_id` |
+| S8 | M3a | Cancellation arrives during execution before the effect and a safe boundary is available | `INTERRUPTED_SAFE` | No effect is reported for the cancelled `effect_id` |
+| S9 | M3a | Cancellation arrives after independent effect evidence says `PRESENT` | `RECOGNIZED_ALREADY_EFFECTIVE` | Never claim cancellation erased a past effect |
+| S10 | M3a | Obstacle or local budget exhaustion appears during execution; Robot restarts | Safe `HOLD` and durable remaining budget | Restart cannot reset attempts, time or action allowance |
+| L1 | M1.8 | Virtual one-way transit is at least 900 seconds, with queue age and asymmetry recorded; validity includes admission | `EXECUTE` A and `SUCCEEDED` after independent effect evidence | A blackout label alone cannot count as a long-delay proof |
+| L2 | M1.8 | The same recorded transit reaches Field after `expires_at` and before admission | `REJECTED_EXPIRED` | No dispatch and no effect for the expired `effect_id` |
+
+For A1–A5, the oracle checks the bounded selection correction only; it does not establish complete
+lineage for multiple operations. For S2, the oracle is fixed before the run: identity A remains
+authorized, and proximity or visual similarity cannot authorize B. For S5 and S6, the device
+counter is the independent reference; the Robot journal is deliberately insufficient. For S9, the
+positive device evidence is delivered before the cancellation is processed, so the expected result
+is fixed. For L1, a shorter or unrecorded transit run may
+still test transport, but cannot be reported as the fifteen-minute propagation evidence.
+
+## 7. Replay procedure and evidence
+
+The planned harness will:
+
+1. seed operation, intent, message and device identities;
+2. set a virtual monotonic timeline and record source/produced/arrival times separately;
+3. generate the hidden fixture truth and independent device log before releasing only the
+   scheduled observations to the three authorities;
+4. inject delay, queueing, duplication, reorder, reconnect, crash and cancellation events;
+5. compare each decision and outcome with the matrix oracle;
+6. emit machine-readable causal bundles, decision reasons, budget transitions, effect counters and
+   a Mission-view artifact suitable for human inspection.
+
+The long-delay configuration must state one-way and return transit, blackout intervals, local
+queue age, clock uncertainty and intent validity. A virtual 900-second transit is an evidence
+parameter, not a calendar deadline. For M3a, physical hardware, engine startup and actuator motion
+are outside the validation run.
+
+### M3b physical transposition
+
+M3b is a separate planned physical-fixture procedure. Before delayed trials, it must record a
+calibrated SO-101 and its measured articulated mirror in Unreal, a real two-button fixture with
+independent button instrumentation and an independent effect register, and a validated local
+`PressButton` skill with an independent local stop and documented conservative test conditions.
+The S0–S10 M3a oracles are then transposed without changing target-identity or effect semantics.
+Each physical result must include Robot evidence and independent fixture/effect-register evidence;
+an event from either source alone is insufficient. This gate creates a narrowly scoped physical
+result for the documented fixture and conditions, not a general hardware-safety claim.
+
+## 8. Acceptance gates
+
+There is no date-based gate. The following artifacts and invariants close the increments:
+
+### M1.7a gate
+
+- deterministic replay passes A1–A5;
+- the latest intent is selected globally with `MAX(created_at, str(message_id))`, then its
+  correlation is used for filtering;
+- the mapping among Mission outbox intents is validated during view construction; conflicting
+  operation/correlation mappings raise `MissionViewSelectionError` and assemble no Mission view;
+- duplicate delivery of one unambiguous operation/correlation mapping remains idempotent;
+- snapshot, forecast and terminal layers are filtered to the selected operation/correlation;
+- frame, calibration or robot mismatches in snapshot/forecast/target projection produce
+  absent/unknown layers without fallback; terminal events have no frame;
+- the existing `dtt/0` golden session and Unreal Mission-view checks remain unchanged;
+- the result is reported as a bounded correction only, with no complete lineage claim.
+
+### M1.7 full gate
+
+- deterministic two-operation replay passes C1 and C2;
+- every view and event has operation and intent-revision lineage;
+- no cross-operation association occurs under reversal, duplication or reconnect;
+- missing, stale or incompatible context is visible as such in machine-readable and Mission-view
+  evidence.
+
+### M1.8 gate
+
+- S4–S6 prove independent effect recognition and the unknown-result path across the journal crash
+  window;
+- L1 and L2 contain recorded virtual one-way transit of at least 900 seconds and separate
+  propagation from blackout and local queue time;
+- expiry and admission decisions use the receiving-side evidence and do not silently reset the
+  effect identity or autonomy budget;
+- no duplicate external effect is produced in replay.
+
+### M3a simulation gate
+
+- S0–S10 pass with the exact target identity, action/outcome and effect-counter invariants;
+- the two-button swap and ambiguity cases produce no unauthorized action;
+- late cancellation is reported according to observed effect state;
+- fixed-skill, delayed 2D and delayed VR variants run with the same low-level controller, budget,
+  fixture and delay schedule; the 2D and VR variants also use identical bounded local autonomy,
+  with metrics and failures retained for comparison;
+- the gate is simulation-only and makes no physical-hardware claim.
+
+### M3b physical-fixture gate
+
+- a calibrated SO-101 and measured articulated mirror are recorded in Unreal;
+- the real two-button fixture, independent button instrumentation and independent effect register
+  are validated under the declared test conditions;
+- the local `PressButton` skill and independent local stop are validated before delayed trials;
+- the S0–S10 M3a oracles are transposed with physical Robot evidence and independent fixture
+  evidence recorded separately for every result;
+- no physical result is accepted from a Robot event or fixture register alone.
+
+### M3 completion rule
+
+M3 is complete only when both M3a and M3b pass. This documentation does not close M1.7 or M3;
+M3a and M3b remain planned gates until their respective artifacts and evidence exist.
+
+## 9. Scope limits
+
+The first proof has two instrumented buttons, stable fixture identities, bounded displacement and
+deterministic observations. It establishes whether explicit authorization, abstention and causal
+reconciliation work in this narrow setting. It does not establish general visual identity,
+robot-agnostic task transfer, multi-robot coordination, learned policies or safety certification.
+
+M3a is simulation-only and cannot be reported as physical evidence. M3b may support a physical
+claim only for the calibrated SO-101, documented two-button fixture and validated test conditions
+that pass its gate; M3 is complete only when both gates pass.
+
+Broader capability registries, context acquisition and plan revision remain M4/M5 work. An
+optional LLM adapter may later propose a grounding or explanation, but it is excluded from the
+M1.7a/M1.7/M1.8/M3a/M3b decision oracles and cannot grant authorization. The historical `v0.1.0`
+M1 release and the hardware-free `v0.2.0` M2 target keep their existing evidence boundaries.

--- a/docs/design/M2_SO101_MATHEMATICAL_TWIN.md
+++ b/docs/design/M2_SO101_MATHEMATICAL_TWIN.md
@@ -1,15 +1,22 @@
 # M2 design — SO-101 mathematical twin and VR kinematic authoring
 
-Status: **implementation in progress**  
-Parent epic: [#12](https://github.com/YannickPr/Deferred-Teleoperation/issues/12)  
-Target release: `v0.2.0`  
+Status: **implementation in progress**
+Parent epic: [#12](https://github.com/YannickPr/Deferred-Teleoperation/issues/12)
+Target release: `v0.2.0`
 Last reviewed: 2026-09-04
+
+Related validation boundary: [delayed-intent validation design](DELAYED_INTENT_VALIDATION.md).
 
 ## 1. Purpose
 
 M2 replaces the M1 dummy geometry with a tested mathematical SO-101 twin. It lets an operator author an end-effector goal in desktop or VR, solve a bounded kinematic problem and inspect a time-sampled preview.
 
 M2 is deliberately not a physics or hardware milestone.
+
+The goal and preview are local authoring artifacts. They do not admit work, issue an actuator
+command or prove an external effect. A later explicit protocol step must carry the goal into an
+`OperationIntent`, where Field can apply the bounded delayed-intent rules and Robot can make a
+local execution decision. The M2 target remains `v0.2.0` and requires no physical SO-101.
 
 ```text
 named articulated state
@@ -50,6 +57,8 @@ M2 does not implement:
 - dense environment reconstruction;
 - a generic runtime URDF importer;
 - an exact arbitrary six-degree-of-freedom IK claim.
+- deciding whether a delayed target still identifies the intended object;
+- admitting, executing, cancelling or confirming an external effect.
 
 A result produced in M2 is a `KinematicPreview`, never a certified or collision-safe `MotionPlan`.
 
@@ -511,13 +520,47 @@ Wire order has no semantic meaning. Runtime code validates names against the mod
 
 The gripper must not be smuggled into the same field using a normalized 0-100 value. Either omit it from the first arm-state fixture or define a distinct typed actuator-state domain.
 
-Mission view data carries three articulated states with independent provenance:
+Mission view data carries three articulated states with available provenance; complete
+multi-operation lineage is a later M1.7 concern:
 
 ```text
 confirmed_robot_state
 arrival_robot_state
 target_robot_state
 ```
+
+### 13.1 Available references for the three state layers
+
+The three layers are categories of knowledge, not interchangeable snapshots. M2 prepares and
+displays the references available in the current articulated `dtt/0` state; it does not require
+the complete lineage schema planned for M1.7. When references are available, a delayed operation's
+branch may carry this compact record:
+
+```text
+CausalLineage
+- operation_id
+- intent_revision
+- source_observation_id
+- source_world_revision
+- forecast_id                  # when available; absence is displayed explicitly
+- model_reference
+- calibration_reference        # explicit unavailable value is valid in M2
+- parent_state_reference
+```
+
+`CONFIRMED` points to received Robot evidence, `ARRIVAL` points to the observation and forecast
+used for its conditional projection, and `TARGET` points to the local goal and its source
+observation. A target goal without a source observation remains a local draft and is shown with
+that reference missing; it cannot be mislabeled as confirmed or arrival state. Missing or
+incompatible references are rendered as unknown or incompatible, never filled from the latest
+item belonging to another operation.
+
+M2 performs these limited association checks and displays available/missing references. It does
+not implement the full multi-operation lineage gate, Field admission, Robot execution or the
+effect oracle. The implemented M1.7a correction handles bounded Mission selection; M1.7 later closes
+the full lineage behavior. The M2 `v0.2.0` mathematical gate does not depend on that future
+schema. The multi-operation and external-effect cases are defined in the [delayed-intent
+validation design](DELAYED_INTENT_VALIDATION.md).
 
 ## 14. IK task model
 
@@ -598,9 +641,19 @@ EndEffectorGoal
 - desired_approach_axis
 - reference_frame
 - authored_at
+- source_observation_id       # when available; missing is shown explicitly
+- model_reference             # required for the kinematic calculation
+- causal_lineage              # available references, not a complete M1.7 schema
 ```
 
 The target object's Unreal transform crosses the Unreal/canonical boundary once. The solver never consumes an Unreal world transform directly.
+
+`EndEffectorGoal` remains a local draft until an explicit authoring action creates an
+`OperationIntent`. That conversion must preserve the source observation, target identity and
+constraints required by the delayed-intent contract; a successful IK solve is not an admission.
+The interface must keep draft, submitted, admitted, adapted, held and completed states visually
+distinct. A candidate trajectory may differ from the trajectory later selected by Robot while
+still satisfying the admitted constraints.
 
 Required interaction behavior:
 
@@ -639,6 +692,13 @@ duration = max_i(abs(q_target_i - q_start_i) / preview_velocity_i)
 with configured minimum duration and a smooth interpolation parameter for visual continuity. Preview velocity limits are presentation/planning assumptions, not validated hardware limits.
 
 Every tool sample is recomputed through FK. Rendering may interpolate the committed samples, but the original samples remain inspectable.
+
+The preview records its `model_reference`, available source observation and generation status;
+missing references are shown explicitly. It is conditional on those inputs and may become stale
+before a delayed intent is admitted. No preview sample is an actuator command, an external-effect
+assertion or a collision/safety guarantee. The M2 release gate therefore checks mathematical
+reproducibility and operator-visible available provenance; full stale-world decisions and
+multi-operation lineage belong to the later [validation matrix](DELAYED_INTENT_VALIDATION.md).
 
 ## 17. Dependency graph
 
@@ -725,6 +785,18 @@ Mitigation: warm starts, update-rate cap, coalescing, bounded steps, rich status
 
 Mitigation: debug primitives are the mathematical release baseline; visual pack is parallel and removable.
 
+### Causal branches are mixed across operations
+
+Mitigation: M2 displays available operation, observation, forecast and model references and marks
+missing values; M1.7 later carries the complete intent-revision lineage and rejects incompatible
+bundles instead of selecting a convenient latest value. The deterministic two-operation replay is
+a later validation gate.
+
+### Preview is mistaken for an execution order
+
+Mitigation: keep local goal, submitted intent, Field admission and Robot outcome as separate
+states; label `KinematicPreview` as conditional and preserve its provenance.
+
 ### M1 protocol compatibility
 
 Mitigation: M2 math/model work remains independent. The articulated protocol extension builds on
@@ -748,6 +820,7 @@ Mitigation: consistently call the result `KinematicPreview`; document absent col
 - passing canonical/Unreal conversion tests;
 - explicit tool frame;
 - confirmed/arrival/target articulated states;
+- available state references and explicit missing-reference labels;
 - position-only and approach-axis IK with residual/status reporting;
 - time-sampled KinematicPreview;
 - desktop and VR visible evidence;
@@ -757,6 +830,9 @@ Mitigation: consistently call the result `KinematicPreview`; document absent col
 - documentation that accurately excludes physics, collision and safety guarantees.
 
 High-fidelity static meshes are desirable but do not override mathematical correctness. A debug-geometry build remains a supported fallback.
+This is an M2 gate only: it does not retroactively change the historical `v0.1.0` M1 release or
+claim completion of M1.7a, M1.7, M1.8, M3a or M3b. Full multi-operation lineage is a later M1.7
+gate. No physical robot or hardware-control path is required.
 
 ## 22. Open decisions intentionally deferred
 


### PR DESCRIPTION
The first delayed physical operation needs to identify its target again and decide when to request context or hold. The roadmap now makes these bounded requirements part of M3, retains M2's mathematical twin, and specifies multi-operation view and external-effect recovery work.

The delayed-intent validation design defines a two-button benchmark, long-delay scenarios, and desktop/VR comparisons with equal local autonomy. It separates the first correlation-scoped view correction from the later complete lineage gate, and the M3 simulation prerequisite from the physical fixture gate. Historical M1 evidence remains separate from these planned acceptance criteria.

The status document records the M1.7a correction already merged in #30; the complete lineage, external-effect and physical-fixture gates remain open.

Validation: documentation review against the current implementation and an independent critical review. No runtime or protocol changes; no physical hardware used.

Closes #31.
