### PR TITLE
feat(runtime): reconcile uncertain external effects without replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ### Added
 
+- experimental external-effect recovery with a separate persistent simulated button, durable
+  device binding, observe-only recovery after uncertain dispatch, and immutable outcome evidence;
+- explicit historical dummy-fixture compatibility; normal Field reconciliation requires compatible
+  Robot telemetry instead of manufacturing a measured completion pose from a terminal event.
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
 
 ## 0.1.0 - 2026-09-04

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,11 +96,18 @@ general perception system. M1.7a is a prerequisite correction, not a substitute 
 
 ## M1.8 — External effect and long-delay evidence
 
-Status: **in progress; virtual-time dummy domain tests implemented**
+Status: **in progress; external-effect recovery and virtual-time dummy domain tests implemented**
 
 The [long-delay domain tests](docs/m1/LONG_DELAY_DOMAIN.md) cover 0, 30, 900 and 1200 seconds
 of one-way transit, blackout, expiry and persisted-service restart. They use the M1 dummy effect;
 the combined independent-device, delayed-intent and durable-budget gate below remains open.
+
+The [external-effect recovery proof](docs/m1/EXTERNAL_EFFECT_RECOVERY.md) separately exercises
+a non-idempotent simulated device with its own persistent record. Robot binds the device at
+dispatch, observes after uncertain dispatch instead of repeating the action, and holds when the
+outcome is unknown or not applied. Missing or substituted adapters are rejected during recovery.
+This experimental injection path does not yet combine the independent device with the long-delay
+scenario, stable effect identity across plan revisions, or a durable autonomy budget.
 
 M1.8 adds the smallest deterministic proof that a recorded execution event is not itself proof
 of an external effect. A fake button device keeps an effect counter or state in storage separate

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1 | **Implemented; `v0.1.0` historical** | Delay-tolerant dummy, persistence, replay and Mission reconciliation |
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
-| M1.8 | **In progress** | Virtual-time dummy domain tests implemented; combined independent-effect gate remains open |
+| M1.8 | **In progress** | External-effect recovery and virtual-time dummy tests implemented separately; combined gate remains open |
 | M2 | **In progress; target `v0.2.0`** | M2.1 structural model is complete; FK, articulated Unreal state, IK and authoring remain |
 | M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
@@ -109,17 +109,25 @@ All 72 Python tests, Ruff and the unchanged M1 CI release gate passed in
 - explicit handling for missing or incompatible parent references;
 - deterministic machine-readable and visible evidence without cross-operation association.
 
-### M1.8 external effect and long-delay gate
+### M1.8 combined external-effect and long-delay gate
 
 The [long-delay domain tests](m1/LONG_DELAY_DOMAIN.md) already exercise the real M1 services
-and deterministic link with up to 1200 seconds of one-way transit. This is supporting dummy
-evidence; the following combined gate remains unimplemented:
+and deterministic link with up to 1200 seconds of one-way transit. Separately, the
+[external-effect recovery proof](m1/EXTERNAL_EFFECT_RECOVERY.md) uses a persistent simulated
+device outside the Robot journal. Dispatch binds its identity durably; recovery observes without
+blind replay and rejects a missing or substituted adapter. An unknown outcome remains held, and
+a terminal event alone does not manufacture measured completion telemetry in the normal Field.
 
-- a deterministic external device whose effect evidence is independent of the Robot journal;
-- crash-window recovery that recognizes an observed effect or reports an unknown result without
-  blind replay;
-- virtual-time long-delay runs that distinguish propagation from blackout, queue age, validity and
-  expiry.
+The integrated Python suite passes 109 tests. Regenerating the historical golden session in a
+separate directory also reproduced all six committed files byte for byte. Its explicit dummy
+fixture compatibility is documented; it is not an external observation guarantee.
+
+The remaining combined gate requires:
+
+- the independent device exercised through the delayed domain, including asymmetric transit,
+  queue age, validity, expiry and restart;
+- stable effect identity across plan revisions and durable autonomy-budget accounting;
+- machine-readable evidence connecting those decisions and the independently recorded effect.
 
 ### Remaining M2 work
 

--- a/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
+++ b/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
@@ -1,0 +1,83 @@
+# M1.8a external-effect recovery proof
+
+M1's database-backed dummy effect is effect-once because the effect counter and
+the Robot journal share one SQLite transaction. A physical actuator cannot use
+that transaction. M1.8a makes this boundary executable with a deliberately
+non-idempotent, file-backed button fixture.
+
+The fixture journal is separate from `robot.sqlite3`. Each call to its
+`press(effect_key)` appends one impulse, including repeated calls with the same
+key. The Robot runtime receives the fixture through an injected
+`ExternalEffectAdapter`; there is no command-line flag that enables it and no
+hardware backend is loaded by default.
+
+The recovery rule is intentionally conservative:
+
+1. The Robot persists `ACCEPTED -> DISPATCH_RECORDED` before the first adapter
+   call. That transition authorizes one `press` call and durably binds the
+   non-empty adapter `device_id` to this contract and `effect_key`.
+2. Once dispatch is durable, a restart calls `observe(effect_key)` and never
+   calls `press` again. This closes the crash window after an external action
+   and before the Robot terminal record. Recovery and resolution reject an
+   adapter or proof whose device identity differs from that binding.
+3. An attributable `APPLIED` observation resolves the contract to `SUCCEEDED`.
+   `UNKNOWN` resolves to `HELD` with local outcome `OUTCOME_UNKNOWN`; a
+   `NOT_APPLIED` observation after a dispatch uncertainty resolves to `HELD`
+   with local outcome `NOT_APPLIED_AFTER_UNCERTAIN_DISPATCH`.
+4. The terminal result stores the semantic `effect_key`, concrete `device_id`,
+   observation identity, timestamp, outcome and adapter details. A bare boolean,
+   count, or unaddressed status is rejected. Repeating a resolved observation
+   cannot overwrite its terminal record.
+
+The external path also requires the runtime clock to be at or after the durable
+`dispatch_recorded_at` boundary before it creates `RUNNING`, calls `press` or
+`observe`, or writes a terminal result. A clock-regressed restart raises a
+`RecordConflictError` before adapter I/O and leaves the journal and outbox
+unchanged (the inbox claim/reset is ordinary retry bookkeeping); after the
+clock catches up, recovery observes the existing fixture record and continues
+without replaying the impulse. Storage applies the same ordering check to a
+terminal resolution.
+
+The external resolution transaction writes the terminal event and immutable
+contract result together, while leaving the Robot journal's `effect_count` at
+zero. The counter belongs only to the historical database dummy path. The
+fixture's persistent press record is the independent evidence used by
+`observe`; the runtime never reads a test counter.
+
+The Field only emits a reconciled site snapshot for `SUCCEEDED` when it has a
+compatible measured or fused `RobotState` with the same correlation and robot
+identifier. A `HELD` result or telemetry from a different operation does not
+create a measured pose. The external fixture emits no Robot pose, so its
+successful terminal event does not manufacture a site snapshot when
+`dummy_fixture_compatibility=False`. The historical dummy compatibility option
+is disabled by default. The golden replay passes
+`dummy_fixture_compatibility=True` explicitly because its delivery order
+presents the terminal before the dummy's pre-effect telemetry. That option is
+not a physical observation guarantee. The external path has no message-shape
+discriminator and never relies on one.
+
+This is an experimental Python injection seam, not a physical exactly-once
+protocol. It proves no atomicity between a real actuator and SQLite, supplies
+no actuator safety mechanism, and does not advance the public wire schema or
+Unreal contract. `HELD` uses the existing wire state; this tranche adds no typed
+wire reason for it. It does not complete M1.8, and only execution-contract
+revision 1 is covered. A real adapter must supply a durable, attributable
+observation keyed to the intended effect and device before a future integration
+can claim a stronger result.
+
+Run the focused proof from the repository root:
+
+```text
+PYTHONPATH=python/src python -m pytest -q tests/test_external_effect.py tests/test_external_outcome_storage.py
+```
+
+The normal dummy golden and CI checks remain:
+
+The release gate validates the committed golden history; this tranche does not
+regenerate or claim a newly generated golden artifact.
+
+```text
+PYTHONPATH=python/src python -m pytest -q
+ruff check .
+python -m deferred_teleop.release_gate verify --scope ci --skip-pytest
+```

