### PR TITLE
Add the combined external-effect proof for asymmetric long delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,17 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 - experimental external-effect recovery with a separate persistent simulated button, durable
   device binding, observe-only recovery after uncertain dispatch, and immutable outcome evidence;
 - explicit historical dummy-fixture compatibility; normal Field reconciliation requires compatible
-  Robot telemetry instead of manufacturing a measured completion pose from a terminal event.
+  Robot telemetry instead of manufacturing a measured completion pose from a terminal event;
+- combined M1.8b virtual-time proof that drives the independent non-idempotent device through
+  symmetric 1200-second and asymmetric 900-second outbound / 1200-second return delays, including
+  duplicate-contract recovery and receiving-site expiry boundaries;
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
+
+### Status
+
+- M1.8 remains in progress after M1.8b: durable autonomy-budget accounting and stable effect
+  identity across contract revisions are not implemented, and no physical hardware validation is
+  claimed.
 
 ## 0.1.0 - 2026-09-04
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,18 +96,22 @@ general perception system. M1.7a is a prerequisite correction, not a substitute 
 
 ## M1.8 — External effect and long-delay evidence
 
-Status: **in progress; external-effect recovery and virtual-time dummy domain tests implemented**
+Status: **in progress; M1.8b combined external-effect/long-delay proof implemented**
 
 The [long-delay domain tests](docs/m1/LONG_DELAY_DOMAIN.md) cover 0, 30, 900 and 1200 seconds
-of one-way transit, blackout, expiry and persisted-service restart. They use the M1 dummy effect;
-the combined independent-device, delayed-intent and durable-budget gate below remains open.
+of one-way transit, blackout, expiry and persisted-service restart with the M1 dummy effect. The
+[M1.8b combined proof](docs/m1/EXTERNAL_EFFECT_LONG_DELAY.md) now runs the independent device
+through the delayed Mission/Field domain, including symmetric 1200-second and asymmetric
+900-second outbound / 1200-second return transit.
 
-The [external-effect recovery proof](docs/m1/EXTERNAL_EFFECT_RECOVERY.md) separately exercises
-a non-idempotent simulated device with its own persistent record. Robot binds the device at
+The [external-effect recovery proof](docs/m1/EXTERNAL_EFFECT_RECOVERY.md) defines the
+non-idempotent simulated device and its own persistent record. Robot binds the device at
 dispatch, observes after uncertain dispatch instead of repeating the action, and holds when the
 outcome is unknown or not applied. Missing or substituted adapters are rejected during recovery.
-This experimental injection path does not yet combine the independent device with the long-delay
-scenario, stable effect identity across plan revisions, or a durable autonomy budget.
+The M1.8b proof combines that adapter with the delayed domain and verifies independent pulse
+history, duplicate contract delivery after Robot-store recovery, receiving-site expiry, and the
+absence of a fabricated completion snapshot. Stable effect identity across plan revisions and a
+durable autonomy budget remain unimplemented.
 
 M1.8 adds the smallest deterministic proof that a recorded execution event is not itself proof
 of an external effect. A fake button device keeps an effect counter or state in storage separate
@@ -120,6 +124,13 @@ fifteen-minute delay must configure and record at least 900 seconds of one-way t
 900-second blackout alone is not such evidence. The run also varies direction/asymmetry and
 validity so that admission, execution and expiry are evaluated at the receiving site rather than
 inferred from a link profile name.
+
+The M1.8b bounded combined slice is implemented and covered by six focused tests in the 115-test
+Python suite. It does not validate physical hardware, a real network, or a whole-OS restart.
+Positive and ambiguous observation recovery are covered under long delay; absent external
+evidence remains covered by the separate M1.8a recovery proof. It covers contract revision 1;
+cross-revision identity and durable budget accounting remain open. Expiry or cancellation after
+external dispatch and before Robot recovery is outside this proof.
 
 M1.8 closes when deterministic evidence shows that:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,15 +11,16 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1 | **Implemented; `v0.1.0` historical** | Delay-tolerant dummy, persistence, replay and Mission reconciliation |
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
-| M1.8 | **In progress** | External-effect recovery and virtual-time dummy tests implemented separately; combined gate remains open |
+| M1.8 | **In progress; M1.8b combined proof implemented** | External device runs through delayed Mission/Field domain; durable budget and cross-revision identity remain open |
 | M2 | **In progress; target `v0.2.0`** | M2.1 structural model is complete; FK, articulated Unreal state, IK and authoring remain |
 | M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
 
 M1.7a, M1.7, M1.8 and the enriched M3a/M3b slices are specified in the [delayed-intent
 validation design](design/DELAYED_INTENT_VALIDATION.md). M1.7a is implemented in
-[PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30); the other new gates remain
-planned and are not established by the design document.
+[PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30), and the bounded M1.8b
+combined proof is implemented in [the external long-delay evidence](m1/EXTERNAL_EFFECT_LONG_DELAY.md).
+The remaining M1.7 and full M1.8 gates are not established by the design document.
 
 ## Implemented in M0
 
@@ -111,21 +112,22 @@ All 72 Python tests, Ruff and the unchanged M1 CI release gate passed in
 
 ### M1.8 combined external-effect and long-delay gate
 
-The [long-delay domain tests](m1/LONG_DELAY_DOMAIN.md) already exercise the real M1 services
-and deterministic link with up to 1200 seconds of one-way transit. Separately, the
+The [long-delay domain tests](m1/LONG_DELAY_DOMAIN.md) exercise the real M1 services and
+deterministic link with up to 1200 seconds of one-way transit. The
 [external-effect recovery proof](m1/EXTERNAL_EFFECT_RECOVERY.md) uses a persistent simulated
-device outside the Robot journal. Dispatch binds its identity durably; recovery observes without
-blind replay and rejects a missing or substituted adapter. An unknown outcome remains held, and
-a terminal event alone does not manufacture measured completion telemetry in the normal Field.
+device outside the Robot journal. The combined [M1.8b proof](m1/EXTERNAL_EFFECT_LONG_DELAY.md)
+now runs that device through the delayed Mission/Field domain. Dispatch binds its identity
+durably; recovery observes without blind replay and rejects a missing or substituted adapter. An
+unknown outcome remains held, and a terminal event alone does not manufacture measured completion
+telemetry in the normal Field.
 
-The integrated Python suite passes 109 tests. Regenerating the historical golden session in a
-separate directory also reproduced all six committed files byte for byte. Its explicit dummy
-fixture compatibility is documented; it is not an external observation guarantee.
+The integrated Python suite passes 115 tests, including six focused M1.8b scenarios. The historical
+golden session and its six committed files remain unchanged, and the release gate remains
+unchanged. Its explicit dummy fixture compatibility is documented; it is not an external
+observation guarantee.
 
-The remaining combined gate requires:
+The remaining full M1.8 gate requires:
 
-- the independent device exercised through the delayed domain, including asymmetric transit,
-  queue age, validity, expiry and restart;
 - stable effect identity across plan revisions and durable autonomy-budget accounting;
 - machine-readable evidence connecting those decisions and the independently recorded effect.
 
@@ -174,8 +176,8 @@ M3 remains incomplete until both M3a and M3b pass. Neither gate is currently imp
 ## Evidence boundary
 
 This documentation update introduces no runtime implementation or hardware path. M1.7a has the
-separate implementation and validation cited above; the broader scenario matrix remains planned.
-A milestone is complete
+separate implementation and validation cited above; the bounded M1.8b proof is implemented while
+the full M1.8 gate remains open. A milestone is complete
 only after its deterministic replay, machine-readable artifacts and visible result satisfy the
 gate in the [roadmap](../ROADMAP.md).
 