--- a/python/src/deferred_teleop/external_effect.py
+++ b/python/src/deferred_teleop/external_effect.py
@@ -1,0 +1,334 @@
+"""Explicit boundary for effects whose durable commit is external to Robot.
+
+The M1.8a fixture is intentionally small.  Its append-only JSON-lines journal is
+owned by the fixture, not by :class:`~deferred_teleop.storage.NodeStore`, so a
+test can close and reopen the two stores independently.  Calling ``press`` is
+therefore never idempotent: every call records one impulse.  Idempotency is a
+property of the Robot recovery algorithm, which must observe after a dispatch
+has been recorded instead of calling ``press`` again.
+
+The types in this module are local Python test/runtime types.  They are not
+protocol messages and do not change the ``dtt/0`` wire schema.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+
+class ExternalEffectError(RuntimeError):
+    """Base class for an external-effect adapter failure."""
+
+
+class InvalidExternalProofError(ExternalEffectError, ValueError):
+    """An adapter returned an observation without attributable evidence."""
+
+
+class ExternalOutcome(StrEnum):
+    """What an adapter can establish about one addressed effect."""
+
+    APPLIED = "APPLIED"
+    NOT_APPLIED = "NOT_APPLIED"
+    UNKNOWN = "UNKNOWN"
+
+
+def _utc_text(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_datetime(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise InvalidExternalProofError(f"{field_name} must be an ISO-8601 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise InvalidExternalProofError(f"{field_name} is not a valid timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise InvalidExternalProofError(f"{field_name} must be timezone-aware")
+    return parsed
+
+
+@dataclass(frozen=True)
+class ExternalEffectObservation:
+    """Attributable proof returned by an external adapter observation.
+
+    ``effect_key`` and ``device_id`` are mandatory by design.  A bare boolean,
+    a count, or an unaddressed status cannot close an execution contract.  The
+    optional ``details`` object is retained as forensic adapter metadata and is
+    never used as the source of truth for whether an effect was pressed.
+    """
+
+    effect_key: str
+    device_id: str
+    outcome: ExternalOutcome
+    observed_at: datetime
+    observation_id: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.effect_key, str) or not self.effect_key.strip():
+            raise ValueError("effect_key must not be empty")
+        if not isinstance(self.device_id, str) or not self.device_id.strip():
+            raise ValueError("device_id must not be empty")
+        if not isinstance(self.observation_id, str) or not self.observation_id.strip():
+            raise ValueError("observation_id must not be empty")
+        if (
+            not isinstance(self.observed_at, datetime)
+            or self.observed_at.tzinfo is None
+            or self.observed_at.utcoffset() is None
+        ):
+            raise ValueError("observed_at must be timezone-aware")
+        if not isinstance(self.outcome, ExternalOutcome):
+            try:
+                object.__setattr__(self, "outcome", ExternalOutcome(self.outcome))
+            except (TypeError, ValueError) as error:
+                raise ValueError("outcome must be APPLIED, NOT_APPLIED, or UNKNOWN") from error
+        if not isinstance(self.details, Mapping):
+            raise ValueError("details must be a mapping")
+
+    def model_dump(self) -> dict[str, Any]:
+        """Return a JSON-compatible proof object for storage and audit logs."""
+
+        return {
+            "effect_key": self.effect_key,
+            "device_id": self.device_id,
+            "outcome": self.outcome.value,
+            "observed_at": _utc_text(self.observed_at),
+            "observation_id": self.observation_id,
+            "details": dict(self.details),
+        }
+
+
+class ExternalEffectAdapter(Protocol):
+    """The injected capability needed by ``DummyRobotService``.
+
+    Implementations must persist the external action before returning from
+    ``press`` when they can.  A crash after the action and before the Robot
+    terminal commit is expected; recovery will call ``observe`` using the same
+    effect key and must not call ``press`` again.
+    """
+
+    device_id: str
+
+    def press(self, effect_key: str) -> ExternalEffectObservation | None:
+        """Issue one external impulse for ``effect_key``."""
+
+    def observe(self, effect_key: str) -> ExternalEffectObservation:
+        """Return attributable evidence for ``effect_key``."""
+
+
+def coerce_observation(
+    value: ExternalEffectObservation | Mapping[str, Any] | object,
+    *,
+    expected_effect_key: str,
+    expected_device_id: str | None = None,
+) -> ExternalEffectObservation:
+    """Validate and normalize adapter output at the storage boundary.
+
+    In particular, ``True``/``False`` and an unaddressed ``{"outcome": ...}``
+    mapping are rejected.  Accepting mappings keeps tiny test adapters easy to
+    write while requiring the same proof fields as the typed dataclass.
+    """
+
+    if isinstance(value, ExternalEffectObservation):
+        observation = value
+    elif isinstance(value, Mapping):
+        required = {"effect_key", "device_id", "outcome", "observed_at", "observation_id"}
+        missing = required.difference(value)
+        if missing:
+            raise InvalidExternalProofError(
+                "external observation is missing attributable fields: "
+                + ", ".join(sorted(missing))
+            )
+        try:
+            for field_name in ("effect_key", "device_id", "observation_id"):
+                field_value = value[field_name]
+                if not isinstance(field_value, str) or not field_value.strip():
+                    raise InvalidExternalProofError(
+                        f"external observation {field_name} must be a non-empty string"
+                    )
+            outcome = ExternalOutcome(value["outcome"])
+            observed_at = value["observed_at"]
+            if not isinstance(observed_at, datetime):
+                observed_at = _parse_datetime(observed_at, field_name="observed_at")
+            observation = ExternalEffectObservation(
+                effect_key=value["effect_key"],
+                device_id=value["device_id"],
+                outcome=outcome,
+                observed_at=observed_at,
+                observation_id=value["observation_id"],
+                details=value.get("details", {}),
+            )
+        except InvalidExternalProofError:
+            raise
+        except (TypeError, ValueError) as error:
+            raise InvalidExternalProofError("external observation has invalid fields") from error
+    else:
+        raise InvalidExternalProofError(
+            "external adapter must return attributable observation proof, not a boolean"
+        )
+
+    if observation.effect_key != expected_effect_key:
+        raise InvalidExternalProofError(
+            "external observation effect_key does not match dispatched effect"
+        )
+    if expected_device_id is not None and observation.device_id != expected_device_id:
+        raise InvalidExternalProofError(
+            "external observation device_id does not match addressed device"
+        )
+    return observation
+
+
+class PersistentDummyExternalEffect:
+    """A deliberately non-idempotent, file-backed button fixture.
+
+    The fixture is intentionally independent from the Robot SQLite database.
+    ``press`` appends a record on every invocation, including repeated keys.  A
+    caller can force the observation result with ``observation_outcome`` to
+    model a missing or ambiguous physical sensor; the persistent press records
+    remain available in ``records`` for forensic assertions.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        device_id: str = "dummy-external-button-1",
+        observation_outcome: ExternalOutcome | str | None = None,
+        clock: object | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not isinstance(device_id, str) or not device_id.strip():
+            raise ValueError("device_id must not be empty")
+        self.device_id = device_id
+        self._clock = clock
+        self.observation_outcome = (
+            ExternalOutcome(observation_outcome) if observation_outcome is not None else None
+        )
+        # Validate existing rows at construction, but never rewrite them.  A
+        # malformed fixture is evidence corruption and must fail loudly.
+        self._read_records()
+
+    @property
+    def records(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self._read_records())
+
+    @property
+    def press_count(self) -> int:
+        return len(self.records)
+
+    def set_observation_outcome(self, outcome: ExternalOutcome | str | None) -> None:
+        self.observation_outcome = ExternalOutcome(outcome) if outcome is not None else None
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        if not effect_key.strip():
+            raise ValueError("effect_key must not be empty")
+        record = {
+            "press_id": str(uuid4()),
+            "effect_key": effect_key,
+            "device_id": self.device_id,
+            "pressed_at": _utc_text(self._now()),
+        }
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n")
+            handle.flush()
+            # fsync is the point of this fixture: a test crash after ``press``
+            # must leave an observable record after reopening the file.
+            import os
+
+            os.fsync(handle.fileno())
+        return self.observe(effect_key)
+
+    def observe(self, effect_key: str) -> ExternalEffectObservation:
+        if not effect_key.strip():
+            raise ValueError("effect_key must not be empty")
+        records = [record for record in self.records if record["effect_key"] == effect_key]
+        if self.observation_outcome is not None:
+            selected = self.observation_outcome
+        elif records:
+            selected = ExternalOutcome.APPLIED
+        else:
+            selected = ExternalOutcome.NOT_APPLIED
+        latest_at = (
+            _parse_datetime(records[-1]["pressed_at"], field_name="pressed_at")
+            if records
+            else self._now()
+        )
+        return ExternalEffectObservation(
+            effect_key=effect_key,
+            device_id=self.device_id,
+            outcome=selected,
+            observed_at=self._now(),
+            observation_id=str(uuid4()),
+            details={
+                "fixture": "persistent-dummy-external-effect-v1",
+                "press_count_for_effect": len(records),
+                "latest_press_at": _utc_text(latest_at) if records else None,
+            },
+        )
+
+    def _read_records(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        seen_press_ids: set[str] = set()
+        with self.path.open(encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise ExternalEffectError(
+                        f"invalid external fixture record at line {line_number}"
+                    ) from error
+                if not isinstance(record, dict):
+                    raise ExternalEffectError(
+                        f"external fixture record at line {line_number} is not an object"
+                    )
+                required = {"press_id", "effect_key", "device_id", "pressed_at"}
+                if not required.issubset(record):
+                    raise ExternalEffectError(
+                        f"external fixture record at line {line_number} is incomplete"
+                    )
+                if any(
+                    not isinstance(record[key], str) or not record[key].strip()
+                    for key in ("press_id", "effect_key", "device_id")
+                ):
+                    raise ExternalEffectError(
+                        f"external fixture record at line {line_number} has invalid identity"
+                    )
+                if record["press_id"] in seen_press_ids:
+                    raise ExternalEffectError(
+                        f"duplicate external fixture press_id at line {line_number}"
+                    )
+                seen_press_ids.add(record["press_id"])
+                if record["device_id"] != self.device_id:
+                    raise ExternalEffectError(
+                        f"external fixture device mismatch at line {line_number}"
+                    )
+                _parse_datetime(record["pressed_at"], field_name="pressed_at")
+                records.append(record)
+        return records
+
+    def _now(self) -> datetime:
+        if self._clock is not None:
+            now = getattr(self._clock, "now", None)
+            if not callable(now):
+                raise ValueError("external fixture clock must expose callable now()")
+            value = now()
+        else:
+            value = datetime.now(UTC)
+        if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("external fixture clock must return timezone-aware datetime")
+        return value

--- a/python/src/deferred_teleop/release_gate.py
+++ b/python/src/deferred_teleop/release_gate.py
@@ -182,7 +182,11 @@ async def _build_golden_values(data_dir: Path) -> dict[str, Any]:
             _factory("mission-1", clock),
             configured_one_way_delay=0.25,
         )
-        field = FieldService(field_store, _factory("field-1", clock))
+        field = FieldService(
+            field_store,
+            _factory("field-1", clock),
+            dummy_fixture_compatibility=True,
+        )
         robot = DummyRobotService(
             robot_store,
             _factory("dummy-robot-1", clock),

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -8,6 +8,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
 
+from deferred_teleop.external_effect import (
+    ExternalEffectAdapter,
+    ExternalEffectObservation,
+    ExternalOutcome,
+    coerce_observation,
+)
 from deferred_teleop.mission_view import (
     ArrivalBeliefView,
     ConfirmedStateView,
@@ -45,7 +51,7 @@ from deferred_teleop.protocol import (
     Vector3,
     WireModel,
 )
-from deferred_teleop.storage import NodeStore
+from deferred_teleop.storage import NodeStore, RecordConflictError
 
 TERMINAL_STATES = frozenset(
     {
@@ -108,6 +114,20 @@ EventSink = Callable[[str, Mapping[str, Any]], None]
 
 def _ignore_event(_event: str, _fields: Mapping[str, Any]) -> None:
     return None
+
+
+def _durable_timestamp(value: object, *, field_name: str) -> datetime:
+    """Decode one UTC timestamp persisted in the execution journal."""
+
+    if not isinstance(value, str):
+        raise RecordConflictError(f"journal {field_name} is not a timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RecordConflictError(f"journal {field_name} is not a timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RecordConflictError(f"journal {field_name} must be timezone-aware")
+    return parsed
 
 
 @dataclass
@@ -700,11 +720,16 @@ class FieldService(RuntimeService):
         *,
         mission_id: str = "mission-1",
         robot_id: str = "dummy-robot-1",
+        # The historical no-telemetry ordering is opt-in.  The golden replay
+        # enables it explicitly; a normal Field only reconciles measured or
+        # fused RobotState evidence.
+        dummy_fixture_compatibility: bool = False,
         emit: EventSink = _ignore_event,
     ) -> None:
         super().__init__(store, factory, emit=emit)
         self.mission_id = mission_id
         self.robot_id = robot_id
+        self.dummy_fixture_compatibility = dummy_fixture_compatibility
 
     async def process_claimed(self, envelope: MessageEnvelope) -> None:
         if isinstance(envelope.payload, OperationIntent):
@@ -902,37 +927,73 @@ class FieldService(RuntimeService):
         outgoing: list[MessageEnvelope] = [forwarded]
         if (
             isinstance(envelope.payload, ExecutionEvent)
-            and envelope.payload.next_state in TERMINAL_STATES
+            and envelope.payload.next_state is ContractState.SUCCEEDED
         ):
             robot_state = next(
                 (
                     message.payload
                     for message in reversed(self.store.inbox_messages())
-                    if isinstance(message.payload, RobotState)
+                    if (
+                        message.correlation_id == envelope.correlation_id
+                        and isinstance(message.payload, RobotState)
+                        and message.payload.robot_id == self.robot_id
+                        and message.payload.evidence.provenance
+                        in {ProvenanceKind.MEASURED, ProvenanceKind.FUSED}
+                    )
                 ),
-                RobotState(
-                    robot_id=self.robot_id,
-                    pose=dummy_pose(pressed=True),
-                    evidence=evidence(
-                        "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
-                    ),
-                ),
+                None,
             )
-            snapshot = self.factory.make(
-                "site.snapshot",
-                self.mission_id,
-                envelope.correlation_id,
-                SiteSnapshot(
-                    site_id="dummy-site-1",
-                    entities=("dummy-button-1",),
-                    robot_states=(robot_state,),
-                    evidence=evidence(
-                        "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
+            # A terminal event alone is not physical evidence.  In particular,
+            # never borrow a state from another operation or synthesize a
+            # measured pose for an external effect that emitted no telemetry.
+            if robot_state is not None:
+                snapshot = self.factory.make(
+                    "site.snapshot",
+                    self.mission_id,
+                    envelope.correlation_id,
+                    SiteSnapshot(
+                        site_id="dummy-site-1",
+                        entities=("dummy-button-1",),
+                        robot_states=(robot_state,),
+                        evidence=evidence(
+                            "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
+                        ),
                     ),
-                ),
-                causation_id=envelope.message_id,
-            )
-            outgoing.append(snapshot)
+                    causation_id=envelope.message_id,
+                )
+                outgoing.append(snapshot)
+            elif self.dummy_fixture_compatibility:
+                # Preserve the historical M1 golden replay for the original
+                # database dummy.  Its fixture emits the terminal before its
+                # pre-effect telemetry.  This compatibility option is explicit
+                # and is never inferred from the message shape; callers
+                # handling an external adapter must disable it.
+                snapshot = self.factory.make(
+                    "site.snapshot",
+                    self.mission_id,
+                    envelope.correlation_id,
+                    SiteSnapshot(
+                        site_id="dummy-site-1",
+                        entities=("dummy-button-1",),
+                        robot_states=(
+                            RobotState(
+                                robot_id=self.robot_id,
+                                pose=dummy_pose(pressed=True),
+                                evidence=evidence(
+                                    "field-fixture-1",
+                                    now,
+                                    ProvenanceKind.MEASURED,
+                                    world_revision=2,
+                                ),
+                            ),
+                        ),
+                        evidence=evidence(
+                            "field-fixture-1", now, ProvenanceKind.MEASURED, world_revision=2
+                        ),
+                    ),
+                    causation_id=envelope.message_id,
+                )
+                outgoing.append(snapshot)
         self.store.complete_inbox(
             envelope.message_id,
             processed_at=now,
@@ -956,11 +1017,13 @@ class DummyRobotService(RuntimeService):
         *,
         field_id: str = "field-1",
         phase_duration: float = 0.05,
+        external_effect_adapter: ExternalEffectAdapter | None = None,
         emit: EventSink = _ignore_event,
     ) -> None:
         super().__init__(store, factory, emit=emit)
         self.field_id = field_id
         self.phase_duration = phase_duration
+        self.external_effect_adapter = external_effect_adapter
 
     @property
     def capabilities(self) -> tuple[str, ...]:
@@ -1038,6 +1101,8 @@ class DummyRobotService(RuntimeService):
             )
             return
 
+        external_device_id = self._external_device_id()
+        external_mode = self.external_effect_adapter is not None
         effect_key = f"press:{contract.operation_id}:{contract.contract_revision}"
         accepted_now = self.store.accept_contract(
             contract_id=contract.contract_id,
@@ -1048,6 +1113,7 @@ class DummyRobotService(RuntimeService):
             accepted_at=self.clock.now(),
         )
         journal = self._journal(contract)
+        self._assert_external_dispatch_configuration(journal, external_device_id)
         if journal["state"] in {state.value for state in TERMINAL_STATES}:
             self._enqueue_terminal_replay(envelope, journal)
             self.store.complete_inbox(
@@ -1063,18 +1129,34 @@ class DummyRobotService(RuntimeService):
                 ContractState.RECEIVED,
                 ContractState.ACCEPTED,
                 ordinal=1,
+                occurred_at=(
+                    _durable_timestamp(journal["accepted_at"], field_name="accepted_at")
+                    if external_mode
+                    else None
+                ),
             )
+        dispatch_recorded_now = False
         if journal["state"] == ContractState.ACCEPTED.value:
-            self.store.record_dispatch(
+            dispatch_recorded_now = self.store.record_dispatch(
                 contract.contract_id,
                 contract.contract_revision,
                 recorded_at=self.clock.now(),
+                device_id=external_device_id,
             )
+            journal = self._journal(contract)
             self._enqueue_transition(
                 envelope,
                 ContractState.ACCEPTED,
                 ContractState.DISPATCH_RECORDED,
                 ordinal=2,
+                occurred_at=(
+                    _durable_timestamp(
+                        journal["dispatch_recorded_at"],
+                        field_name="dispatch_recorded_at",
+                    )
+                    if external_mode
+                    else None
+                ),
             )
             invocation_id = uuid5(
                 NAMESPACE_URL,
@@ -1096,6 +1178,17 @@ class DummyRobotService(RuntimeService):
                 "robot.skill_invoked",
                 {"contract_id": str(contract.contract_id), **invocation},
             )
+
+        if self.external_effect_adapter is not None:
+            journal = self._journal(contract)
+            self._assert_external_dispatch_configuration(journal, external_device_id)
+            await self._process_external_contract(
+                envelope,
+                effect_key=effect_key,
+                dispatch_recorded_now=dispatch_recorded_now,
+                expected_device_id=external_device_id,
+            )
+            return
 
         self._enqueue_transition(
             envelope,
@@ -1174,6 +1267,221 @@ class DummyRobotService(RuntimeService):
             },
         )
 
+    def _external_device_id(self) -> str | None:
+        adapter = self.external_effect_adapter
+        if adapter is None:
+            return None
+        device_id = getattr(adapter, "device_id", None)
+        if not isinstance(device_id, str) or not device_id.strip():
+            raise ValueError(
+                "an external effect adapter must expose a non-empty string device_id"
+            )
+        return device_id
+
+    def _assert_external_dispatch_configuration(
+        self, journal: Mapping[str, Any], expected_device_id: str | None
+    ) -> None:
+        """Prevent a durable external dispatch from falling back to dummy I/O."""
+
+        durable_device_id = journal.get("dispatch_device_id")
+        dispatch_recorded = journal.get("dispatch_recorded_at") is not None
+        if durable_device_id is not None:
+            if self.external_effect_adapter is None:
+                raise RecordConflictError(
+                    "external dispatch requires its original adapter for recovery"
+                )
+            assert expected_device_id is not None
+            self._assert_external_identity(journal, expected_device_id)
+        elif dispatch_recorded and self.external_effect_adapter is not None:
+            # A pre-v3 journal has no trustworthy external device binding.  It
+            # may still be replayed by the historical database dummy, but an
+            # injected adapter must not guess which device performed dispatch.
+            raise RecordConflictError(
+                "external adapter cannot recover a dispatch without durable device identity"
+            )
+
+    @staticmethod
+    def _assert_external_identity(
+        journal: Mapping[str, Any], expected_device_id: str
+    ) -> None:
+        durable_device_id = journal.get("dispatch_device_id")
+        if durable_device_id != expected_device_id:
+            raise RecordConflictError(
+                "external adapter device_id differs from durable dispatch identity"
+            )
+
+    def _external_clock_at_or_after(self, persisted_at: datetime) -> datetime:
+        """Refuse external recovery while the process clock is behind dispatch.
+
+        The durable dispatch boundary is the earliest valid timestamp for the
+        remaining external lifecycle.  A restarted process whose clock has
+        moved backwards must wait for a trusted clock before it can observe or
+        resolve the effect.  Returning the checked value also prevents a
+        second ``now()`` call from producing a terminal timestamp before the
+        check that guarded it.
+        """
+
+        current = self.clock.now()
+        if (
+            not isinstance(current, datetime)
+            or current.tzinfo is None
+            or current.utcoffset() is None
+        ):
+            raise RecordConflictError(
+                "external recovery requires a timezone-aware runtime clock"
+            )
+        if current < persisted_at:
+            raise RecordConflictError(
+                "external recovery clock is earlier than durable dispatch_recorded_at"
+            )
+        return current
+
+    async def _process_external_contract(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        effect_key: str,
+        dispatch_recorded_now: bool,
+        expected_device_id: str,
+    ) -> None:
+        """Issue or recover one external effect without a hidden retry.
+
+        The durable dispatch boundary is deliberately checked before calling
+        the adapter.  A fresh contract may press once after
+        ``ACCEPTED -> DISPATCH_RECORDED``.  Any later invocation observes the
+        external device, even when the previous process died before writing its
+        terminal result.
+        """
+
+        contract = envelope.payload
+        assert isinstance(contract, ExecutionContract)
+        adapter = self.external_effect_adapter
+        assert adapter is not None
+        journal = self._journal(contract)
+        self._assert_external_identity(journal, expected_device_id)
+        dispatch_recorded_at = _durable_timestamp(
+            journal["dispatch_recorded_at"], field_name="dispatch_recorded_at"
+        )
+        # Check before constructing/enqueuing RUNNING and before any adapter
+        # observation or press.  This keeps a clock-regressed restart from
+        # adding a synthetic lifecycle event or issuing an impulse.
+        self._external_clock_at_or_after(dispatch_recorded_at)
+
+        running_event = self._transition(
+            envelope,
+            ContractState.DISPATCH_RECORDED,
+            ContractState.RUNNING,
+            ordinal=3,
+            occurred_at=dispatch_recorded_at,
+        )
+        self._enqueue_if_absent(running_event)
+        if dispatch_recorded_now:
+            self._external_clock_at_or_after(dispatch_recorded_at)
+            invocation_id = uuid5(
+                NAMESPACE_URL,
+                f"dtt-external-skill:{contract.contract_id}:{contract.contract_revision}",
+            )
+            self.store.append_execution_audit(
+                contract.contract_id,
+                contract.contract_revision,
+                event_type="external-effect-dispatch",
+                metadata={
+                    "effect_key": effect_key,
+                    "device_id": expected_device_id,
+                    "invocation_id": str(invocation_id),
+                },
+                recorded_at=self.clock.now(),
+            )
+            self.emit(
+                "robot.external_effect_dispatch",
+                {
+                    "contract_id": str(contract.contract_id),
+                    "effect_key": effect_key,
+                    "device_id": expected_device_id,
+                },
+            )
+            # A conforming adapter may persist the physical/test action and
+            # then raise to model a crash.  Let that exception escape: the
+            # inbox remains PROCESSING and recovery will observe, never press.
+            adapter.press(effect_key)
+        else:
+            self._external_clock_at_or_after(dispatch_recorded_at)
+            self.store.append_execution_audit(
+                contract.contract_id,
+                contract.contract_revision,
+                event_type="external-effect-recovery-observation",
+                metadata={
+                    "effect_key": effect_key,
+                    "device_id": expected_device_id,
+                    "reason": "dispatch-already-recorded",
+                },
+                recorded_at=self.clock.now(),
+            )
+
+        self._external_clock_at_or_after(dispatch_recorded_at)
+        observation: ExternalEffectObservation = coerce_observation(
+            adapter.observe(effect_key),
+            expected_effect_key=effect_key,
+            expected_device_id=expected_device_id,
+        )
+        terminal_state = (
+            ContractState.SUCCEEDED
+            if observation.outcome is ExternalOutcome.APPLIED
+            else ContractState.HELD
+        )
+        terminal_at = self._external_clock_at_or_after(dispatch_recorded_at)
+        terminal_event = self._transition(
+            envelope,
+            ContractState.RUNNING,
+            terminal_state,
+            ordinal=4,
+            occurred_at=terminal_at,
+            causation_id=running_event.message_id,
+        )
+        resolution = {
+            ExternalOutcome.APPLIED: "APPLIED",
+            ExternalOutcome.UNKNOWN: "OUTCOME_UNKNOWN",
+            ExternalOutcome.NOT_APPLIED: "NOT_APPLIED_AFTER_UNCERTAIN_DISPATCH",
+        }[observation.outcome]
+        committed = self.store.resolve_external_outcome(
+            contract.contract_id,
+            contract.contract_revision,
+            observation=observation,
+            expected_device_id=expected_device_id,
+            terminal_state=terminal_state,
+            terminal_result={
+                "effect_key": effect_key,
+                "device_id": observation.device_id,
+                "outcome": resolution,
+                "external_outcome": observation.outcome.value,
+            },
+            occurred_at=terminal_at,
+            terminal_event=terminal_event,
+        )
+        self.store.append_execution_audit(
+            contract.contract_id,
+            contract.contract_revision,
+            event_type="external-effect-outcome",
+            metadata=observation.model_dump(),
+            recorded_at=terminal_at,
+        )
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"external-{resolution.lower()}:{contract.contract_id}",
+        )
+        self.emit(
+            "robot.external_effect_resolved",
+            {
+                "contract_id": str(contract.contract_id),
+                "effect_key": effect_key,
+                "device_id": observation.device_id,
+                "outcome": observation.outcome.value,
+                "terminal_state": terminal_state.value,
+                "committed": committed,
+            },
+        )
+
     def _journal(self, contract: ExecutionContract) -> dict[str, Any]:
         return next(
             row
@@ -1189,13 +1497,19 @@ class DummyRobotService(RuntimeService):
         next_state: ContractState,
         *,
         ordinal: int,
+        occurred_at: datetime | None = None,
+        causation_id: UUID | None = None,
     ) -> MessageEnvelope:
         contract = cause.payload
         assert isinstance(contract, ExecutionContract)
         stable = f"{contract.contract_id}:{contract.contract_revision}:{next_state.value}"
         event_id = uuid5(NAMESPACE_URL, f"dtt-event:{stable}")
         message_id = uuid5(NAMESPACE_URL, f"dtt-envelope:{stable}")
-        occurred_at = cause.created_at + timedelta(milliseconds=ordinal)
+        event_occurred_at = (
+            occurred_at
+            if occurred_at is not None
+            else cause.created_at + timedelta(milliseconds=ordinal)
+        )
         return self.factory.make(
             "execution.event",
             self.field_id,
@@ -1206,11 +1520,11 @@ class DummyRobotService(RuntimeService):
                 contract_revision=contract.contract_revision,
                 previous_state=previous,
                 next_state=next_state,
-                occurred_at=occurred_at,
+                occurred_at=event_occurred_at,
             ),
-            causation_id=cause.message_id,
+            causation_id=causation_id or cause.message_id,
             message_id=message_id,
-            created_at=occurred_at,
+            created_at=event_occurred_at,
         )
 
     def _enqueue_transition(
@@ -1220,9 +1534,18 @@ class DummyRobotService(RuntimeService):
         next_state: ContractState,
         *,
         ordinal: int,
+        occurred_at: datetime | None = None,
+        causation_id: UUID | None = None,
     ) -> None:
         self._enqueue_if_absent(
-            self._transition(cause, previous, next_state, ordinal=ordinal)
+            self._transition(
+                cause,
+                previous,
+                next_state,
+                ordinal=ordinal,
+                occurred_at=occurred_at,
+                causation_id=causation_id,
+            )
         )
 
     def _enqueue_if_absent(self, envelope: MessageEnvelope) -> bool:

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -18,9 +18,14 @@ from uuid import UUID
 
 from pydantic import ValidationError
 
+from deferred_teleop.external_effect import (
+    ExternalEffectObservation,
+    ExternalOutcome,
+    coerce_observation,
+)
 from deferred_teleop.protocol import ContractState, ExecutionEvent, MessageEnvelope
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 DEFAULT_BUSY_TIMEOUT_MS = 5_000
 TERMINAL_STATES = frozenset(
     {
@@ -56,6 +61,20 @@ def _utc_text(value: datetime) -> str:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError("timestamps must be timezone-aware")
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc_text(value: object, *, field_name: str) -> datetime:
+    """Decode a persisted timestamp before making an external decision."""
+
+    if not isinstance(value, str):
+        raise CorruptRecordError(f"journal {field_name} is not a timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise CorruptRecordError(f"journal {field_name} is not a timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CorruptRecordError(f"journal {field_name} must be timezone-aware")
+    return parsed
 
 
 def _now_text() -> str:
@@ -167,7 +186,18 @@ def _migration_2(connection: sqlite3.Connection) -> None:
         connection.execute(statement)
 
 
-MIGRATIONS = {1: _migration_1, 2: _migration_2}
+def _migration_3(connection: sqlite3.Connection) -> None:
+    """Bind an optional external device to the durable dispatch boundary."""
+
+    connection.execute(
+        """
+        ALTER TABLE execution_journal ADD COLUMN dispatch_device_id TEXT
+            CHECK (dispatch_device_id IS NULL OR length(trim(dispatch_device_id)) > 0)
+        """
+    )
+
+
+MIGRATIONS = {1: _migration_1, 2: _migration_2, 3: _migration_3}
 
 
 def initialize_database(
@@ -515,21 +545,41 @@ class NodeStore:
         return True
 
     def record_dispatch(
-        self, contract_id: UUID, contract_revision: int, *, recorded_at: datetime
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        recorded_at: datetime,
+        device_id: str | None = None,
     ) -> bool:
+        if device_id is not None and (
+            not isinstance(device_id, str) or not device_id.strip()
+        ):
+            raise ValueError("device_id must be a non-empty string when provided")
         with self._transaction() as connection:
             row = self._journal_row(connection, contract_id, contract_revision)
             if row["dispatch_recorded_at"] is not None:
+                stored_device_id = row["dispatch_device_id"]
+                if device_id is not None and stored_device_id != device_id:
+                    raise RecordConflictError(
+                        "dispatch device identity is immutable and does not match"
+                    )
                 return False
             if row["state"] != "ACCEPTED":
                 raise InvalidStateTransitionError("dispatch requires ACCEPTED state")
             connection.execute(
                 """
                 UPDATE execution_journal
-                SET state = 'DISPATCH_RECORDED', dispatch_recorded_at = ?
+                SET state = 'DISPATCH_RECORDED', dispatch_recorded_at = ?,
+                    dispatch_device_id = ?
                 WHERE contract_id = ? AND contract_revision = ?
                 """,
-                (_utc_text(recorded_at), str(contract_id), contract_revision),
+                (
+                    _utc_text(recorded_at),
+                    device_id,
+                    str(contract_id),
+                    contract_revision,
+                ),
             )
         return True
 
@@ -577,6 +627,161 @@ class NodeStore:
                     terminal_state.value,
                     _utc_text(occurred_at),
                     _utc_text(occurred_at),
+                    encoded_result,
+                    str(contract_id),
+                    contract_revision,
+                ),
+            )
+        return True
+
+    def resolve_external_outcome(
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        observation: ExternalEffectObservation | Mapping[str, Any] | object | None = None,
+        expected_device_id: str | None = None,
+        terminal_state: ContractState | None = None,
+        terminal_result: Mapping[str, Any] | None = None,
+        occurred_at: datetime,
+        terminal_event: MessageEnvelope,
+    ) -> bool:
+        """Atomically resolve an effect performed outside the Robot journal.
+
+        The external path deliberately leaves ``effect_count`` at zero.  The
+        adapter owns the physical/test effect record, while this transaction
+        owns only the immutable contract resolution and its terminal outbox
+        event.  A proof must identify both the semantic ``effect_key`` and the
+        concrete ``device_id``; a bare status or boolean is rejected.
+
+        When ``terminal_state`` is omitted it is derived from the proof:
+        APPLIED resolves to SUCCEEDED and either other observation resolves to
+        HELD.
+        """
+
+        if observation is None:
+            raise ValueError("external observation proof is required")
+
+        row = self._journal_row(self._connection, contract_id, contract_revision)
+        expected_effect_key = str(row["effect_key"])
+        occurred_text = _utc_text(occurred_at)
+        dispatch_recorded_at = row["dispatch_recorded_at"]
+        if dispatch_recorded_at is not None:
+            dispatch_at = _parse_utc_text(
+                dispatch_recorded_at, field_name="dispatch_recorded_at"
+            )
+            if occurred_at < dispatch_at:
+                raise RecordConflictError(
+                    "external terminal resolution cannot precede durable dispatch_recorded_at"
+                )
+        proof = coerce_observation(
+            observation,
+            expected_effect_key=expected_effect_key,
+            expected_device_id=expected_device_id,
+        )
+        if proof.observed_at > occurred_at:
+            raise RecordConflictError(
+                "external observation cannot be later than its terminal resolution"
+            )
+        resolved_state = (
+            ContractState.SUCCEEDED
+            if proof.outcome is ExternalOutcome.APPLIED
+            else ContractState.HELD
+        )
+        if terminal_state is not None:
+            try:
+                terminal_state = ContractState(terminal_state)
+            except (TypeError, ValueError) as error:
+                raise ValueError("terminal_state must be a ContractState") from error
+            if terminal_state is not resolved_state:
+                raise RecordConflictError("terminal state does not match external observation")
+        terminal_state = resolved_state
+
+        event = terminal_event.payload
+        if not isinstance(event, ExecutionEvent):
+            raise ValueError("terminal_event must contain an ExecutionEvent")
+        if (
+            event.contract_id != contract_id
+            or event.contract_revision != contract_revision
+            or event.previous_state is not ContractState.RUNNING
+            or event.next_state is not terminal_state
+            or event.occurred_at != occurred_at
+            or terminal_event.created_at != occurred_at
+        ):
+            raise RecordConflictError(
+                "terminal event or timestamp does not match external resolution"
+            )
+
+        resolution = {
+            ExternalOutcome.APPLIED: "APPLIED",
+            ExternalOutcome.UNKNOWN: "OUTCOME_UNKNOWN",
+            ExternalOutcome.NOT_APPLIED: "NOT_APPLIED_AFTER_UNCERTAIN_DISPATCH",
+        }[proof.outcome]
+        result: dict[str, Any] = dict(terminal_result or {})
+        required_result = {
+            "effect_key": proof.effect_key,
+            "device_id": proof.device_id,
+            "external_outcome": proof.outcome.value,
+            "outcome": resolution,
+            "resolution": resolution,
+            "observation_id": proof.observation_id,
+            "observed_at": proof.observed_at.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "terminal_at": occurred_text,
+            "proof": proof.model_dump(),
+        }
+        for key, value in required_result.items():
+            if key in result and result[key] != value:
+                raise RecordConflictError(f"external terminal result field collision: {key}")
+            result[key] = value
+        encoded_result = _result_json(result)
+
+        with self._transaction() as connection:
+            journal = self._journal_row(connection, contract_id, contract_revision)
+            dispatch_device_id = journal["dispatch_device_id"]
+            if journal["terminal_at"] is not None:
+                if dispatch_device_id is None:
+                    raise RecordConflictError(
+                        "external resolution has no durable dispatch device identity"
+                    )
+                if dispatch_device_id != proof.device_id:
+                    raise RecordConflictError(
+                        "external observation device differs from durable dispatch identity"
+                    )
+                existing_raw = journal["terminal_result_json"]
+                try:
+                    existing = json.loads(existing_raw) if existing_raw is not None else {}
+                except (TypeError, json.JSONDecodeError) as error:
+                    raise CorruptRecordError(
+                        f"invalid external terminal result {contract_id}:{contract_revision}"
+                    ) from error
+                # Compare the complete canonical record.  Python's mapping
+                # equality would treat values such as 1 and 1.0 as equal and
+                # could silently accept a changed immutable proof detail.
+                if _canonical_json(existing) == encoded_result:
+                    return False
+                raise RecordConflictError("external terminal result is immutable")
+            if journal["state"] != "DISPATCH_RECORDED" or journal["effect_count"] != 0:
+                raise InvalidStateTransitionError(
+                    "external outcome requires an unconsumed DISPATCH_RECORDED journal entry"
+                )
+            if dispatch_device_id is None:
+                raise RecordConflictError(
+                    "external resolution has no durable dispatch device identity"
+                )
+            if dispatch_device_id != proof.device_id:
+                raise RecordConflictError(
+                    "external observation device differs from durable dispatch identity"
+                )
+            self._insert_outbox(connection, terminal_event)
+            connection.execute(
+                """
+                UPDATE execution_journal SET state = ?, terminal_at = ?,
+                    terminal_result_json = ?
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (
+                    terminal_state.value,
+                    occurred_text,
                     encoded_result,
                     str(contract_id),
                     contract_revision,

--- a/tests/test_external_effect.py
+++ b/tests/test_external_effect.py
@@ -1,0 +1,910 @@
+import asyncio
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from deferred_teleop.external_effect import (
+    ExternalEffectObservation,
+    ExternalOutcome,
+    InvalidExternalProofError,
+    PersistentDummyExternalEffect,
+)
+from deferred_teleop.protocol import ContractState, ExecutionEvent, ProvenanceKind, RobotState
+from deferred_teleop.runtime import (
+    DummyRobotService,
+    EnvelopeFactory,
+    FieldService,
+    MissionService,
+    dummy_pose,
+    evidence,
+)
+from deferred_teleop.storage import NodeStore, RecordConflictError, initialize_database
+
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+
+
+class VirtualClock:
+    def __init__(self, current: datetime = NOW) -> None:
+        self.current = current
+
+    def now(self) -> datetime:
+        return self.current
+
+    async def sleep(self, seconds: float) -> None:
+        del seconds
+
+
+class CrashAfterPress(PersistentDummyExternalEffect):
+    def __init__(self, path: str | Path, **kwargs: object) -> None:
+        super().__init__(path, **kwargs)
+        self._crash = True
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        result = super().press(effect_key)
+        if self._crash:
+            self._crash = False
+            raise RuntimeError("injected crash after external press")
+        return result
+
+
+class CrashBeforePress(PersistentDummyExternalEffect):
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        del effect_key
+        raise RuntimeError("injected crash before external press")
+
+
+class BooleanObservationAdapter:
+    device_id = "dummy-external-button-1"
+
+    def press(self, effect_key: str) -> None:
+        del effect_key
+
+    def observe(self, effect_key: str) -> bool:
+        del effect_key
+        return True
+
+
+class CountingObservationAdapter:
+    def __init__(self, *, device_id: str, clock: VirtualClock) -> None:
+        self.device_id = device_id
+        self.clock = clock
+        self.press_calls = 0
+        self.observe_calls = 0
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        self.press_calls += 1
+        return self.observe(effect_key)
+
+    def observe(self, effect_key: str) -> ExternalEffectObservation:
+        self.observe_calls += 1
+        return ExternalEffectObservation(
+            effect_key=effect_key,
+            device_id=self.device_id,
+            outcome=ExternalOutcome.APPLIED,
+            observed_at=self.clock.now(),
+            observation_id=f"observation-{self.device_id}-{self.observe_calls}",
+        )
+
+
+class InvalidDeviceAdapter:
+    def __init__(self, device_id: str | None) -> None:
+        if device_id is not None:
+            self.device_id = device_id
+        self.press_calls = 0
+
+    def press(self, effect_key: str) -> None:
+        self.press_calls += 1
+        del effect_key
+
+    def observe(self, effect_key: str) -> bool:
+        del effect_key
+        return True
+
+
+async def _deliver(service, envelope) -> None:
+    if service.store.receive(envelope, received_at=service.clock.now()):
+        await service.handle(envelope)
+
+
+async def _make_chain(tmp_path: Path, clock: VirtualClock):
+    mission_store = NodeStore(tmp_path / "mission.sqlite3")
+    field_store = NodeStore(tmp_path / "field.sqlite3")
+    mission = MissionService(
+        mission_store,
+        EnvelopeFactory("mission-1", clock),
+        configured_one_way_delay=0.0,
+    )
+    field = FieldService(
+        field_store,
+        EnvelopeFactory("field-1", clock),
+        dummy_fixture_compatibility=False,
+    )
+    intent = mission.submit_press_button()
+    await _deliver(field, intent)
+    assignment = next(
+        message
+        for message in field_store.outbox_messages()
+        if message.message_type == "task.assignment"
+    )
+    contract = next(
+        message
+        for message in field_store.outbox_messages()
+        if message.message_type == "execution.contract"
+    )
+    return mission_store, field_store, field, assignment, contract
+
+
+def test_persistent_fixture_reopens_and_each_press_is_an_impulse(tmp_path: Path) -> None:
+    path = tmp_path / "external-effect.jsonl"
+    effect_key = "press:operation:1"
+    clock = VirtualClock()
+    first = PersistentDummyExternalEffect(path, clock=clock)
+    first.press(effect_key)
+    first.press(effect_key)
+    assert first.press_count == 2
+
+    reopened = PersistentDummyExternalEffect(path, clock=clock)
+    observation = reopened.observe(effect_key)
+    assert observation.outcome is ExternalOutcome.APPLIED
+    assert observation.effect_key == effect_key
+    assert observation.device_id == "dummy-external-button-1"
+    assert observation.details["press_count_for_effect"] == 2
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_external_success_has_attributable_proof_and_no_robot_effect_counter(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        with (
+            mission_store,
+            field_store,
+            NodeStore(tmp_path / "robot.sqlite3") as robot_store,
+        ):
+            adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=0.0,
+                external_effect_adapter=adapter,
+            )
+            await _deliver(robot, assignment)
+            await _deliver(robot, contract)
+
+            assert adapter.press_count == 1
+            assert robot.effect_counter == 0
+            journal = robot_store.inspect_execution_journal()[0]
+            assert journal["state"] == ContractState.SUCCEEDED.value
+            assert journal["effect_count"] == 0
+            result = json.loads(journal["terminal_result_json"])
+            assert result["effect_key"] == journal["effect_key"]
+            assert result["device_id"] == adapter.device_id
+            assert result["external_outcome"] == ExternalOutcome.APPLIED.value
+            assert result["outcome"] == "APPLIED"
+            assert result["observed_at"] == result["terminal_at"]
+            assert result["proof"]["observed_at"] == result["observed_at"]
+            assert not any(
+                isinstance(message.payload, RobotState)
+                for message in robot_store.outbox_messages()
+            )
+
+            for message in robot_store.outbox_messages():
+                await _deliver(field, message)
+            snapshots = [
+                message
+                for message in field_store.outbox_messages()
+                if message.message_type == "site.snapshot"
+            ]
+            # The admission snapshot is valid; terminal success without Robot
+            # telemetry must not create a second measured snapshot.
+            assert len(snapshots) == 1
+            assert not any(
+                message.payload.next_state is ContractState.SUCCEEDED
+                and message.causation_id is not None
+                and snapshot.causation_id == message.message_id
+                for snapshot in snapshots
+                for message in field_store.inbox_messages()
+                if message.message_type == "execution.event"
+            )
+
+    asyncio.run(scenario())
+
+
+def test_external_events_use_durable_dispatch_times_without_clock_advance(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        with mission_store, field_store, NodeStore(tmp_path / "robot.sqlite3") as robot_store:
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                external_effect_adapter=PersistentDummyExternalEffect(
+                    tmp_path / "external.jsonl", clock=clock
+                ),
+            )
+            await _deliver(robot, assignment)
+            await _deliver(robot, contract)
+
+            event_messages = [
+                message
+                for message in robot_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+            ]
+            assert {message.payload.next_state for message in event_messages} == {
+                ContractState.ACCEPTED,
+                ContractState.DISPATCH_RECORDED,
+                ContractState.RUNNING,
+                ContractState.SUCCEEDED,
+            }
+            assert all(
+                message.payload.occurred_at <= clock.now()
+                and message.created_at == message.payload.occurred_at
+                for message in event_messages
+            )
+            running = next(
+                message
+                for message in event_messages
+                if message.payload.next_state is ContractState.RUNNING
+            )
+            terminal = next(
+                message
+                for message in event_messages
+                if message.payload.next_state is ContractState.SUCCEEDED
+            )
+            assert terminal.causation_id == running.message_id
+            journal = robot_store.inspect_execution_journal()[0]
+            accepted_at = datetime.fromisoformat(
+                journal["accepted_at"].replace("Z", "+00:00")
+            )
+            dispatch_at = datetime.fromisoformat(
+                journal["dispatch_recorded_at"].replace("Z", "+00:00")
+            )
+            terminal_at = datetime.fromisoformat(
+                journal["terminal_at"].replace("Z", "+00:00")
+            )
+            accepted = next(
+                message
+                for message in event_messages
+                if message.payload.next_state is ContractState.ACCEPTED
+            )
+            dispatch = next(
+                message
+                for message in event_messages
+                if message.payload.next_state is ContractState.DISPATCH_RECORDED
+            )
+            assert accepted.payload.occurred_at == accepted_at
+            assert dispatch.payload.occurred_at == dispatch_at
+            assert running.payload.occurred_at == dispatch_at
+            assert terminal.payload.occurred_at == terminal_at
+
+    asyncio.run(scenario())
+
+
+def test_crash_after_external_press_reopens_and_observes_without_repressing(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=CrashAfterPress(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError, match="after external press"):
+                    await _deliver(robot, contract)
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+                assert robot_store.inspect_execution_journal()[0]["state"] == (
+                    ContractState.DISPATCH_RECORDED.value
+                )
+
+            with NodeStore(robot_path) as restarted_store:
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                )
+                assert await recovered.recover() == 1
+                assert recovered.effect_counter == 0
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+                assert restarted_store.inspect_execution_journal()[0]["state"] == (
+                    ContractState.SUCCEEDED.value
+                )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("crash_factory", "expected_press_count"),
+    [(CrashBeforePress, 0), (CrashAfterPress, 1)],
+    ids=["before-press", "after-press"],
+)
+def test_external_dispatch_never_falls_back_to_dummy_without_adapter(
+    tmp_path: Path, crash_factory, expected_press_count: int
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=crash_factory(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError):
+                    await _deliver(robot, contract)
+                outbox_before_recovery = tuple(
+                    message.message_id for message in robot_store.outbox_messages()
+                )
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["dispatch_device_id"] == "dummy-external-button-1"
+                assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+                assert journal["effect_count"] == 0
+
+            with NodeStore(robot_path) as restarted_store:
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                )
+                with pytest.raises(RecordConflictError, match="original adapter"):
+                    await recovered.recover()
+                assert tuple(
+                    message.message_id for message in restarted_store.outbox_messages()
+                ) == outbox_before_recovery
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+                assert journal["effect_count"] == 0
+                assert not any(
+                    isinstance(message.payload, RobotState)
+                    for message in restarted_store.outbox_messages()
+                )
+                assert not any(
+                    isinstance(message.payload, ExecutionEvent)
+                    and message.payload.next_state is ContractState.SUCCEEDED
+                    for message in restarted_store.outbox_messages()
+                )
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == (
+                    expected_press_count
+                )
+
+    asyncio.run(scenario())
+
+
+def test_clock_regression_blocks_external_recovery_before_observation(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=CrashAfterPress(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError, match="after external press"):
+                    await _deliver(robot, contract)
+                journal_before = robot_store.inspect_execution_journal()
+                outbox_before = [
+                    message.model_dump(mode="json")
+                    for message in robot_store.outbox_messages()
+                ]
+
+            # A restarted process may have a wall clock earlier than the
+            # persisted dispatch boundary.  It must wait before touching the
+            # adapter or adding a recovery event.
+            clock.current = NOW - timedelta(seconds=1)
+            with NodeStore(robot_path) as restarted_store:
+                adapter = CountingObservationAdapter(
+                    device_id="dummy-external-button-1", clock=clock
+                )
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                )
+                with pytest.raises(RecordConflictError, match="clock.*dispatch_recorded_at"):
+                    await recovered.recover()
+                assert adapter.press_calls == 0
+                assert adapter.observe_calls == 0
+                assert restarted_store.inspect_execution_journal() == journal_before
+                assert [
+                    message.model_dump(mode="json")
+                    for message in restarted_store.outbox_messages()
+                ] == outbox_before
+
+            # Once the clock catches up, recovery observes the durable fixture
+            # record and converges without issuing a second impulse.
+            clock.current = NOW
+            with NodeStore(robot_path) as recovered_store:
+                recovered = DummyRobotService(
+                    recovered_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                )
+                assert await recovered.recover() == 1
+                assert recovered_store.inspect_execution_journal()[0]["state"] == (
+                    ContractState.SUCCEEDED.value
+                )
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_recovery_binds_to_original_device_before_observing_or_pressing(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=CrashAfterPress(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError, match="after external press"):
+                    await _deliver(robot, contract)
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["dispatch_device_id"] == "dummy-external-button-1"
+
+            with NodeStore(robot_path) as restarted_store:
+                adapter_b = CountingObservationAdapter(
+                    device_id="replacement-external-button-2", clock=clock
+                )
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter_b,
+                )
+                with pytest.raises(RecordConflictError, match="durable dispatch identity"):
+                    await recovered.recover()
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+                assert adapter_b.press_calls == 0
+                assert adapter_b.observe_calls == 0
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_external_terminal_redelivery_without_adapter_is_rejected(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                outbox_before_redelivery = tuple(
+                    message.message_id for message in robot_store.outbox_messages()
+                )
+
+            with NodeStore(robot_path) as restarted_store:
+                duplicate = contract.model_copy(
+                    update={
+                        "message_id": uuid4(),
+                        "source_sequence": contract.source_sequence + 1,
+                    }
+                )
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                )
+                with pytest.raises(RecordConflictError, match="original adapter"):
+                    await _deliver(recovered, duplicate)
+                assert tuple(
+                    message.message_id for message in restarted_store.outbox_messages()
+                ) == outbox_before_redelivery
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.SUCCEEDED.value
+                assert journal["effect_count"] == 0
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+                assert not any(
+                    isinstance(message.payload, RobotState)
+                    for message in restarted_store.outbox_messages()
+                )
+
+    asyncio.run(scenario())
+
+
+def test_v2_dispatch_without_device_refuses_adapter_and_keeps_legacy_dummy_path(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        robot_path = tmp_path / "robot.sqlite3"
+        initialize_database(robot_path, target_version=2)
+        contract_payload = contract.payload
+        assignment_payload = assignment.payload
+        connection = sqlite3.connect(robot_path)
+        connection.execute(
+            """
+            INSERT INTO execution_journal (
+                contract_id, contract_revision, operation_id, task_id, state,
+                effect_key, effect_count, accepted_at, dispatch_recorded_at
+            ) VALUES (?, ?, ?, ?, 'DISPATCH_RECORDED', ?, 0, ?, ?)
+            """,
+            (
+                str(contract_payload.contract_id),
+                contract_payload.contract_revision,
+                str(contract_payload.operation_id),
+                str(assignment_payload.task_id),
+                f"press:{contract_payload.operation_id}:{contract_payload.contract_revision}",
+                NOW.isoformat().replace("+00:00", "Z"),
+                NOW.isoformat().replace("+00:00", "Z"),
+            ),
+        )
+        connection.commit()
+        connection.close()
+
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                assert robot_store.schema_version == 3
+                adapter = CountingObservationAdapter(
+                    device_id="legacy-replacement-device", clock=clock
+                )
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RecordConflictError, match="without durable device"):
+                    await _deliver(robot, contract)
+                assert adapter.press_calls == 0
+                assert adapter.observe_calls == 0
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["dispatch_device_id"] is None
+                assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+
+            with NodeStore(robot_path) as restarted_store:
+                legacy_dummy = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    phase_duration=0.0,
+                )
+                assert await legacy_dummy.recover() == 1
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.SUCCEEDED.value
+                assert journal["effect_count"] == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("device_id", [None, "", "   "])
+def test_external_adapter_requires_device_identity_before_press(
+    tmp_path: Path, device_id: str | None
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        adapter = InvalidDeviceAdapter(device_id)
+        with mission_store, field_store, NodeStore(tmp_path / "robot.sqlite3") as robot_store:
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                external_effect_adapter=adapter,
+            )
+            await _deliver(robot, assignment)
+            with pytest.raises(ValueError, match="non-empty string device_id"):
+                await _deliver(robot, contract)
+            assert adapter.press_calls == 0
+            assert robot_store.inspect_execution_journal() == []
+
+    asyncio.run(scenario())
+
+
+def test_unknown_after_external_press_is_held_without_repressing(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=CrashAfterPress(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError):
+                    await _deliver(robot, contract)
+
+            with NodeStore(robot_path) as restarted_store:
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path,
+                        observation_outcome=ExternalOutcome.UNKNOWN,
+                        clock=clock,
+                    ),
+                )
+                await recovered.recover()
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.HELD.value
+                assert journal["effect_count"] == 0
+                result = json.loads(journal["terminal_result_json"])
+                assert result["outcome"] == "OUTCOME_UNKNOWN"
+                assert result["external_outcome"] == ExternalOutcome.UNKNOWN.value
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_not_applied_after_crash_before_press_is_held_and_stays_zero(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=CrashBeforePress(external_path, clock=clock),
+                )
+                await _deliver(robot, assignment)
+                with pytest.raises(RuntimeError, match="before external press"):
+                    await _deliver(robot, contract)
+
+            with NodeStore(robot_path) as restarted_store:
+                recovered = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path,
+                        observation_outcome=ExternalOutcome.NOT_APPLIED,
+                        clock=clock,
+                    ),
+                )
+                await recovered.recover()
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.HELD.value
+                assert journal["effect_count"] == 0
+                result = json.loads(journal["terminal_result_json"])
+                assert result["outcome"] == "NOT_APPLIED_AFTER_UNCERTAIN_DISPATCH"
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_duplicate_contracts_and_restart_do_not_replay_external_press(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                duplicate = contract.model_copy(
+                    update={
+                        "message_id": uuid4(),
+                        "source_sequence": contract.source_sequence + 1,
+                    }
+                )
+                await _deliver(robot, duplicate)
+                assert adapter.press_count == 1
+
+            with NodeStore(robot_path) as restarted_store:
+                restarted = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                )
+                duplicate_after_restart = contract.model_copy(
+                    update={
+                        "message_id": uuid4(),
+                        "source_sequence": contract.source_sequence + 2,
+                    }
+                )
+                await _deliver(restarted, duplicate_after_restart)
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_unattributed_boolean_observation_is_rejected(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        with mission_store, field_store, NodeStore(tmp_path / "robot.sqlite3") as robot_store:
+            robot = DummyRobotService(
+                robot_store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                external_effect_adapter=BooleanObservationAdapter(),
+            )
+            await _deliver(robot, assignment)
+            with pytest.raises(InvalidExternalProofError, match="attributable"):
+                await _deliver(robot, contract)
+            assert robot_store.inspect_execution_journal()[0]["state"] == (
+                ContractState.DISPATCH_RECORDED.value
+            )
+
+    asyncio.run(scenario())
+
+
+def test_external_legacy_causation_shape_without_pose_does_not_make_snapshot(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "field.sqlite3") as store:
+            field = FieldService(
+                store,
+                EnvelopeFactory("field-1", clock),
+                dummy_fixture_compatibility=False,
+            )
+            contract_id = uuid4()
+            terminal = field.factory.make(
+                "execution.event",
+                "field-1",
+                uuid4(),
+                ExecutionEvent(
+                    event_id=uuid4(),
+                    contract_id=contract_id,
+                    contract_revision=1,
+                    previous_state=ContractState.RUNNING,
+                    next_state=ContractState.SUCCEEDED,
+                    occurred_at=clock.now(),
+                ),
+                # This was the former external-path discriminator.  It is
+                # deliberately insufficient evidence by itself.
+                causation_id=contract_id,
+            )
+            await _deliver(field, terminal)
+            assert not any(
+                message.message_type == "site.snapshot" for message in store.outbox_messages()
+            )
+
+    asyncio.run(scenario())
+
+
+def test_field_does_not_reconcile_held_or_cross_correlation_terminal(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        with NodeStore(tmp_path / "field.sqlite3") as store:
+            field = FieldService(
+                store,
+                EnvelopeFactory("field-1", clock),
+                dummy_fixture_compatibility=False,
+            )
+            contract_id = uuid4()
+            held = field.factory.make(
+                "execution.event",
+                "field-1",
+                uuid4(),
+                ExecutionEvent(
+                    event_id=uuid4(),
+                    contract_id=contract_id,
+                    contract_revision=1,
+                    previous_state=ContractState.RUNNING,
+                    next_state=ContractState.HELD,
+                    occurred_at=clock.now(),
+                ),
+                causation_id=uuid4(),
+            )
+            await _deliver(field, held)
+            assert not any(
+                message.message_type == "site.snapshot" for message in store.outbox_messages()
+            )
+
+            correlation_a = uuid4()
+            state = field.factory.make(
+                "robot.state",
+                "field-1",
+                correlation_a,
+                RobotState(
+                    robot_id="dummy-robot-1",
+                    pose=dummy_pose(),
+                    evidence=evidence(
+                        "robot-1", clock.now(), ProvenanceKind.MEASURED, world_revision=1
+                    ),
+                ),
+            )
+            await _deliver(field, state)
+            correlation_b = uuid4()
+            terminal = field.factory.make(
+                "execution.event",
+                "field-1",
+                correlation_b,
+                ExecutionEvent(
+                    event_id=uuid4(),
+                    contract_id=contract_id,
+                    contract_revision=1,
+                    previous_state=ContractState.RUNNING,
+                    next_state=ContractState.SUCCEEDED,
+                    occurred_at=clock.now(),
+                ),
+                causation_id=uuid4(),
+            )
+            await _deliver(field, terminal)
+            assert not any(
+                message.causation_id == terminal.message_id
+                and message.message_type == "site.snapshot"
+                for message in store.outbox_messages()
+            )
+
+    asyncio.run(scenario())

--- a/tests/test_external_outcome_storage.py
+++ b/tests/test_external_outcome_storage.py
@@ -1,0 +1,376 @@
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from deferred_teleop.external_effect import (
+    ExternalEffectObservation,
+    ExternalOutcome,
+    InvalidExternalProofError,
+)
+from deferred_teleop.protocol import ContractState, ExecutionEvent
+from deferred_teleop.runtime import EnvelopeFactory
+from deferred_teleop.storage import (
+    InvalidStateTransitionError,
+    NodeStore,
+    RecordConflictError,
+    initialize_database,
+)
+
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+CONTRACT_ID = UUID("70000000-0000-4000-8000-000000000001")
+OPERATION_ID = UUID("30000000-0000-4000-8000-000000000001")
+TASK_ID = UUID("50000000-0000-4000-8000-000000000001")
+EFFECT_KEY = "press:30000000-0000-4000-8000-000000000001:1"
+
+
+class Clock:
+    def now(self) -> datetime:
+        return NOW
+
+
+def _dispatch(store: NodeStore) -> None:
+    assert store.accept_contract(
+        contract_id=CONTRACT_ID,
+        contract_revision=1,
+        operation_id=OPERATION_ID,
+        task_id=TASK_ID,
+        effect_key=EFFECT_KEY,
+        accepted_at=NOW,
+    )
+    assert store.record_dispatch(
+        CONTRACT_ID,
+        1,
+        recorded_at=NOW + timedelta(seconds=1),
+        device_id="button-sensor-1",
+    )
+
+
+def _terminal_event(
+    outcome: ContractState = ContractState.SUCCEEDED,
+    *,
+    event_occurred_at: datetime = NOW + timedelta(seconds=2),
+    envelope_created_at: datetime | None = None,
+):
+    return EnvelopeFactory("dummy-robot-1", Clock()).make(
+        "execution.event",
+        "field-1",
+        OPERATION_ID,
+        ExecutionEvent(
+            event_id=UUID("80000000-0000-4000-8000-000000000001"),
+            contract_id=CONTRACT_ID,
+            contract_revision=1,
+            previous_state=ContractState.RUNNING,
+            next_state=outcome,
+            occurred_at=event_occurred_at,
+        ),
+        causation_id=UUID("90000000-0000-4000-8000-000000000001"),
+        created_at=envelope_created_at or event_occurred_at,
+    )
+
+
+def _proof(
+    *,
+    outcome: ExternalOutcome = ExternalOutcome.APPLIED,
+    device_id: str = "button-sensor-1",
+    effect_key: str = EFFECT_KEY,
+    observation_id: str = "observation-1",
+    observed_at: datetime = NOW + timedelta(seconds=2),
+    details: dict[str, object] | None = None,
+) -> ExternalEffectObservation:
+    return ExternalEffectObservation(
+        effect_key=effect_key,
+        device_id=device_id,
+        outcome=outcome,
+        observed_at=observed_at,
+        observation_id=observation_id,
+        details=details or {},
+    )
+
+
+def test_external_resolution_is_atomic_reopenable_and_keeps_dummy_counter_zero(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "robot.sqlite3"
+    proof = _proof()
+    with NodeStore(path) as store:
+        _dispatch(store)
+        assert store.resolve_external_outcome(
+            CONTRACT_ID,
+            1,
+            observation=proof,
+            expected_device_id=proof.device_id,
+            occurred_at=NOW + timedelta(seconds=2),
+            terminal_event=_terminal_event(),
+        )
+        journal = store.inspect_execution_journal()[0]
+        assert journal["state"] == ContractState.SUCCEEDED.value
+        assert journal["effect_count"] == 0
+        result = json.loads(journal["terminal_result_json"])
+        assert result["effect_key"] == EFFECT_KEY
+        assert result["device_id"] == proof.device_id
+        assert result["external_outcome"] == ExternalOutcome.APPLIED.value
+        assert store.pending_outbox(now=NOW + timedelta(seconds=3))
+
+    with NodeStore(path) as restarted:
+        assert restarted.inspect_execution_journal()[0]["effect_count"] == 0
+        assert not restarted.resolve_external_outcome(
+            CONTRACT_ID,
+            1,
+            observation=proof,
+            expected_device_id=proof.device_id,
+            occurred_at=NOW + timedelta(seconds=2),
+            terminal_event=_terminal_event(),
+        )
+
+
+def test_external_dispatch_device_binding_is_immutable(tmp_path: Path) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        assert not store.record_dispatch(
+            CONTRACT_ID,
+            1,
+            recorded_at=NOW + timedelta(seconds=2),
+            device_id="button-sensor-1",
+        )
+        with pytest.raises(RecordConflictError, match="device identity"):
+            store.record_dispatch(
+                CONTRACT_ID,
+                1,
+                recorded_at=NOW + timedelta(seconds=2),
+                device_id="replacement-sensor-2",
+            )
+        assert store.inspect_execution_journal()[0]["dispatch_device_id"] == (
+            "button-sensor-1"
+        )
+
+
+def test_external_resolution_rejects_unattributed_or_conflicting_proof(tmp_path: Path) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        with pytest.raises(InvalidExternalProofError, match="attributable"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=True,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(),
+            )
+        with pytest.raises(InvalidExternalProofError, match="device_id"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=_proof(device_id="wrong-device"),
+                expected_device_id="button-sensor-1",
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(),
+            )
+        assert store.inspect_execution_journal()[0]["state"] == (
+            ContractState.DISPATCH_RECORDED.value
+        )
+
+        proof = _proof()
+        store.resolve_external_outcome(
+            CONTRACT_ID,
+            1,
+            observation=proof,
+            expected_device_id=proof.device_id,
+            occurred_at=NOW + timedelta(seconds=2),
+            terminal_event=_terminal_event(),
+        )
+        with pytest.raises(RecordConflictError, match="immutable"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=_proof(outcome=ExternalOutcome.UNKNOWN, observation_id="other"),
+                expected_device_id=proof.device_id,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(ContractState.HELD),
+            )
+
+
+def test_external_terminal_proof_identity_timestamp_and_details_are_immutable(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        proof = _proof()
+        store.resolve_external_outcome(
+            CONTRACT_ID,
+            1,
+            observation=proof,
+            expected_device_id=proof.device_id,
+            occurred_at=NOW + timedelta(seconds=2),
+            terminal_event=_terminal_event(),
+        )
+        variants = (
+            _proof(observation_id="observation-other"),
+            _proof(observed_at=NOW + timedelta(seconds=1)),
+            _proof(details={"sensor": "different"}),
+        )
+        for conflicting_proof in variants:
+            with pytest.raises(RecordConflictError, match="immutable"):
+                store.resolve_external_outcome(
+                    CONTRACT_ID,
+                    1,
+                    observation=conflicting_proof,
+                    expected_device_id=proof.device_id,
+                    occurred_at=NOW + timedelta(seconds=2),
+                    terminal_event=_terminal_event(),
+                )
+
+
+def test_external_future_proof_is_rejected_before_journal_or_outbox_mutation(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        with pytest.raises(RecordConflictError, match="later than"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=_proof(observed_at=NOW + timedelta(seconds=3)),
+                expected_device_id="button-sensor-1",
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(),
+            )
+        journal = store.inspect_execution_journal()[0]
+        assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+        assert journal["terminal_at"] is None
+        assert store.pending_outbox(now=NOW + timedelta(seconds=10)) == []
+
+
+def test_external_resolution_before_dispatch_is_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        journal_before = store.inspect_execution_journal()
+        outbox_before = [
+            message.model_dump(mode="json") for message in store.outbox_messages()
+        ]
+        with pytest.raises(RecordConflictError, match="precede durable dispatch_recorded_at"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=_proof(observed_at=NOW),
+                expected_device_id="button-sensor-1",
+                occurred_at=NOW + timedelta(milliseconds=500),
+                terminal_event=_terminal_event(
+                    event_occurred_at=NOW + timedelta(milliseconds=500)
+                ),
+            )
+        assert store.inspect_execution_journal() == journal_before
+        assert [
+            message.model_dump(mode="json") for message in store.outbox_messages()
+        ] == outbox_before
+
+
+def test_external_terminal_timestamp_mismatch_is_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        _dispatch(store)
+        proof = _proof()
+        with pytest.raises(RecordConflictError, match="timestamp"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=proof,
+                expected_device_id=proof.device_id,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(
+                    envelope_created_at=NOW + timedelta(seconds=3)
+                ),
+            )
+        with pytest.raises(RecordConflictError, match="timestamp"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=proof,
+                expected_device_id=proof.device_id,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(
+                    event_occurred_at=NOW + timedelta(seconds=3)
+                ),
+            )
+        journal = store.inspect_execution_journal()[0]
+        assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+        assert journal["terminal_at"] is None
+        assert store.pending_outbox(now=NOW + timedelta(seconds=10)) == []
+
+
+def test_v2_dispatch_without_device_migrates_and_preserves_legacy_dummy_recovery(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "robot.sqlite3"
+    initialize_database(path, target_version=2)
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        INSERT INTO execution_journal (
+            contract_id, contract_revision, operation_id, task_id, state,
+            effect_key, effect_count, accepted_at, dispatch_recorded_at
+        ) VALUES (?, ?, ?, ?, 'DISPATCH_RECORDED', ?, 0, ?, ?)
+        """,
+        (
+            str(CONTRACT_ID),
+            1,
+            str(OPERATION_ID),
+            str(TASK_ID),
+            EFFECT_KEY,
+            NOW.isoformat().replace("+00:00", "Z"),
+            (NOW + timedelta(seconds=1)).isoformat().replace("+00:00", "Z"),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    with NodeStore(path) as store:
+        assert store.schema_version == 3
+        journal = store.inspect_execution_journal()[0]
+        assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+        assert journal["dispatch_device_id"] is None
+
+
+def test_external_resolution_requires_dispatch_and_matches_terminal_state(
+    tmp_path: Path,
+) -> None:
+    with NodeStore(tmp_path / "robot.sqlite3") as store:
+        store.accept_contract(
+            contract_id=CONTRACT_ID,
+            contract_revision=1,
+            operation_id=OPERATION_ID,
+            task_id=TASK_ID,
+            effect_key=EFFECT_KEY,
+            accepted_at=NOW,
+        )
+        proof = _proof()
+        with pytest.raises(InvalidStateTransitionError, match="DISPATCH_RECORDED"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=proof,
+                expected_device_id=proof.device_id,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(),
+            )
+
+        assert store.record_dispatch(
+            CONTRACT_ID,
+            1,
+            recorded_at=NOW + timedelta(seconds=1),
+            device_id="button-sensor-1",
+        )
+        with pytest.raises(RecordConflictError, match="terminal state"):
+            store.resolve_external_outcome(
+                CONTRACT_ID,
+                1,
+                observation=proof,
+                expected_device_id=proof.device_id,
+                terminal_state=ContractState.HELD,
+                occurred_at=NOW + timedelta(seconds=2),
+                terminal_event=_terminal_event(),
+            )


### PR DESCRIPTION
A crash after a device action can leave the Robot journal without its result. This change adds an experimental injectable path whose persistent simulated device records every pulse independently. Recovery observes after a durable dispatch and never sends that pulse again automatically; unknown or absent evidence produces a held outcome.

Dispatch binds the device identity durably. Missing or substituted adapters, conflicting observations and inconsistent or regressed timestamps are rejected. SQLite v3 migrates old journals without inventing an external device binding. Normal Field reconciliation requires compatible Robot telemetry; the historical dummy golden uses an explicit compatibility option.

Validation: 109 Python tests, Ruff, schema drift check and the fourteen-profile M1 CI gate pass. Fresh generation in a separate directory reproduced all six historical golden files byte for byte. Independent critical review exercised device substitution, missing-adapter recovery, immutable evidence, clock regression and migration before publication.

This is the external-recovery part of M1.8, with no physical hardware backend or wire-schema change. Its combined long-delay, cross-revision effect-identity and durable-budget gate remains open. The roadmap and status distinguish these boundaries.

Closes #35.