--- a/docs/m1/EXTERNAL_EFFECT_LONG_DELAY.md
+++ b/docs/m1/EXTERNAL_EFFECT_LONG_DELAY.md
@@ -1,0 +1,70 @@
+# M1.8b external effect under long delay
+
+This proof composes the real Python M1 services through durable stores:
+
+```text
+Mission -> DeterministicLink (outbound) -> Field
+       -> DummyRobotService(external_effect_adapter=PersistentDummyExternalEffect)
+       -> Field -> DeterministicLink (return) -> Mission
+```
+
+The two links are independent deterministic schedulers driven by one virtual
+clock. The nominal matrix covers a symmetric 1200 second one way delay and an
+asymmetric 900 second outbound / 1200 second return path. A delay is scheduled
+from the actual send instant. Each envelope is checked independently: the
+sender can send it only when `created_at`, `not_before`, and `expires_at` allow
+the send, while the link delivers a scheduled copy only when its delivery
+instant remains before `expires_at`. The harness advances time only to the next
+link delivery or genuinely eligible outbox attempt. The local Field queue case
+persists an envelope before expiry and evaluates its expiry later, at the
+handling boundary. Send, delivery, and queue decisions all use the same virtual
+clock.
+
+The external device is a separate append-only JSON-lines file. It is deliberately
+non-idempotent: every `press(effect_key)` appends one pulse, including a repeated
+key. Robot's `effect_count` remains zero on this path. The crash case persists a
+pulse, interrupts Robot before its terminal commit, reopens Robot's SQLite store
+and the adapter, then submits the same contract again. Recovery observes the
+existing device record and produces exactly one `SUCCEEDED` result. When the
+reopened adapter reports `UNKNOWN`, recovery produces `HELD` and never reports a
+false success. Contract revision 1, the semantic effect key, the device identity,
+and observation identity are checked after recovery.
+
+Two expiry boundaries are covered. A 60 second TTL with a 900 second outbound
+delay expires in the transport and is never admitted by Field, so no pulse is
+possible. A separate local Field queue persists the inbox first, waits until the
+same 60 second TTL boundary, and then processes the intent; Field emits `HELD`
+without creating a Robot assignment, pulse, or completion snapshot. A fifteen
+minute blackout remains a transport condition and is covered by the preceding
+domain proof; these tests use the local queue to exercise the distinct
+post-inbox boundary.
+
+Each nominal invocation writes a small machine-readable result table named
+`external-effect-long-delay-results.json` below pytest's temporary directory.
+It is an execution report, not a committed or golden artifact.
+
+Run the proof from the repository root:
+
+```text
+PYTHONPATH=python/src python -m pytest -q tests/test_external_effect_long_delay.py
+```
+
+The virtual clock, dummy Field/Robot domain, deterministic schedulers, SQLite
+stores, and JSON-lines device are test fixtures. This does not validate a
+15-minute weather forecast, a changed physical world, a real network, an OS
+restart, or physical hardware. Reopen means closing and reopening the involved
+service's SQLite store and the external adapter; it does not restart the whole
+operating system. The proof does not provide cross-revision identity or budget
+enforcement. Expiry or cancellation after an external dispatch but before Robot
+recovery is outside this tranche; no outcome policy for that in-flight window is
+claimed. The proof does not extend the wire schema and does not close M1.8. A
+real adapter still needs a durable attributable observation and its own safety
+and actuation guarantees.
+
+The broader checks remain:
+
+```text
+PYTHONPATH=python/src python -m pytest -q
+ruff check .
+python -m deferred_teleop.release_gate verify --scope ci --skip-pytest
+```

--- a/tests/test_external_effect_long_delay.py
+++ b/tests/test_external_effect_long_delay.py
@@ -1,0 +1,619 @@
+"""Virtual-time proofs for an external effect across long asymmetric links.
+
+The harness deliberately reuses the M1 domain harness.  Only the Mission/Field
+link is split into two deterministic directional links; Field/Robot still uses
+the durable direct service path from the existing harness.  The external device
+is a separate non-idempotent JSON-lines journal, so a second ``press`` is an
+observable failure even when the Robot SQLite store is reopened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from datetime import timedelta
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from deferred_teleop.external_effect import (
+    ExternalEffectObservation,
+    ExternalOutcome,
+    PersistentDummyExternalEffect,
+)
+from deferred_teleop.link import DeterministicLink, FaultProfile, LinkFrame, ScheduledFrame
+from deferred_teleop.protocol import (
+    ContractState,
+    ExecutionContract,
+    ExecutionEvent,
+    MessageEnvelope,
+    OperationIntent,
+    SiteSnapshot,
+)
+from deferred_teleop.runtime import DummyRobotService
+from deferred_teleop.storage import NodeStore
+from test_long_delay_domain import EPOCH, RETRY_HORIZON_SECONDS, DomainHarness, VirtualClock
+
+AdapterFactory = Callable[[Path, VirtualClock], PersistentDummyExternalEffect]
+
+
+class CrashAfterExternalPress(PersistentDummyExternalEffect):
+    """Persist one physical pulse, then interrupt the Robot before its commit."""
+
+    def __init__(self, path: str | Path, **kwargs: object) -> None:
+        super().__init__(path, **kwargs)
+        self._crash = True
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        observation = super().press(effect_key)
+        if self._crash:
+            self._crash = False
+            raise RuntimeError("injected crash after external press")
+        return observation
+
+
+def _persistent_adapter(path: Path, clock: VirtualClock) -> PersistentDummyExternalEffect:
+    return PersistentDummyExternalEffect(path, clock=clock)
+
+
+class ExternalDelayHarness(DomainHarness):
+    """The previous domain harness with real directional delay and external I/O."""
+
+    def __init__(
+        self,
+        data_dir: Path,
+        *,
+        forward_delay: float,
+        return_delay: float,
+        forward_profile: FaultProfile | None = None,
+        return_profile: FaultProfile | None = None,
+        adapter_factory: AdapterFactory = _persistent_adapter,
+        clock: VirtualClock | None = None,
+        hold_field_intent: bool = False,
+    ) -> None:
+        self.forward_delay = forward_delay
+        self.return_delay = return_delay
+        self._return_profile = return_profile or FaultProfile(
+            one_way_delay_seconds=return_delay
+        )
+        self._adapter_factory = adapter_factory
+        self.external_path = data_dir / "external-device.jsonl"
+        self._hold_field_intent = hold_field_intent
+        self._held_field_intents: list[MessageEnvelope] = []
+        super().__init__(
+            data_dir,
+            forward_profile or FaultProfile(one_way_delay_seconds=forward_delay),
+            configured_one_way_delay=forward_delay,
+            clock=clock or VirtualClock(),
+        )
+        # DomainHarness constructs one link before opening the services.  Replace
+        # that in-memory scheduler with the two physical directions after the
+        # services have been opened; all stores and factories remain shared.
+        self.outbound_link = DeterministicLink(self.profile, wall_epoch=EPOCH)
+        self.return_link = DeterministicLink(self._return_profile, wall_epoch=EPOCH)
+        self.link = self.outbound_link
+
+    def _open_robot(self) -> None:
+        self.robot_store = NodeStore(self.data_dir / "robot.sqlite3")
+        adapter = self._adapter_factory(self.external_path, self.clock)
+        self.external_adapter = adapter
+        self.robot = DummyRobotService(
+            self.robot_store,
+            self._factories["dummy-robot-1"],
+            phase_duration=0.0,
+            external_effect_adapter=adapter,
+        )
+
+    async def reopen_robot(
+        self, adapter_factory: AdapterFactory, *, recover: bool = True
+    ) -> None:
+        """Reopen only Robot SQLite and its independently persisted device."""
+
+        self.robot_store.close()
+        self._adapter_factory = adapter_factory
+        self._open_robot()
+        if recover:
+            await self.robot.recover()
+
+    def _link_for_source(self, source: Literal["mission", "field"]) -> DeterministicLink:
+        return self.outbound_link if source == "mission" else self.return_link
+
+    async def submit_pending_link(self, source: Literal["mission", "field"]) -> bool:
+        if source == "mission":
+            service = self.mission
+            destination = "field-1"
+            source_label = "mission->outbound"
+        else:
+            service = self.field
+            destination = "mission-1"
+            source_label = "field->return"
+        submitted = False
+        link = self._link_for_source(source)
+        for envelope in self._pending_due(service.store):
+            if envelope.destination_id != destination:
+                continue
+            self._record_send(source_label, envelope)
+            service.store.record_attempt(
+                envelope.message_id,
+                next_attempt_at=self.clock.now() + timedelta(seconds=RETRY_HORIZON_SECONDS),
+            )
+            link.submit(source, LinkFrame.for_envelope(envelope), now=self.clock.seconds)
+            submitted = True
+        return submitted
+
+    async def deliver_link_due(self) -> bool:
+        due: list[tuple[ScheduledFrame, str]] = []
+        for link_name, link in (("outbound", self.outbound_link), ("return", self.return_link)):
+            due.extend((item, link_name) for item in link.deliver_due(now=self.clock.seconds))
+        # Each direction has its own sequence.  The direction rank makes equal
+        # virtual timestamps reproducible without inventing a future timestamp.
+        due.sort(
+            key=lambda entry: (
+                entry[0].delivery_time,
+                entry[0].priority,
+                entry[1],
+                entry[0].sequence,
+            )
+        )
+
+        for item, link_name in due:
+            self.clock.advance_to(max(self.clock.seconds, item.delivery_time))
+            self.delivery_log.append(
+                {
+                    "delivery_time": item.delivery_time,
+                    "received_at": self.clock.seconds,
+                    "destination": item.destination,
+                    "link": link_name,
+                    "frame": item.frame,
+                }
+            )
+            if item.frame.kind == "ack":
+                message_id = item.frame.acknowledged_message_id
+                assert message_id is not None
+                target_store = (
+                    self.mission_store if item.destination == "mission" else self.field_store
+                )
+                target_store.acknowledge(message_id, acked_at=self.clock.now())
+                continue
+
+            envelope = item.frame.envelope
+            assert envelope is not None
+            received_at = self.clock.now()
+            assert received_at >= envelope.created_at
+            if envelope.not_before is not None:
+                assert received_at >= envelope.not_before
+            if item.destination == "field":
+                target = self.field
+                target_store = self.field_store
+                ack_source: Literal["mission", "field"] = "field"
+                ack_link = self.return_link
+            else:
+                target = self.mission
+                target_store = self.mission_store
+                ack_source = "mission"
+                ack_link = self.outbound_link
+            is_new = target_store.receive(envelope, received_at=received_at)
+            # ACK follows the durable inbox write and travels over the opposite
+            # physical direction, including for a duplicate envelope.
+            ack_link.submit(
+                ack_source,
+                LinkFrame.for_ack(envelope.message_id),
+                now=self.clock.seconds,
+            )
+            if is_new:
+                if (
+                    self._hold_field_intent
+                    and item.destination == "field"
+                    and isinstance(envelope.payload, OperationIntent)
+                ):
+                    self._held_field_intents.append(envelope)
+                else:
+                    await target.handle(envelope)
+        return bool(due)
+
+    def advance_to_next_work(self) -> bool:
+        next_deliveries = [
+            link.status(now=self.clock.seconds)["next_delivery_time"]
+            for link in (self.outbound_link, self.return_link)
+        ]
+        next_delivery = min((value for value in next_deliveries if value is not None), default=None)
+        next_outbox = self._next_outbox_attempt()
+        future_work = [
+            instant
+            for instant in (next_delivery, next_outbox)
+            if instant is not None and instant > self.clock.seconds
+        ]
+        if not future_work:
+            return False
+        self.clock.advance_to(min(future_work))
+        return True
+
+    async def release_field_intents(self) -> None:
+        held = tuple(self._held_field_intents)
+        self._held_field_intents.clear()
+        for envelope in held:
+            await self.field.handle(envelope)
+
+    async def settle(self, *, before_return: object | None = None) -> None:
+        """Converge all due domain work while advancing only real deadlines."""
+
+        checkpoint_called = False
+        for _ in range(256):
+            progressed = False
+            if await self.submit_pending_link("mission"):
+                progressed = True
+            if await self.submit_pending_link("field"):
+                progressed = True
+            if await self.deliver_link_due():
+                progressed = True
+            if await self.drain_field_robot():
+                progressed = True
+            if (
+                before_return is not None
+                and not checkpoint_called
+                and self.external_adapter.press_count
+            ):
+                assert callable(before_return)
+                before_return()
+                checkpoint_called = True
+            if await self.submit_pending_link("mission"):
+                progressed = True
+            if await self.submit_pending_link("field"):
+                progressed = True
+            if await self.deliver_link_due():
+                progressed = True
+            if await self.drain_field_robot():
+                progressed = True
+
+            next_deliveries = [
+                link.status(now=self.clock.seconds)["next_delivery_time"]
+                for link in (self.outbound_link, self.return_link)
+            ]
+            next_delivery = min(
+                (value for value in next_deliveries if value is not None), default=None
+            )
+            next_outbox = self._next_outbox_attempt()
+            if self.advance_to_next_work():
+                progressed = True
+            if not progressed and next_delivery is None and next_outbox is None:
+                return
+        raise AssertionError("external long-delay domain did not converge")
+
+
+def _run(coroutine):
+    return asyncio.run(coroutine)
+
+
+def _assert_virtual_timing(harness: ExternalDelayHarness) -> None:
+    """Check send/receive/not-before/expiry against the same virtual clock."""
+
+    link_sources = {"outbound": "mission->outbound", "return": "field->return"}
+    link_delays = {"outbound": harness.forward_delay, "return": harness.return_delay}
+    for record in harness.send_log:
+        envelope = record["envelope"]
+        assert isinstance(envelope, MessageEnvelope)
+        sent_at = EPOCH + timedelta(seconds=float(record["send_time"]))
+        assert sent_at >= envelope.created_at
+        if envelope.not_before is not None:
+            assert sent_at >= envelope.not_before
+        if envelope.expires_at is not None:
+            assert sent_at < envelope.expires_at
+
+    for record in harness.delivery_log:
+        frame = record["frame"]
+        if frame.kind != "envelope":
+            continue
+        envelope = frame.envelope
+        assert envelope is not None
+        received_at = EPOCH + timedelta(seconds=float(record["received_at"]))
+        assert received_at >= envelope.created_at
+        if envelope.not_before is not None:
+            assert received_at >= envelope.not_before
+        if envelope.expires_at is not None:
+            assert received_at < envelope.expires_at
+        link_name = str(record["link"])
+        if link_name not in link_sources:
+            continue
+        source = link_sources[link_name]
+        send = next(
+            entry
+            for entry in harness.send_log
+            if entry["source"] == source
+            and entry["envelope"].message_id == envelope.message_id
+        )
+        expected_delivery = float(send["send_time"]) + link_delays[link_name]
+        assert float(record["delivery_time"]) + 1e-9 >= expected_delivery
+
+
+def _journal_result(harness: ExternalDelayHarness) -> tuple[dict[str, object], dict[str, object]]:
+    journal = harness.robot_store.inspect_execution_journal()
+    assert len(journal) == 1
+    row = journal[0]
+    result = json.loads(str(row["terminal_result_json"]))
+    assert isinstance(result, dict)
+    return row, result
+
+
+def _write_machine_table(data_dir: Path, row: dict[str, object]) -> None:
+    """Export one actual run without committing a random/golden artifact."""
+
+    report = data_dir / "external-effect-long-delay-results.json"
+    report.write_text(
+        json.dumps(
+            {"schema": "dtt.external-effect-long-delay.v1", "rows": [row]},
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    encoded = json.loads(report.read_text(encoding="utf-8"))
+    assert encoded["schema"] == "dtt.external-effect-long-delay.v1"
+    assert len(encoded["rows"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("forward_delay", "return_delay"),
+    [(1200.0, 1200.0), (900.0, 1200.0)],
+    ids=["symmetric-1200", "asymmetric-900-out-1200-back"],
+)
+def test_external_effect_long_delay_nominal_reconciles_after_return(
+    tmp_path: Path, forward_delay: float, return_delay: float
+) -> None:
+    async def scenario() -> None:
+        harness = ExternalDelayHarness(
+            tmp_path,
+            forward_delay=forward_delay,
+            return_delay=return_delay,
+        )
+        try:
+            ttl_seconds = forward_delay + return_delay + 600.0
+            intent = harness.mission.submit_press_button(expires_in_seconds=ttl_seconds)
+            checkpoints: list[float] = []
+
+            def assert_before_return() -> None:
+                checkpoints.append(harness.clock.seconds)
+                assert harness.external_adapter.press_count == 1
+                assert harness.robot.effect_counter == 0
+                assert harness.mission.view()["terminal_state"] is None
+
+            await harness.settle(before_return=assert_before_return)
+            view = harness.mission.view()
+            assert checkpoints == [pytest.approx(forward_delay)]
+            assert view["operation_id"] == str(intent.payload.operation_id)
+            assert view["terminal_state"] == ContractState.SUCCEEDED.value
+            assert harness.external_adapter.press_count == 1
+            assert harness.robot.effect_counter == 0
+
+            journal, result = _journal_result(harness)
+            effect_key = f"press:{intent.payload.operation_id}:1"
+            assert journal["contract_revision"] == 1
+            assert journal["state"] == ContractState.SUCCEEDED.value
+            assert journal["effect_count"] == 0
+            assert result["effect_key"] == effect_key
+            assert result["device_id"] == "dummy-external-button-1"
+            assert result["external_outcome"] == ExternalOutcome.APPLIED.value
+            assert isinstance(result["observation_id"], str)
+            records = harness.external_adapter.records
+            assert len(records) == 1
+            assert records[0]["effect_key"] == effect_key
+            assert records[0]["device_id"] == result["device_id"]
+
+            # External resolution has no robot telemetry.  Field forwards its
+            # initial measured snapshot, but never invents a completion snapshot.
+            snapshots = [
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, SiteSnapshot)
+            ]
+            assert len(snapshots) == 1
+            assert snapshots[0].payload.evidence.world_revision == 1
+
+            terminal_send = next(
+                record
+                for record in harness.send_log
+                if record["source"] == "field->return"
+                and isinstance(record["envelope"].payload, ExecutionEvent)
+                and record["envelope"].payload.next_state is ContractState.SUCCEEDED
+            )
+            terminal_delivery = next(
+                record
+                for record in harness.delivery_log
+                if record["destination"] == "mission"
+                and record["frame"].kind == "envelope"
+                and isinstance(record["frame"].envelope.payload, ExecutionEvent)
+                and record["frame"].envelope.payload.next_state is ContractState.SUCCEEDED
+            )
+            assert terminal_send["send_time"] == pytest.approx(forward_delay)
+            assert terminal_delivery["delivery_time"] == pytest.approx(
+                forward_delay + return_delay
+            )
+            _assert_virtual_timing(harness)
+            _write_machine_table(
+                tmp_path,
+                {
+                    "scenario": "nominal",
+                    "forward_delay_seconds": forward_delay,
+                    "return_delay_seconds": return_delay,
+                    "ttl_seconds": ttl_seconds,
+                    "effect_pulses": harness.external_adapter.press_count,
+                    "terminal_state": view["terminal_state"],
+                    "virtual_seconds": harness.clock.seconds,
+                },
+            )
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("recovery_outcome", "expected_state"),
+    [
+        (ExternalOutcome.APPLIED, ContractState.SUCCEEDED),
+        (ExternalOutcome.UNKNOWN, ContractState.HELD),
+    ],
+    ids=["recovery-applied", "recovery-unknown-held"],
+)
+def test_external_effect_crash_duplicate_contract_reopens_without_second_pulse(
+    tmp_path: Path, recovery_outcome: ExternalOutcome, expected_state: ContractState
+) -> None:
+    async def scenario() -> None:
+        harness = ExternalDelayHarness(
+            tmp_path,
+            forward_delay=900.0,
+            return_delay=1200.0,
+            adapter_factory=lambda path, clock: CrashAfterExternalPress(path, clock=clock),
+        )
+        try:
+            intent = harness.mission.submit_press_button(expires_in_seconds=3000.0)
+            with pytest.raises(RuntimeError, match="after external press"):
+                await harness.settle()
+
+            contract = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            assert harness.external_adapter.press_count == 1
+            assert harness.robot.effect_counter == 0
+            assert harness.mission.view()["terminal_state"] is None
+            assert harness.robot_store.inspect_inbox()[-1]["processing_state"] == "PROCESSING"
+
+            def reopened_adapter(path: Path, clock: VirtualClock) -> PersistentDummyExternalEffect:
+                return PersistentDummyExternalEffect(
+                    path,
+                    clock=clock,
+                    observation_outcome=recovery_outcome,
+                )
+
+            await harness.reopen_robot(reopened_adapter, recover=False)
+            # The same contract is received again while the interrupted inbox
+            # row is still durable.  NodeStore deduplicates it by message_id.
+            assert harness.robot_store.receive(contract, received_at=harness.clock.now()) is False
+            assert await harness.robot.recover() == 1
+            assert harness.external_adapter.press_count == 1
+            assert harness.robot.effect_counter == 0
+
+            await harness.settle()
+            view = harness.mission.view()
+            assert view["operation_id"] == str(intent.payload.operation_id)
+            assert view["terminal_state"] == expected_state.value
+            journal, result = _journal_result(harness)
+            effect_key = f"press:{intent.payload.operation_id}:1"
+            assert journal["contract_revision"] == 1
+            assert journal["state"] == expected_state.value
+            assert journal["effect_count"] == 0
+            assert result["effect_key"] == effect_key
+            assert result["device_id"] == "dummy-external-button-1"
+            assert result["external_outcome"] == recovery_outcome.value
+            assert len(harness.external_adapter.records) == 1
+            assert harness.external_adapter.records[0]["effect_key"] == effect_key
+            assert harness.external_adapter.records[0]["device_id"] == result["device_id"]
+
+            terminal_states = {
+                message.payload.next_state
+                for message in harness.mission_store.inbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+            }
+            if expected_state is ContractState.HELD:
+                assert ContractState.SUCCEEDED not in terminal_states
+            assert expected_state in terminal_states
+            snapshots = [
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, SiteSnapshot)
+            ]
+            assert len(snapshots) == 1
+            assert snapshots[0].payload.evidence.world_revision == 1
+            _assert_virtual_timing(harness)
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_external_effect_transport_expiry_before_field_admission_has_zero_pulses(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = ExternalDelayHarness(
+            tmp_path,
+            forward_delay=900.0,
+            return_delay=1200.0,
+        )
+        try:
+            intent = harness.mission.submit_press_button(expires_in_seconds=60.0)
+            await harness.settle()
+            assert harness.outbound_link.metrics["expired"] == 1
+            assert harness.outbound_link.status(now=harness.clock.seconds)["queued_deliveries"] == 0
+            assert harness.field_store.inbox_messages() == []
+            assert harness.external_adapter.press_count == 0
+            assert harness.robot.effect_counter == 0
+            assert harness.mission.view()["terminal_state"] is None
+            pending = [
+                row
+                for row in harness.mission_store.inspect_outbox()
+                if row["message_id"] == str(intent.message_id)
+            ]
+            assert len(pending) == 1
+            assert pending[0]["ack_state"] == "PENDING"
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_external_effect_field_inbox_queue_expires_without_invented_completion(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = ExternalDelayHarness(
+            tmp_path,
+            forward_delay=0.0,
+            return_delay=1200.0,
+            hold_field_intent=True,
+        )
+        try:
+            intent = harness.mission.submit_press_button(expires_in_seconds=60.0)
+            # EnvelopeFactory preserves a monotonic microsecond boundary after
+            # the epoch; advance to that real eligibility instant before sending.
+            assert harness.advance_to_next_work()
+            assert await harness.submit_pending_link("mission")
+            assert await harness.deliver_link_due()
+            assert harness.clock.seconds > 0.0
+            assert harness.clock.seconds < 0.001
+            assert len(harness._held_field_intents) == 1
+            field_row = next(
+                row
+                for row in harness.field_store.inspect_inbox()
+                if row["message_id"] == str(intent.message_id)
+            )
+            assert field_row["processing_state"] == "RECEIVED"
+            assert harness.external_adapter.press_count == 0
+            assert harness.field_store.outbox_messages() == []
+
+            assert intent.expires_at is not None
+            harness.clock.advance_to((intent.expires_at - EPOCH).total_seconds())
+            await harness.release_field_intents()
+            assert harness.external_adapter.press_count == 0
+            held_events = [
+                message.payload
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+            ]
+            assert len(held_events) == 1
+            assert held_events[0].next_state is ContractState.HELD
+            assert not any(
+                isinstance(message.payload, SiteSnapshot)
+                for message in harness.field_store.outbox_messages()
+            )
+
+            await harness.settle()
+            assert harness.external_adapter.press_count == 0
+            assert harness.robot.effect_counter == 0
+            assert harness.mission.view()["terminal_state"] == ContractState.HELD.value
+            _assert_virtual_timing(harness)
+        finally:
+            harness.close()
+
+    _run(scenario())


### PR DESCRIPTION
The M1.8b proof now runs the independently persistent, deliberately
non-idempotent external device through the real delayed Mission/Field domain.
Two deterministic directional links cover symmetric 1200-second and asymmetric
900-second outbound / 1200-second return propagation. The virtual scheduler
advances only to actual delivery or outbox eligibility and checks envelope
creation, not-before, and expiry boundaries.

The crash scenario records one device pulse, reopens the Robot SQLite store and
adapter, then delivers the same contract again. Recovery observes the existing
device record and retains one pulse; an ambiguous observation becomes `HELD`
without a false success. Transport expiry before Field admission and a locally
queued Field inbox evaluated at expiry produce no pulse and no invented completion
snapshot. The nominal runs export a temporary machine-readable result table and
leave the historical golden artifacts unchanged.

Validation: 6 focused tests pass; the full Python suite passes 115 tests; Ruff
and the CI release gate pass. No UE, network, OS-restart, or physical-hardware
validation is claimed. M1.8 remains open for durable autonomy-budget accounting
and cross-revision effect identity. Expiry or cancellation after external
dispatch and before Robot recovery is outside this proof; late-cancellation
policy belongs to the later M3a validation gate.

Closes #37