### PR TITLE
Add canonical transforms and generic fixed/revolute FK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
   symmetric 1200-second and asymmetric 900-second outbound / 1200-second return delays, including
   duplicate-contract recovery and receiving-site expiry boundaries;
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
+- canonical Unreal C++ transforms, strict robot-description parsing, generic tree FK, tool-frame
+  propagation, Blueprint functions and deterministic Automation Tests.
 
 ### Status
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
   symmetric 1200-second and asymmetric 900-second outbound / 1200-second return delays, including
   duplicate-contract recovery and receiving-site expiry boundaries;
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
-- canonical Unreal C++ transforms, strict robot-description parsing, generic tree FK, tool-frame
-  propagation, Blueprint functions and deterministic Automation Tests.
+- canonical Unreal C++ transforms, schema-scoped robot-description parsing, generic tree FK,
+  tool-frame propagation, Blueprint functions and Automation Test coverage. The roadmap tracks
+  the articulated-state protocol as M2.2 (#14), this FK implementation as M2.3 (#15), and the
+  numerical cross-language oracle as the planned M2.4 increment (#16). M2.3 is validated on
+  Linux and Win64 with Unreal Engine 5.8.2; the generated SO-101 check remains structural and
+  is not an M2.4 FK oracle.
 
 ### Status
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
-| SO-101 twin | M2.1 pinned structural description; FK, Unreal articulation and IK remain planned |
+| SO-101 twin | M2.2 canonical transforms and generic FK; SO-101 golden fixtures, Unreal articulation and IK remain planned |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
 
@@ -104,6 +104,10 @@ The [M1 release gate](docs/m1/RELEASE_GATE.md) binds a deterministic golden sess
 adversarial test matrix and records the evidence required for `v0.1.0`.
 The runtime authority and recovery boundaries are recorded in
 [ADR 0005](docs/adr/0005-m1-delayed-dummy-runtime.md).
+
+M2 starts from a pinned SO-101 structural source and a deterministic canonical description. The
+[canonical Unreal kinematics guide](docs/m2/CANONICAL_KINEMATICS.md) documents the generic C++
+fixed/revolute tree, its Blueprint boundary, and the remaining limits of this increment.
 
 Verify the portable gate in CI-compatible mode:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
-| SO-101 twin | M2.2 canonical transforms and generic FK; SO-101 golden fixtures, Unreal articulation and IK remain planned |
+| SO-101 twin | M2.3 canonical transforms/generic FK code (#15) complete with Linux and Win64 UE 5.8.2 evidence; M2.2 articulated-state protocol (#14), M2.4 numerical oracle (#16), Jacobian and IK remain pending |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
 
@@ -105,9 +105,13 @@ adversarial test matrix and records the evidence required for `v0.1.0`.
 The runtime authority and recovery boundaries are recorded in
 [ADR 0005](docs/adr/0005-m1-delayed-dummy-runtime.md).
 
-M2 starts from a pinned SO-101 structural source and a deterministic canonical description. The
-[canonical Unreal kinematics guide](docs/m2/CANONICAL_KINEMATICS.md) documents the generic C++
-fixed/revolute tree, its Blueprint boundary, and the remaining limits of this increment.
+M2 starts from a pinned SO-101 structural source and a deterministic canonical description. M2.2
+covers the articulated robot-state and model-reference protocol (#14), while M2.3 provides the
+generic C++ fixed/revolute tree and canonical/Unreal boundary (#15). The [canonical Unreal
+kinematics guide](docs/m2/CANONICAL_KINEMATICS.md)
+documents the schema-scoped parser, its Blueprint boundary, and the remaining limits of this
+increment. M2.4 will provide the numerical cross-language oracle (#16); no SO-101 FK golden
+result is claimed before that work and its Unreal validation are evidenced.
 
 Verify the portable gate in CI-compatible mode:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -144,18 +144,24 @@ No hardware-control path is introduced by this increment.
 
 ## M2 — Mathematical SO-101 twin in Unreal
 
-Status: **implementation in progress; M2.1 structural description complete**
+Status: **M2.3 math core complete; M2.2 protocol, M2.4 oracle, Jacobian and IK remain open**
 Target release: **`v0.2.0`**
 
-- textual robot description;
-- forward kinematics, Jacobian and constrained damped-least-squares IK in C++;
+- M2.2 articulated robot-state and model-reference protocol (#14);
+- M2.3 canonical transforms and generic fixed/revolute forward kinematics in C++ (#15),
+  validated on Linux and Win64 with Unreal Engine 5.8.2;
+- M2.4 cross-language numerical oracle (#16);
+- Jacobian and constrained damped-least-squares IK;
 - separate rigid link meshes, without a skeletal mesh;
 - Blueprint-accessible target authoring and debugging;
 - confirmed, arrival and target representations with causal provenance;
 - trajectory lines and temporal markers;
 - a `KinematicPreview` that remains a local candidate, not an execution command.
 
-M2 is a mathematical and visualization milestone. `v0.2.0` requires no physical robot, hardware
+M2.3's recorded Linux and Win64 runs each pass 11 Automation tests (4 M1 and 7 M2) with build
+and headless-editor exit code 0. The generated SO-101 check validates model identity and structure;
+it is not the M2.4 numerical oracle and does not provide an FK golden result. M2 remains a
+mathematical and visualization milestone. `v0.2.0` requires no physical robot, hardware
 calibration or hardware-control path. M2 must preserve the distinction between an operator goal,
 a local kinematic preview, a Field admission and a Robot result. See the [M2 design](docs/design/M2_SO101_MATHEMATICAL_TWIN.md)
 and the [delayed-intent validation design](docs/design/DELAYED_INTENT_VALIDATION.md).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,7 +12,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
 | M1.8 | **In progress; M1.8b combined proof implemented** | External device runs through delayed Mission/Field domain; durable budget and cross-revision identity remain open |
-| M2 | **In progress; target `v0.2.0`** | M2.1 structural model is complete; FK, articulated Unreal state, IK and authoring remain |
+| M2 | **In progress; target `v0.2.0`** | M2.1 structural model and M2.3 FK math core are complete with Linux/Win64 UE evidence; M2.2 protocol, M2.4 oracle, Jacobian, IK and authoring remain |
 | M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
 
@@ -80,10 +80,15 @@ independent external effect, or concurrent-operation causal coherence.
 - deterministic canonical right-handed metre/radian robot description;
 - explicit arm and gripper joint groups plus the `gripper_frame_link` tool frame;
 - offline source-hash, structure and generated-description drift checks on Linux and Windows.
+- M2.3 canonical transforms, generic fixed/revolute tree FK and named tool-frame output (#15);
+- M2.3 Unreal boundary conversion and schema-scoped parser for the generated description;
+- Linux and Win64 Unreal Engine 5.8.2 build and Automation evidence: 11 successful tests on
+  each target (4 M1 and 7 M2), with build and headless-editor exit code 0.
 
-The remaining M2 work is described in the [M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md).
-Its target is `v0.2.0`; it remains a mathematical and visualization milestone and does not
-require a physical robot.
+The generated SO-101 test checks model identity and structure only; it is not the M2.4 numerical
+cross-language oracle and supplies no FK golden result. Remaining M2 work is described in the
+[M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md). Its target is `v0.2.0`; it remains a
+mathematical and visualization milestone and does not require a physical robot.
 
 ## Implemented in M1.7a
 
@@ -133,7 +138,9 @@ The remaining full M1.8 gate requires:
 
 ### Remaining M2 work
 
-- forward kinematics and Jacobian in C++;
+- M2.2 articulated robot-state and model-reference protocol (#14);
+- M2.4 cross-language numerical oracle (#16);
+- Jacobian in C++;
 - constrained damped-least-squares IK with explicit status and residuals;
 - articulated Unreal link visualization and cross-language golden evidence;
 - desktop/VR target authoring and time-sampled `KinematicPreview`;
@@ -191,5 +198,5 @@ M3b's physical-fixture evidence is not present.
 
 No public hardware-control path exists. Nothing in the current repository should command a
 physical robot. The M1 release gate operates entirely on the public dummy path. Unreal Engine
-5.8.2 is verified on the reference Windows platform; `v0.1.0` does not claim Unreal support on
-Linux.
+5.8.2 is verified on the reference Windows platform for `v0.1.0` and on Linux/Win64 for the
+M2.3 math-core evidence; `v0.1.0` does not claim Unreal support on Linux.

--- a/docs/m2/CANONICAL_KINEMATICS.md
+++ b/docs/m2/CANONICAL_KINEMATICS.md
@@ -1,9 +1,13 @@
 # Canonical kinematics in Unreal
 
-M2.2 adds a small, robot-independent C++ kinematics core to
-`DeferredTeleopRuntime`. It consumes the generated `dtt.robot-description/0`
-JSON representation; it does not parse arbitrary URDF at runtime and it does
-not command hardware.
+M2.2 covers the articulated robot-state and model-reference protocol (#14).
+M2.3 implements a small, robot-independent C++ kinematics core in
+`DeferredTeleopRuntime` (#15). It consumes the generated
+`dtt.robot-description/0` JSON representation; it does not parse arbitrary
+URDF at runtime and it does not command hardware. The implementation is
+present and validated on Linux and Win64 with Unreal Engine 5.8.2. The
+cross-language numerical oracle remains M2.4 work; this does not claim an FK
+golden result.
 
 ## Contract
 
@@ -21,6 +25,13 @@ Robot descriptions contain named links, fixed or revolute joints, semantic
 joint groups, and tool frames. Validation rejects malformed transforms,
 non-unit axes, duplicate names, invalid references, multiple parents, cycles,
 disconnected links, and invalid group membership.
+
+The JSON reader is schema-scoped rather than a global strict validator. It
+checks the exact fields and values consumed by the kinematics model. Source
+metadata is checked structurally for traceability, and visual entries are only
+checked to be JSON objects; neither is retained in the kinematics model or used
+by FK. Visual parsing, mesh semantics, source provenance enforcement, and URDF
+import remain outside this increment.
 
 Forward kinematics accepts one finite named position for every revolute joint.
 It traverses the validated tree in a deterministic order and returns named
@@ -42,6 +53,10 @@ outside the mathematical core.
 
 ## Verification
 
+The [platform validation summary](evidence/fk-platform-validation.json) records
+the executed Linux and Win64 results, toolchains, test names and source-file
+hashes for this increment. It is a historical validation snapshot.
+
 Unreal Automation Tests under `DeferredTeleop.M2` cover:
 
 - rigid-transform composition;
@@ -49,27 +64,97 @@ Unreal Automation Tests under `DeferredTeleop.M2` cover:
 - invalid tree, axis, transform, group, and joint-state inputs;
 - explicit limit diagnostics without clamping;
 - canonical JSON parsing;
+- the committed generated SO-101 description, including its model identity,
+  link/joint/group/tool names and cardinalities (structure only, not FK values);
 - signed quarter-turn basis cases and canonical/Unreal round trips.
 
-The reference verification platform is Windows with Unreal Engine 5.8. The
-plugin can be compiled without launching the editor:
+The generated-description check is an integration guard for the structural
+model input consumed by M2.3. It is not the articulated-state protocol work in
+M2.2 (#14) or the numerical cross-language FK oracle planned for M2.4 (#16), and
+no SO-101 FK golden claim is made here.
 
-```powershell
-RunUAT.bat BuildPlugin `
-  -Plugin=C:\path\to\DeferredTeleop.uplugin `
-  -Package=C:\path\to\package `
-  -TargetPlatforms=Win64 `
-  -StrictIncludes
+The M2.3 verification recipe targets Unreal Engine 5.8.2 on Linux and Win64.
+It builds the existing project and runtime module from an intact monorepo
+checkout, then runs the Automation queue with `SoftQuit`:
+
+```bash
+ENGINE_ROOT='<unreal-engine-root>'
+REPO_ROOT='<deferred-teleoperation-checkout>'
+PROJECT="$REPO_ROOT/unreal/DeferredTeleopDemo/DeferredTeleopDemo.uproject"
+PLUGIN="$REPO_ROOT/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/DeferredTeleop.uplugin"
+REPORT_DIR='<writable-automation-report-directory>'
+
+"$ENGINE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh" UnrealEditor Linux Development \
+  -Project="$PROJECT" -Plugin="$PLUGIN" -NoUBTMakefiles -NoHotReload \
+  -MaxParallelActions=4
+
+"$ENGINE_ROOT/Engine/Binaries/Linux/UnrealEditor-Cmd" "$PROJECT" \
+  -unattended -nop4 -nosplash -NullRHI \
+  -ExecCmds="Automation RunTests DeferredTeleop.; SoftQuit" \
+  -ReportExportPath="$REPORT_DIR" -log
 ```
 
-Run the deterministic tests headlessly with a host project:
+The equivalent Win64 commands are:
 
 ```powershell
-UnrealEditor-Cmd.exe C:\path\to\DeferredTeleopDemo.uproject `
-  -unattended -nop4 -nosplash -NullRHI `
-  -ExecCmds="Automation RunTests DeferredTeleop.M2; Quit" `
-  -TestExit="Automation Test Queue Empty"
+$EngineRoot = '<unreal-engine-root>'
+$RepoRoot = '<deferred-teleoperation-checkout>'
+$Project = "$RepoRoot\unreal\DeferredTeleopDemo\DeferredTeleopDemo.uproject"
+$Plugin = "$RepoRoot\unreal\DeferredTeleopDemo\Plugins\DeferredTeleop\DeferredTeleop.uplugin"
+$ReportDir = '<writable-automation-report-directory>'
+
+& "$EngineRoot\Engine\Build\BatchFiles\Build.bat" UnrealEditor Win64 Development `
+  "-Project=$Project" "-Plugin=$Plugin" -NoUBTMakefiles -NoHotReload `
+  -MaxParallelActions=4
+
+$EditorCmd = Join-Path $EngineRoot 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
+$StartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$StartInfo.FileName = $EditorCmd
+$StartInfo.Arguments = @(
+  "`"$Project`""
+  '-unattended'
+  '-nop4'
+  '-nosplash'
+  '-NullRHI'
+  '-ExecCmds="Automation RunTests DeferredTeleop.; SoftQuit"'
+  "-ReportExportPath=`"$ReportDir`""
+  '-log'
+) -join ' '
+$StartInfo.UseShellExecute = $false
+$StartInfo.WorkingDirectory = Split-Path -Parent $Project
+$Process = [System.Diagnostics.Process]::Start($StartInfo)
+$Process.WaitForExit()
+$ExitCode = $Process.ExitCode
+$Process.Dispose()
+if ($ExitCode -ne 0) {
+  throw "UnrealEditor-Cmd failed with exit code $ExitCode"
+}
 ```
+
+The explicit `ProcessStartInfo.Arguments` string is intentional. A direct
+PowerShell native invocation can pass the `-ExecCmds` token with whole-argument
+quoting; Unreal's command-line parser then stops the value at its first space.
+The explicit form keeps the quotes around the complete command value and makes
+the editor exit status observable. This quoting procedure is covered by the
+recorded Windows run below.
+
+Do not add a queue-empty forced-exit flag to this recipe: on the Linux run it
+forced exit code 1 after the Automation tests had succeeded. `SoftQuit` lets
+the report complete and produced editor exit code 0.
+
+The tests require the monorepo checkout: the M2 integration test loads
+`robots/so101/generated/so101.kinematics.json` relative to `ProjectDir()/../../`,
+and the M1 tests load `fixtures/m1/golden-session` the same way. A packaged
+plugin without these repository files is insufficient.
+
+Recorded evidence on 4 September 2026 covers both targets. Linux used Unreal
+Engine 5.8.2 source commit `ff8421f2b8cb4feb76fff57965a1effc53a6eb7b` with
+Clang 20.1.8; the project/module build exited 0 and the headless editor
+reported 11 successful Automation tests (4 M1 and 7 M2) before exiting 0 with
+`SoftQuit`. Win64 UE 5.8.2 likewise reported 11 successful Automation tests
+(4 M1 and 7 M2), with build and editor exit code 0. These runs validate the
+M2.3 math core on both targets and support closing #15; they do not implement
+the M2.4 numerical oracle or add an SO-101 FK golden claim.
 
 These tests establish rigid-transform and FK behaviour only. Collision,
 dynamics, device calibration, motion planning, safety validation, articulated

--- a/docs/m2/CANONICAL_KINEMATICS.md
+++ b/docs/m2/CANONICAL_KINEMATICS.md
@@ -1,0 +1,76 @@
+# Canonical kinematics in Unreal
+
+M2.2 adds a small, robot-independent C++ kinematics core to
+`DeferredTeleopRuntime`. It consumes the generated `dtt.robot-description/0`
+JSON representation; it does not parse arbitrary URDF at runtime and it does
+not command hardware.
+
+## Contract
+
+The core uses one explicit convention until the Unreal presentation boundary:
+
+```text
+right-handed, Z-up
+metres and radians
+quaternion XYZW
+^A T_C = ^A T_B * ^B T_C
+double precision
+```
+
+Robot descriptions contain named links, fixed or revolute joints, semantic
+joint groups, and tool frames. Validation rejects malformed transforms,
+non-unit axes, duplicate names, invalid references, multiple parents, cycles,
+disconnected links, and invalid group membership.
+
+Forward kinematics accepts one finite named position for every revolute joint.
+It traverses the validated tree in a deterministic order and returns named
+world transforms for every link and tool. Position-limit violations are
+reported without silently clamping the requested state.
+
+## Unreal boundary
+
+Canonical transforms cross into Unreal through one conversion function. The
+basis change is `S = diag(1, -1, 1)`, translation is converted from metres to
+centimetres exactly once, and scale remains `(1, 1, 1)`. The reverse function
+exists for authoring and round-trip tests. Negative Actor scale is not used to
+repair handedness.
+
+Blueprint callers can parse a canonical JSON string, validate a description,
+evaluate FK, and convert transforms through
+`UDeferredTeleopKinematicsLibrary`. File selection and asset packaging stay
+outside the mathematical core.
+
+## Verification
+
+Unreal Automation Tests under `DeferredTeleop.M2` cover:
+
+- rigid-transform composition;
+- generic branched fixed/revolute FK and tool propagation;
+- invalid tree, axis, transform, group, and joint-state inputs;
+- explicit limit diagnostics without clamping;
+- canonical JSON parsing;
+- signed quarter-turn basis cases and canonical/Unreal round trips.
+
+The reference verification platform is Windows with Unreal Engine 5.8. The
+plugin can be compiled without launching the editor:
+
+```powershell
+RunUAT.bat BuildPlugin `
+  -Plugin=C:\path\to\DeferredTeleop.uplugin `
+  -Package=C:\path\to\package `
+  -TargetPlatforms=Win64 `
+  -StrictIncludes
+```
+
+Run the deterministic tests headlessly with a host project:
+
+```powershell
+UnrealEditor-Cmd.exe C:\path\to\DeferredTeleopDemo.uproject `
+  -unattended -nop4 -nosplash -NullRHI `
+  -ExecCmds="Automation RunTests DeferredTeleop.M2; Quit" `
+  -TestExit="Automation Test Queue Empty"
+```
+
+These tests establish rigid-transform and FK behaviour only. Collision,
+dynamics, device calibration, motion planning, safety validation, articulated
+rendering, Jacobians, and IK remain outside this increment.

--- a/docs/m2/evidence/fk-platform-validation.json
+++ b/docs/m2/evidence/fk-platform-validation.json
@@ -1,0 +1,287 @@
+{
+  "schema": "dtt.validation-summary/0",
+  "scope": "M2.3 canonical transforms and generic forward kinematics",
+  "evidence_date": "2026-09-04",
+  "evidence_kind": "Normalized record of executed Unreal build and Automation reports",
+  "reproduction_recipe": "docs/m2/CANONICAL_KINEMATICS.md",
+  "build_scope": "Existing UnrealEditor Development project/runtime module; not an engine build or packaged-plugin build",
+  "automation_arguments": [
+    "-unattended",
+    "-nop4",
+    "-nosplash",
+    "-NullRHI",
+    "-ExecCmds=\"Automation RunTests DeferredTeleop.; SoftQuit\"",
+    "-ReportExportPath=<REPORT_DIR>"
+  ],
+  "source_files": [
+    {
+      "path": "fixtures/m1/golden-session/expected-mission-view.json",
+      "bytes": 5221,
+      "sha256": "5412ade4288360091807e7be4040d319873d2089822564683a99eeb4f5033512"
+    },
+    {
+      "path": "robots/so101/generated/so101.kinematics.json",
+      "bytes": 14698,
+      "sha256": "36ce321332248351f5304630a9ccc4887d6665666e17b6933e3302874735e5f2"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/DeferredTeleopDemo.uproject",
+      "bytes": 511,
+      "sha256": "86ba4cc0c07997bdf0b8083b43236a7b79ea642144105aa6263e6bfba24e1b39"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/DeferredTeleop.uplugin",
+      "bytes": 609,
+      "sha256": "5587a5d087cf44eabdea70e2d9de4edc157c20989ba75d9c7cc6221d8c0b6427"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/DeferredTeleopRuntime.Build.cs",
+      "bytes": 566,
+      "sha256": "94cce8c400553ffb84b8a34ebe419276c8d9c86b868df8eddf51fe7479d25f3f"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionClientComponent.cpp",
+      "bytes": 5114,
+      "sha256": "fbda6aab08076de4dbc02216c263a7aa75d8bbc2db7c20ed68e73cbac821532d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.cpp",
+      "bytes": 29101,
+      "sha256": "e7a26dc0306c317070aab990731f037a144fc8494133fcedd197d951553e4ab5"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.h",
+      "bytes": 221,
+      "sha256": "7a00e323cf9a27a07e0af16833d71746b7ec20b72e865b6d17b880a35bc0f38d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopRuntime.cpp",
+      "bytes": 380,
+      "sha256": "c3e3c943960d18a1d9a34742aae5fe9770061191187b39bc5517c5d9b90ae887"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStateVisualizationActor.cpp",
+      "bytes": 21285,
+      "sha256": "e6bf490426bfe6a8610a64747d12d2dc1d5bfa00e047daa37b41d67aea576235"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVersionLibrary.cpp",
+      "bytes": 147,
+      "sha256": "cbb763125de0ae7830795d16860140a1e0bc18038ec7f2fdf15ab3b6dfdbeeef"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVisualizationLibrary.cpp",
+      "bytes": 768,
+      "sha256": "e88d55a276d4de67d09969db610049732ff6a17b9476846b1e08ddc6ec1e4a3c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp",
+      "bytes": 34212,
+      "sha256": "17e07edf30e6bda519da3c0415f0f0cf0563403ac33b9ae0c0ad32a079900773"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp",
+      "bytes": 22320,
+      "sha256": "1de65b1bac4359120f668ec146dada0016c1b6809c1e9c50adb757bbe30083cd"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelTypes.cpp",
+      "bytes": 4178,
+      "sha256": "ca9693125f9ff761105c67cf165b5c16bbc2ee43dc6b8fd58fee4cacbd8a74e0"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp",
+      "bytes": 32513,
+      "sha256": "d2a96bbba4dde2d677918c29d02a90dea085660534f4b64a47b1f547fc827da9"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopMissionViewTests.cpp",
+      "bytes": 5855,
+      "sha256": "40a56f91054898732a26a9b1958c06a9279bc2e07a94ce374fda27fe7bd152e2"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionClientComponent.h",
+      "bytes": 3357,
+      "sha256": "9323d041d73879e54feee96ffd21d2e7e7ca242981157ef370a2b597ea164c9c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionViewTypes.h",
+      "bytes": 7783,
+      "sha256": "a6ab1e5b9b9d23d8693b99b59ae3ed20eee71e6dd71742f43189e329467378ce"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopRuntime.h",
+      "bytes": 276,
+      "sha256": "5ab43d0e84c526acd869d73a2ea98391de5635e7fd75e10663a532051c0a128d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopStateVisualizationActor.h",
+      "bytes": 4702,
+      "sha256": "4c7123a741f1108cdb1f5abfcc502b125ebe5d19f338b352bdce6169df8eb734"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVersionLibrary.h",
+      "bytes": 417,
+      "sha256": "903971ea5a3b55d07a45751acbad2fbf9114a8865d5490d4a286756a19d54f04"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVisualizationLibrary.h",
+      "bytes": 491,
+      "sha256": "0669fd5f9123f8eafc8e7bca5913822a6c3f8cb1efae1da459d8f75eb40fd93c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicsLibrary.h",
+      "bytes": 3812,
+      "sha256": "697f41e5611ba0f35c564d779e5e5a3d8ec447dc258afd428725c3bfeb5ec705"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h",
+      "bytes": 9592,
+      "sha256": "b10aea77aac60a5b8d539d4c00c481250ca465564cf7f83a118d7e287e8939d4"
+    }
+  ],
+  "source_files_sha256": "f847688b80eee86721b0335c7ce61a732875b6f26e42ed77c77a337d9f1d62dc",
+  "source_files_hash_encoding": "UTF-8 JSON of source_files, sorted object keys, separators comma/colon, no trailing newline",
+  "platforms": [
+    {
+      "platform": "Linux",
+      "environment": {
+        "engine_version": "5.8.2",
+        "engine_source_commit": "ff8421f2b8cb4feb76fff57965a1effc53a6eb7b",
+        "compiler": "Clang 20.1.8"
+      },
+      "report_created_at_utc": "2026-09-04T20:40:42+00:00",
+      "build_exit_code": 0,
+      "editor_exit_code": 0,
+      "raw_automation_report_sha256": "c9f649a5debc4513c3b569669b9a594b6da298c7cff267a3b67aa5188ab8f711",
+      "counts": {
+        "succeeded": 11,
+        "succeededWithWarnings": 0,
+        "failed": 0,
+        "notRun": 0,
+        "inProcess": 0
+      },
+      "tests": [
+        {
+          "name": "DeferredTeleop.M1.MissionView.GoldenFixtureParses",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.MissionView.RejectsUnsupportedAndMalformed",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.MissionView.ValidStrictFrame",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.Visualization.ConvertsFrameAndUnits",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.CanonicalComposition",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.CanonicalUnrealConversion",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.GenericTreeForwardKinematics",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.RejectsInvalidDescriptions",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.RejectsInvalidJointInputs",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.RobotModel.ParsesCanonicalJson",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.RobotModel.ParsesGeneratedSo101Description",
+          "state": "Success"
+        }
+      ]
+    },
+    {
+      "platform": "Win64",
+      "environment": {
+        "engine_version": "5.8.2",
+        "engine_source_commit": null,
+        "engine_source_commit_status": "Not independently verifiable in this engine installation",
+        "compiler": "MSVC cl.exe 19.50.35737.0",
+        "toolchain_reported_by_ubt": "14.50.35737",
+        "visual_studio": "18.9.12120.119",
+        "windows_sdk": "10.0.26100.0"
+      },
+      "report_created_at_utc": "2026-09-04T21:42:12+00:00",
+      "build_exit_code": 0,
+      "editor_exit_code": 0,
+      "raw_automation_report_sha256": "2f53939c92866fac16958c3779a8a94a055735fcf318deef9453890e15b5d3bd",
+      "counts": {
+        "succeeded": 11,
+        "succeededWithWarnings": 0,
+        "failed": 0,
+        "notRun": 0,
+        "inProcess": 0
+      },
+      "tests": [
+        {
+          "name": "DeferredTeleop.M1.MissionView.GoldenFixtureParses",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.MissionView.RejectsUnsupportedAndMalformed",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.MissionView.ValidStrictFrame",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M1.Visualization.ConvertsFrameAndUnits",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.CanonicalComposition",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.CanonicalUnrealConversion",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.GenericTreeForwardKinematics",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.RejectsInvalidDescriptions",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.Kinematics.RejectsInvalidJointInputs",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.RobotModel.ParsesCanonicalJson",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.RobotModel.ParsesGeneratedSo101Description",
+          "state": "Success"
+        }
+      ]
+    }
+  ],
+  "limitations": [
+    "Raw logs are retained outside the repository; this summary records their observed results and report hashes.",
+    "The selected source bytes matched both platform snapshots and the reviewed implementation at publication.",
+    "SO-101 coverage here verifies generated-description structure, not the numerical cross-language oracle tracked by M2.4.",
+    "No articulated-state feed, IK, hardware, collision, dynamics or performance claim."
+  ]
+}

--- a/robots/so101/README.md
+++ b/robots/so101/README.md
@@ -69,7 +69,7 @@ radians
 quaternion XYZW rotations
 ```
 
-The Unreal runtime will consume the generated description rather than parse arbitrary URDF/XML.
+The Unreal runtime consumes this generated description rather than parsing arbitrary URDF/XML.
 CI and unit tests reject source-hash drift or a generated file that no longer matches the pinned
 source and generator.
 
@@ -79,6 +79,7 @@ On 4 September 2026, a fresh `--check` produced the same committed artifact with
 
 ## Current status
 
-The M2.1 increment contains the pinned source, source lock, deterministic generator, canonical
-generated description, third-party notice and drift checks. Forward kinematics, Unreal loading and
-hardware calibration remain separate later increments.
+M2.1 contains the pinned source, source lock, deterministic generator, canonical generated
+description, third-party notice and drift checks. M2.2 adds strict Unreal-side parsing and generic
+fixed/revolute tree FK. Shared SO-101 golden fixtures, articulated rendering, IK and hardware
+calibration remain separate later increments.

--- a/robots/so101/README.md
+++ b/robots/so101/README.md
@@ -80,6 +80,10 @@ On 4 September 2026, a fresh `--check` produced the same committed artifact with
 ## Current status
 
 M2.1 contains the pinned source, source lock, deterministic generator, canonical generated
-description, third-party notice and drift checks. M2.2 adds strict Unreal-side parsing and generic
-fixed/revolute tree FK. Shared SO-101 golden fixtures, articulated rendering, IK and hardware
-calibration remain separate later increments.
+description, third-party notice and drift checks. M2.2 covers the articulated robot-state and
+model-reference protocol (#14). M2.3 implements schema-scoped Unreal-side parsing and generic
+fixed/revolute tree FK (#15): source metadata is checked structurally and visual entries are only
+checked as JSON objects, with neither used by FK. The generated-description test checks identity
+and structure only. M2.3 is validated on Linux and Win64 with Unreal Engine 5.8.2; the numerical
+cross-language oracle (M2.4, #16), shared SO-101 FK golden fixtures, articulated rendering, IK and
+hardware calibration remain separate later increments.

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp
@@ -924,9 +924,13 @@ bool ConvertUnrealToCanonicalTransform(
     {
         return Fail(OutError, TEXT("Unreal transform rotation must be non-zero and finite"));
     }
+    if (FMath::Abs(NormSquared - 1.0) > QuaternionNormTolerance)
+    {
+        return Fail(OutError, TEXT("Unreal transform rotation must be a normalized quaternion"));
+    }
 
     const FDttMatrix3 CanonicalRotation = ReflectYBasis(
-        CanonicalRotationMatrix(NormalizeQuaternion(UnrealQuaternion)));
+        CanonicalRotationMatrix(UnrealQuaternion));
     FQuat4d CanonicalQuaternion;
     if (!MatrixToQuaternion(CanonicalRotation, CanonicalQuaternion))
     {

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp
@@ -1,0 +1,996 @@
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+
+#include "Math/UnrealMathUtility.h"
+
+namespace DeferredTeleop::Kinematics::Private
+{
+constexpr double AxisNormTolerance = 1.0e-6;
+constexpr double QuaternionNormTolerance = 1.0e-6;
+constexpr double ScaleTolerance = 1.0e-5;
+
+bool Fail(FString& OutError, const FString& Message)
+{
+    OutError = Message;
+    return false;
+}
+
+bool IsFiniteQuaternion(const FQuat4d& Quaternion)
+{
+    return FMath::IsFinite(Quaternion.X)
+        && FMath::IsFinite(Quaternion.Y)
+        && FMath::IsFinite(Quaternion.Z)
+        && FMath::IsFinite(Quaternion.W);
+}
+
+bool IsUnitAxis(const FDttCanonicalVector& Axis)
+{
+    if (!Axis.IsFinite())
+    {
+        return false;
+    }
+
+    const double NormSquared = Axis.X * Axis.X + Axis.Y * Axis.Y + Axis.Z * Axis.Z;
+    return FMath::IsFinite(NormSquared)
+        && NormSquared > UE_DOUBLE_SMALL_NUMBER
+        && FMath::Abs(NormSquared - 1.0) <= AxisNormTolerance;
+}
+
+FQuat4d NormalizeQuaternion(const FQuat4d& Quaternion)
+{
+    const double NormSquared =
+        Quaternion.X * Quaternion.X
+        + Quaternion.Y * Quaternion.Y
+        + Quaternion.Z * Quaternion.Z
+        + Quaternion.W * Quaternion.W;
+    const double InverseNorm = 1.0 / FMath::Sqrt(NormSquared);
+    return FQuat4d(
+        Quaternion.X * InverseNorm,
+        Quaternion.Y * InverseNorm,
+        Quaternion.Z * InverseNorm,
+        Quaternion.W * InverseNorm);
+}
+
+struct FDttMatrix3
+{
+    double M[3][3] = {
+        {1.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0},
+        {0.0, 0.0, 1.0},
+    };
+};
+
+FDttMatrix3 Multiply(const FDttMatrix3& Left, const FDttMatrix3& Right)
+{
+    FDttMatrix3 Result;
+    for (int32 Row = 0; Row < 3; ++Row)
+    {
+        for (int32 Column = 0; Column < 3; ++Column)
+        {
+            Result.M[Row][Column] = 0.0;
+            for (int32 Index = 0; Index < 3; ++Index)
+            {
+                Result.M[Row][Column] += Left.M[Row][Index] * Right.M[Index][Column];
+            }
+        }
+    }
+    return Result;
+}
+
+FDttMatrix3 CanonicalRotationMatrix(const FQuat4d& InputQuaternion)
+{
+    const FQuat4d Quaternion = NormalizeQuaternion(InputQuaternion);
+    const double XX = Quaternion.X * Quaternion.X;
+    const double YY = Quaternion.Y * Quaternion.Y;
+    const double ZZ = Quaternion.Z * Quaternion.Z;
+    const double XY = Quaternion.X * Quaternion.Y;
+    const double XZ = Quaternion.X * Quaternion.Z;
+    const double YZ = Quaternion.Y * Quaternion.Z;
+    const double WX = Quaternion.W * Quaternion.X;
+    const double WY = Quaternion.W * Quaternion.Y;
+    const double WZ = Quaternion.W * Quaternion.Z;
+
+    FDttMatrix3 Result;
+    Result.M[0][0] = 1.0 - 2.0 * (YY + ZZ);
+    Result.M[0][1] = 2.0 * (XY - WZ);
+    Result.M[0][2] = 2.0 * (XZ + WY);
+    Result.M[1][0] = 2.0 * (XY + WZ);
+    Result.M[1][1] = 1.0 - 2.0 * (XX + ZZ);
+    Result.M[1][2] = 2.0 * (YZ - WX);
+    Result.M[2][0] = 2.0 * (XZ - WY);
+    Result.M[2][1] = 2.0 * (YZ + WX);
+    Result.M[2][2] = 1.0 - 2.0 * (XX + YY);
+    return Result;
+}
+
+/** Apply S = diag(1, -1, 1), i.e. a change from canonical RH to Unreal LH. */
+FDttMatrix3 ReflectYBasis(const FDttMatrix3& Matrix)
+{
+    constexpr double Signs[3] = {1.0, -1.0, 1.0};
+    FDttMatrix3 Result;
+    for (int32 Row = 0; Row < 3; ++Row)
+    {
+        for (int32 Column = 0; Column < 3; ++Column)
+        {
+            Result.M[Row][Column] = Signs[Row] * Matrix.M[Row][Column] * Signs[Column];
+        }
+    }
+    return Result;
+}
+
+bool IsFiniteMatrix(const FDttMatrix3& Matrix)
+{
+    for (int32 Row = 0; Row < 3; ++Row)
+    {
+        for (int32 Column = 0; Column < 3; ++Column)
+        {
+            if (!FMath::IsFinite(Matrix.M[Row][Column]))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool MatrixToQuaternion(const FDttMatrix3& Matrix, FQuat4d& OutQuaternion)
+{
+    if (!IsFiniteMatrix(Matrix))
+    {
+        return false;
+    }
+
+    const double Trace = Matrix.M[0][0] + Matrix.M[1][1] + Matrix.M[2][2];
+    double X = 0.0;
+    double Y = 0.0;
+    double Z = 0.0;
+    double W = 0.0;
+
+    if (Trace > 0.0)
+    {
+        const double S = 2.0 * FMath::Sqrt(FMath::Max(0.0, Trace + 1.0));
+        if (S <= UE_DOUBLE_SMALL_NUMBER)
+        {
+            return false;
+        }
+        W = 0.25 * S;
+        X = (Matrix.M[2][1] - Matrix.M[1][2]) / S;
+        Y = (Matrix.M[0][2] - Matrix.M[2][0]) / S;
+        Z = (Matrix.M[1][0] - Matrix.M[0][1]) / S;
+    }
+    else if (Matrix.M[0][0] > Matrix.M[1][1] && Matrix.M[0][0] > Matrix.M[2][2])
+    {
+        const double S = 2.0 * FMath::Sqrt(FMath::Max(
+            0.0,
+            1.0 + Matrix.M[0][0] - Matrix.M[1][1] - Matrix.M[2][2]));
+        if (S <= UE_DOUBLE_SMALL_NUMBER)
+        {
+            return false;
+        }
+        W = (Matrix.M[2][1] - Matrix.M[1][2]) / S;
+        X = 0.25 * S;
+        Y = (Matrix.M[0][1] + Matrix.M[1][0]) / S;
+        Z = (Matrix.M[0][2] + Matrix.M[2][0]) / S;
+    }
+    else if (Matrix.M[1][1] > Matrix.M[2][2])
+    {
+        const double S = 2.0 * FMath::Sqrt(FMath::Max(
+            0.0,
+            1.0 + Matrix.M[1][1] - Matrix.M[0][0] - Matrix.M[2][2]));
+        if (S <= UE_DOUBLE_SMALL_NUMBER)
+        {
+            return false;
+        }
+        W = (Matrix.M[0][2] - Matrix.M[2][0]) / S;
+        X = (Matrix.M[0][1] + Matrix.M[1][0]) / S;
+        Y = 0.25 * S;
+        Z = (Matrix.M[1][2] + Matrix.M[2][1]) / S;
+    }
+    else
+    {
+        const double S = 2.0 * FMath::Sqrt(FMath::Max(
+            0.0,
+            1.0 + Matrix.M[2][2] - Matrix.M[0][0] - Matrix.M[1][1]));
+        if (S <= UE_DOUBLE_SMALL_NUMBER)
+        {
+            return false;
+        }
+        W = (Matrix.M[1][0] - Matrix.M[0][1]) / S;
+        X = (Matrix.M[0][2] + Matrix.M[2][0]) / S;
+        Y = (Matrix.M[1][2] + Matrix.M[2][1]) / S;
+        Z = 0.25 * S;
+    }
+
+    const FQuat4d Candidate(X, Y, Z, W);
+    if (!IsFiniteQuaternion(Candidate))
+    {
+        return false;
+    }
+
+    const double NormSquared =
+        Candidate.X * Candidate.X
+        + Candidate.Y * Candidate.Y
+        + Candidate.Z * Candidate.Z
+        + Candidate.W * Candidate.W;
+    if (!FMath::IsFinite(NormSquared) || NormSquared <= UE_DOUBLE_SMALL_NUMBER)
+    {
+        return false;
+    }
+
+    OutQuaternion = NormalizeQuaternion(Candidate);
+
+    // q and -q encode the same rotation.  Pick a stable hemisphere for
+    // deterministic Blueprint/debug output and cross-platform fixtures.
+    if (OutQuaternion.W < 0.0
+        || (FMath::IsNearlyZero(OutQuaternion.W)
+            && (OutQuaternion.X < 0.0
+                || (FMath::IsNearlyZero(OutQuaternion.X) && OutQuaternion.Y < 0.0)
+                || (FMath::IsNearlyZero(OutQuaternion.X)
+                    && FMath::IsNearlyZero(OutQuaternion.Y)
+                    && OutQuaternion.Z < 0.0))))
+    {
+        OutQuaternion.X = -OutQuaternion.X;
+        OutQuaternion.Y = -OutQuaternion.Y;
+        OutQuaternion.Z = -OutQuaternion.Z;
+        OutQuaternion.W = -OutQuaternion.W;
+    }
+    return true;
+}
+
+bool ValidateTransform(const FDttCanonicalTransform& Transform, const FString& Path, FString& OutError)
+{
+    if (!Transform.IsFinite())
+    {
+        return Fail(OutError, Path + TEXT(" must contain only finite values"));
+    }
+    if (!Transform.Rotation.IsNormalized(QuaternionNormTolerance))
+    {
+        return Fail(OutError, Path + TEXT(" rotation must be a normalized quaternion"));
+    }
+    return true;
+}
+
+bool ValidateAxis(const FDttCanonicalVector& Axis, const FString& Path, FString& OutError)
+{
+    if (!Axis.IsFinite())
+    {
+        return Fail(OutError, Path + TEXT(" must contain only finite values"));
+    }
+    const double NormSquared = Axis.X * Axis.X + Axis.Y * Axis.Y + Axis.Z * Axis.Z;
+    if (!FMath::IsFinite(NormSquared) || NormSquared <= UE_DOUBLE_SMALL_NUMBER)
+    {
+        return Fail(OutError, Path + TEXT(" must be non-zero"));
+    }
+    if (FMath::Abs(NormSquared - 1.0) > AxisNormTolerance)
+    {
+        return Fail(OutError, Path + TEXT(" must be unit length"));
+    }
+    return true;
+}
+} // namespace DeferredTeleop::Kinematics::Private
+
+void FDttValidatedRobotModel::Reset()
+{
+    LinkIndexByName.Reset();
+    JointIndexByName.Reset();
+    ToolIndexByName.Reset();
+    ParentJointByLink.Reset();
+    LinkTraversalOrder.Reset();
+    JointTraversalOrder.Reset();
+}
+
+int32 FDttValidatedRobotModel::FindLinkIndex(FName LinkName) const
+{
+    const int32* Found = LinkIndexByName.Find(LinkName);
+    return Found != nullptr ? *Found : INDEX_NONE;
+}
+
+int32 FDttValidatedRobotModel::FindJointIndex(FName JointName) const
+{
+    const int32* Found = JointIndexByName.Find(JointName);
+    return Found != nullptr ? *Found : INDEX_NONE;
+}
+
+int32 FDttValidatedRobotModel::FindToolIndex(FName ToolName) const
+{
+    const int32* Found = ToolIndexByName.Find(ToolName);
+    return Found != nullptr ? *Found : INDEX_NONE;
+}
+
+namespace DeferredTeleop::Kinematics
+{
+using namespace Private;
+
+bool ValidateRobotDescription(
+    const FDttRobotDescription& Description,
+    FDttValidatedRobotModel& OutModel,
+    FString& OutError)
+{
+    OutModel.Reset();
+    OutError.Reset();
+
+    if (Description.Links.Num() == 0)
+    {
+        return Fail(OutError, TEXT("robot description must contain at least one link"));
+    }
+    if (Description.RootLinkName.IsNone())
+    {
+        return Fail(OutError, TEXT("robot description root_link_name is required"));
+    }
+    if (Description.ModelId.IsEmpty() || Description.ModelRevision.IsEmpty())
+    {
+        return Fail(
+            OutError,
+            TEXT("robot description model_id and model_revision are required"));
+    }
+
+    OutModel.LinkIndexByName.Reserve(Description.Links.Num());
+    for (int32 LinkIndex = 0; LinkIndex < Description.Links.Num(); ++LinkIndex)
+    {
+        const FName LinkName = Description.Links[LinkIndex].Name;
+        if (LinkName.IsNone())
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("links[%d].name must be non-empty"), LinkIndex));
+        }
+        if (OutModel.LinkIndexByName.Contains(LinkName))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("duplicate link name: %s"), *LinkName.ToString()));
+        }
+        OutModel.LinkIndexByName.Add(LinkName, LinkIndex);
+    }
+
+    const int32 RootLinkIndex = OutModel.FindLinkIndex(Description.RootLinkName);
+    if (RootLinkIndex == INDEX_NONE)
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("root link does not exist: %s"),
+                *Description.RootLinkName.ToString()));
+    }
+
+    OutModel.ParentJointByLink.Init(INDEX_NONE, Description.Links.Num());
+    OutModel.JointIndexByName.Reserve(Description.Joints.Num());
+    for (int32 JointIndex = 0; JointIndex < Description.Joints.Num(); ++JointIndex)
+    {
+        const FDttRobotJointDescription& Joint = Description.Joints[JointIndex];
+        if (Joint.Name.IsNone())
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("joints[%d].name must be non-empty"), JointIndex));
+        }
+        if (OutModel.JointIndexByName.Contains(Joint.Name))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("duplicate joint name: %s"), *Joint.Name.ToString()));
+        }
+        OutModel.JointIndexByName.Add(Joint.Name, JointIndex);
+
+        const int32 ParentIndex = OutModel.FindLinkIndex(Joint.ParentLink);
+        const int32 ChildIndex = OutModel.FindLinkIndex(Joint.ChildLink);
+        if (ParentIndex == INDEX_NONE || ChildIndex == INDEX_NONE)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("joint %s references an unknown parent or child link"),
+                    *Joint.Name.ToString()));
+        }
+        if (ParentIndex == ChildIndex)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("joint %s cannot connect a link to itself"),
+                    *Joint.Name.ToString()));
+        }
+        if (OutModel.ParentJointByLink[ChildIndex] != INDEX_NONE)
+        {
+            const FDttRobotJointDescription& ExistingJoint =
+                Description.Joints[OutModel.ParentJointByLink[ChildIndex]];
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("link %s has multiple parent joints: %s and %s"),
+                    *Joint.ChildLink.ToString(),
+                    *ExistingJoint.Name.ToString(),
+                    *Joint.Name.ToString()));
+        }
+        OutModel.ParentJointByLink[ChildIndex] = JointIndex;
+
+        const FString JointPath = FString::Printf(TEXT("joint %s parent_to_joint"), *Joint.Name.ToString());
+        if (!ValidateTransform(Joint.ParentToJoint, JointPath, OutError))
+        {
+            return false;
+        }
+
+        if (Joint.Type == EDttRobotJointType::Revolute)
+        {
+            if (!ValidateAxis(
+                    Joint.AxisJointFrame,
+                    FString::Printf(TEXT("joint %s axis_joint_frame"), *Joint.Name.ToString()),
+                    OutError))
+            {
+                return false;
+            }
+            if (Joint.bHasPositionLimits)
+            {
+                if (!FMath::IsFinite(Joint.LowerPositionRadians)
+                    || !FMath::IsFinite(Joint.UpperPositionRadians))
+                {
+                    return Fail(
+                        OutError,
+                        FString::Printf(
+                            TEXT("joint %s position limits must be finite"),
+                            *Joint.Name.ToString()));
+                }
+                if (Joint.LowerPositionRadians > Joint.UpperPositionRadians)
+                {
+                    return Fail(
+                        OutError,
+                        FString::Printf(
+                            TEXT("joint %s position limits must be ordered"),
+                            *Joint.Name.ToString()));
+                }
+            }
+        }
+        else if (Joint.Type == EDttRobotJointType::Fixed)
+        {
+            if (Joint.bHasPositionLimits)
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("fixed joint %s cannot define position limits"),
+                        *Joint.Name.ToString()));
+            }
+        }
+        else
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("joint %s has an unsupported type"), *Joint.Name.ToString()));
+        }
+    }
+
+    TSet<FName> GroupNames;
+    for (int32 GroupIndex = 0; GroupIndex < Description.JointGroups.Num(); ++GroupIndex)
+    {
+        const FDttRobotJointGroupDescription& Group = Description.JointGroups[GroupIndex];
+        if (Group.Name.IsNone())
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("joint_groups[%d].name must be non-empty"), GroupIndex));
+        }
+        if (GroupNames.Contains(Group.Name))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("duplicate joint group name: %s"), *Group.Name.ToString()));
+        }
+        if (Group.JointNames.Num() == 0)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("joint group %s must not be empty"), *Group.Name.ToString()));
+        }
+        GroupNames.Add(Group.Name);
+
+        TSet<FName> NamesInGroup;
+        for (const FName JointName : Group.JointNames)
+        {
+            const int32 JointIndex = OutModel.FindJointIndex(JointName);
+            if (JointIndex == INDEX_NONE)
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("joint group %s references unknown joint %s"),
+                        *Group.Name.ToString(),
+                        *JointName.ToString()));
+            }
+            if (Description.Joints[JointIndex].Type != EDttRobotJointType::Revolute)
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("joint group %s references non-revolute joint %s"),
+                        *Group.Name.ToString(),
+                        *JointName.ToString()));
+            }
+            if (NamesInGroup.Contains(JointName))
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("joint group %s contains duplicate joint %s"),
+                        *Group.Name.ToString(),
+                        *JointName.ToString()));
+            }
+            NamesInGroup.Add(JointName);
+        }
+    }
+
+    TArray<TArray<int32>> ChildJointsByLink;
+    ChildJointsByLink.SetNum(Description.Links.Num());
+    for (int32 JointIndex = 0; JointIndex < Description.Joints.Num(); ++JointIndex)
+    {
+        const int32 ParentIndex = OutModel.FindLinkIndex(Description.Joints[JointIndex].ParentLink);
+        ChildJointsByLink[ParentIndex].Add(JointIndex);
+    }
+    for (TArray<int32>& ChildJoints : ChildJointsByLink)
+    {
+        ChildJoints.Sort([&Description](const int32 LeftIndex, const int32 RightIndex)
+        {
+            return Description.Joints[LeftIndex].Name.ToString()
+                < Description.Joints[RightIndex].Name.ToString();
+        });
+    }
+
+    // Check every connected component before applying the single-root rule so
+    // a disconnected cycle reports the cycle itself rather than a misleading
+    // root-count error.
+    TArray<uint8> CycleState;
+    CycleState.Init(0, Description.Links.Num());
+    auto DetectCycle = [&](auto&& Self, int32 LinkIndex) -> bool
+    {
+        if (CycleState[LinkIndex] == 1)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("cycle detected at link %s"),
+                    *Description.Links[LinkIndex].Name.ToString()));
+        }
+        if (CycleState[LinkIndex] == 2)
+        {
+            return true;
+        }
+        CycleState[LinkIndex] = 1;
+        for (const int32 JointIndex : ChildJointsByLink[LinkIndex])
+        {
+            const int32 ChildIndex = OutModel.FindLinkIndex(Description.Joints[JointIndex].ChildLink);
+            if (!Self(Self, ChildIndex))
+            {
+                return false;
+            }
+        }
+        CycleState[LinkIndex] = 2;
+        return true;
+    };
+    for (int32 LinkIndex = 0; LinkIndex < Description.Links.Num(); ++LinkIndex)
+    {
+        if (CycleState[LinkIndex] == 0 && !DetectCycle(DetectCycle, LinkIndex))
+        {
+            OutModel.Reset();
+            return false;
+        }
+    }
+
+    TArray<int32> Roots;
+    Roots.Reserve(Description.Links.Num());
+    for (int32 LinkIndex = 0; LinkIndex < Description.Links.Num(); ++LinkIndex)
+    {
+        if (OutModel.ParentJointByLink[LinkIndex] == INDEX_NONE)
+        {
+            Roots.Add(LinkIndex);
+        }
+    }
+    if (Roots.Num() != 1)
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("robot description must have exactly one root link; found %d"),
+                Roots.Num()));
+    }
+    if (Roots[0] != RootLinkIndex)
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("configured root %s is not the tree root"),
+                *Description.RootLinkName.ToString()));
+    }
+
+    TArray<uint8> VisitState;
+    VisitState.Init(0, Description.Links.Num());
+    auto Visit = [&](auto&& Self, int32 LinkIndex) -> bool
+    {
+        if (VisitState[LinkIndex] == 1)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("cycle detected at link %s"),
+                    *Description.Links[LinkIndex].Name.ToString()));
+        }
+        if (VisitState[LinkIndex] == 2)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("link %s is reachable more than once"),
+                    *Description.Links[LinkIndex].Name.ToString()));
+        }
+
+        VisitState[LinkIndex] = 1;
+        OutModel.LinkTraversalOrder.Add(LinkIndex);
+        for (const int32 JointIndex : ChildJointsByLink[LinkIndex])
+        {
+            OutModel.JointTraversalOrder.Add(JointIndex);
+            const int32 ChildIndex = OutModel.FindLinkIndex(Description.Joints[JointIndex].ChildLink);
+            if (!Self(Self, ChildIndex))
+            {
+                return false;
+            }
+        }
+        VisitState[LinkIndex] = 2;
+        return true;
+    };
+
+    if (!Visit(Visit, RootLinkIndex))
+    {
+        OutModel.Reset();
+        return false;
+    }
+    if (OutModel.LinkTraversalOrder.Num() != Description.Links.Num())
+    {
+        for (int32 LinkIndex = 0; LinkIndex < Description.Links.Num(); ++LinkIndex)
+        {
+            if (VisitState[LinkIndex] != 2)
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("disconnected link: %s"),
+                        *Description.Links[LinkIndex].Name.ToString()));
+            }
+        }
+        return Fail(OutError, TEXT("robot description contains disconnected links"));
+    }
+
+    OutModel.ToolIndexByName.Reserve(Description.ToolFrames.Num());
+    for (int32 ToolIndex = 0; ToolIndex < Description.ToolFrames.Num(); ++ToolIndex)
+    {
+        const FDttRobotToolFrameDescription& Tool = Description.ToolFrames[ToolIndex];
+        if (Tool.Name.IsNone())
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("tool_frames[%d].name must be non-empty"), ToolIndex));
+        }
+        if (OutModel.ToolIndexByName.Contains(Tool.Name))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("duplicate tool frame name: %s"), *Tool.Name.ToString()));
+        }
+        if (OutModel.FindLinkIndex(Tool.LinkName) == INDEX_NONE)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("tool frame %s references an unknown link %s"),
+                    *Tool.Name.ToString(),
+                    *Tool.LinkName.ToString()));
+        }
+        if (!ValidateTransform(
+                Tool.LinkToTool,
+                FString::Printf(TEXT("tool frame %s link_to_tool"), *Tool.Name.ToString()),
+                OutError))
+        {
+            return false;
+        }
+        OutModel.ToolIndexByName.Add(Tool.Name, ToolIndex);
+    }
+
+    return true;
+}
+
+bool EvaluateForwardKinematics(
+    const FDttRobotDescription& Description,
+    const FDttCanonicalTransform& WorldTransformOfRoot,
+    const TArray<FDttNamedJointPosition>& JointPositions,
+    FDttForwardKinematicsResult& OutResult)
+{
+    OutResult = FDttForwardKinematicsResult();
+
+    FDttValidatedRobotModel Model;
+    FString Error;
+    if (!ValidateRobotDescription(Description, Model, Error))
+    {
+        OutResult.ErrorMessage = Error;
+        return false;
+    }
+    if (!ValidateTransform(WorldTransformOfRoot, TEXT("world_transform_of_root"), Error))
+    {
+        OutResult.ErrorMessage = Error;
+        return false;
+    }
+
+    OutResult.ModelId = Description.ModelId;
+    OutResult.ModelRevision = Description.ModelRevision;
+
+    TArray<double> JointValues;
+    JointValues.Init(0.0, Description.Joints.Num());
+    TArray<uint8> Provided;
+    Provided.Init(0, Description.Joints.Num());
+
+    for (const FDttNamedJointPosition& NamedPosition : JointPositions)
+    {
+        if (NamedPosition.JointName.IsNone())
+        {
+            OutResult.ErrorMessage = TEXT("joint input name must be non-empty");
+            return false;
+        }
+        const int32 JointIndex = Model.FindJointIndex(NamedPosition.JointName);
+        if (JointIndex == INDEX_NONE)
+        {
+            OutResult.ErrorMessage = FString::Printf(
+                TEXT("unknown joint input: %s"),
+                *NamedPosition.JointName.ToString());
+            return false;
+        }
+        if (Provided[JointIndex] != 0)
+        {
+            OutResult.ErrorMessage = FString::Printf(
+                TEXT("duplicate joint input: %s"),
+                *NamedPosition.JointName.ToString());
+            return false;
+        }
+        const FDttRobotJointDescription& Joint = Description.Joints[JointIndex];
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            OutResult.ErrorMessage = FString::Printf(
+                TEXT("joint input is not allowed for fixed joint: %s"),
+                *NamedPosition.JointName.ToString());
+            return false;
+        }
+        if (!FMath::IsFinite(NamedPosition.PositionRadians))
+        {
+            OutResult.ErrorMessage = FString::Printf(
+                TEXT("joint input is non-finite: %s"),
+                *NamedPosition.JointName.ToString());
+            return false;
+        }
+        JointValues[JointIndex] = NamedPosition.PositionRadians;
+        Provided[JointIndex] = 1;
+    }
+
+    for (int32 JointIndex = 0; JointIndex < Description.Joints.Num(); ++JointIndex)
+    {
+        const FDttRobotJointDescription& Joint = Description.Joints[JointIndex];
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        if (Provided[JointIndex] == 0)
+        {
+            OutResult.ErrorMessage = FString::Printf(
+                TEXT("missing joint input: %s"),
+                *Joint.Name.ToString());
+            return false;
+        }
+        if (Joint.bHasPositionLimits
+            && (JointValues[JointIndex] < Joint.LowerPositionRadians
+                || JointValues[JointIndex] > Joint.UpperPositionRadians))
+        {
+            OutResult.bWithinJointLimits = false;
+            OutResult.Diagnostics.Add(FString::Printf(
+                TEXT("joint %s is outside limits [%0.17g, %0.17g] at %0.17g radians"),
+                *Joint.Name.ToString(),
+                Joint.LowerPositionRadians,
+                Joint.UpperPositionRadians,
+                JointValues[JointIndex]));
+        }
+    }
+
+    TArray<FDttCanonicalTransform> WorldTransforms;
+    WorldTransforms.SetNum(Description.Links.Num());
+    const int32 RootLinkIndex = Model.FindLinkIndex(Description.RootLinkName);
+    WorldTransforms[RootLinkIndex] = WorldTransformOfRoot;
+
+    for (const int32 JointIndex : Model.JointTraversalOrder)
+    {
+        const FDttRobotJointDescription& Joint = Description.Joints[JointIndex];
+        const int32 ParentIndex = Model.FindLinkIndex(Joint.ParentLink);
+        const int32 ChildIndex = Model.FindLinkIndex(Joint.ChildLink);
+        FDttCanonicalTransform Motion = FDttCanonicalTransform::Identity();
+        if (Joint.Type == EDttRobotJointType::Revolute)
+        {
+            Motion = FDttCanonicalTransform::FromAxisAngle(
+                FVector3d(0.0, 0.0, 0.0),
+                Joint.AxisJointFrame.ToVector3d(),
+                JointValues[JointIndex]);
+        }
+        WorldTransforms[ChildIndex] =
+            WorldTransforms[ParentIndex] * Joint.ParentToJoint * Motion;
+    }
+
+    for (const int32 LinkIndex : Model.LinkTraversalOrder)
+    {
+        FDttNamedCanonicalTransform& NamedTransform = OutResult.LinkTransforms.AddDefaulted_GetRef();
+        NamedTransform.Name = Description.Links[LinkIndex].Name;
+        NamedTransform.Transform = WorldTransforms[LinkIndex];
+    }
+    for (const FDttRobotToolFrameDescription& Tool : Description.ToolFrames)
+    {
+        const int32 LinkIndex = Model.FindLinkIndex(Tool.LinkName);
+        FDttNamedCanonicalTransform& NamedTransform = OutResult.ToolTransforms.AddDefaulted_GetRef();
+        NamedTransform.Name = Tool.Name;
+        NamedTransform.Transform = WorldTransforms[LinkIndex] * Tool.LinkToTool;
+    }
+
+    OutResult.bSuccess = true;
+    return true;
+}
+
+bool ConvertCanonicalToUnrealTransform(
+    const FDttCanonicalTransform& CanonicalTransform,
+    FTransform& OutUnrealTransform,
+    FString& OutError)
+{
+    OutError.Reset();
+    if (!ValidateTransform(CanonicalTransform, TEXT("canonical_transform"), OutError))
+    {
+        return false;
+    }
+
+    const FDttMatrix3 UnrealRotationMatrix = ReflectYBasis(
+        CanonicalRotationMatrix(CanonicalTransform.GetRotationQuaternion()));
+    FQuat4d UnrealQuaternion;
+    if (!MatrixToQuaternion(UnrealRotationMatrix, UnrealQuaternion))
+    {
+        return Fail(OutError, TEXT("canonical rotation could not be converted to Unreal"));
+    }
+
+    const FVector3d CanonicalTranslation = CanonicalTransform.GetTranslationMetres();
+    const FVector3d UnrealTranslationCentimetres(
+        100.0 * CanonicalTranslation.X,
+        -100.0 * CanonicalTranslation.Y,
+        100.0 * CanonicalTranslation.Z);
+    const FQuat UnrealRotationQuaternion(
+        UnrealQuaternion.X,
+        UnrealQuaternion.Y,
+        UnrealQuaternion.Z,
+        UnrealQuaternion.W);
+    const FVector UnrealTranslation(
+        UnrealTranslationCentimetres.X,
+        UnrealTranslationCentimetres.Y,
+        UnrealTranslationCentimetres.Z);
+    if (!FMath::IsFinite(UnrealRotationQuaternion.X)
+        || !FMath::IsFinite(UnrealRotationQuaternion.Y)
+        || !FMath::IsFinite(UnrealRotationQuaternion.Z)
+        || !FMath::IsFinite(UnrealRotationQuaternion.W)
+        || !FMath::IsFinite(UnrealTranslation.X)
+        || !FMath::IsFinite(UnrealTranslation.Y)
+        || !FMath::IsFinite(UnrealTranslation.Z))
+    {
+        return Fail(OutError, TEXT("canonical transform exceeds Unreal finite range"));
+    }
+
+    OutUnrealTransform = FTransform(UnrealRotationQuaternion, UnrealTranslation);
+    return true;
+}
+
+bool ConvertUnrealToCanonicalTransform(
+    const FTransform& UnrealTransform,
+    FDttCanonicalTransform& OutCanonicalTransform,
+    FString& OutError)
+{
+    OutError.Reset();
+    const FVector UnrealScale = UnrealTransform.GetScale3D();
+    const FVector UnrealTranslation = UnrealTransform.GetLocation();
+    const FQuat UnrealQuaternionValue = UnrealTransform.GetRotation();
+    if (!FMath::IsFinite(UnrealScale.X)
+        || !FMath::IsFinite(UnrealScale.Y)
+        || !FMath::IsFinite(UnrealScale.Z)
+        || !FMath::IsFinite(UnrealTranslation.X)
+        || !FMath::IsFinite(UnrealTranslation.Y)
+        || !FMath::IsFinite(UnrealTranslation.Z)
+        || !FMath::IsFinite(UnrealQuaternionValue.X)
+        || !FMath::IsFinite(UnrealQuaternionValue.Y)
+        || !FMath::IsFinite(UnrealQuaternionValue.Z)
+        || !FMath::IsFinite(UnrealQuaternionValue.W))
+    {
+        return Fail(OutError, TEXT("Unreal transform contains non-finite values"));
+    }
+    if (!FMath::IsNearlyEqual(UnrealScale.X, 1.0F, static_cast<float>(ScaleTolerance))
+        || !FMath::IsNearlyEqual(UnrealScale.Y, 1.0F, static_cast<float>(ScaleTolerance))
+        || !FMath::IsNearlyEqual(UnrealScale.Z, 1.0F, static_cast<float>(ScaleTolerance)))
+    {
+        return Fail(OutError, TEXT("Unreal transform must have unit scale"));
+    }
+
+    const FQuat4d UnrealQuaternion(
+        UnrealQuaternionValue.X,
+        UnrealQuaternionValue.Y,
+        UnrealQuaternionValue.Z,
+        UnrealQuaternionValue.W);
+    const double NormSquared =
+        UnrealQuaternion.X * UnrealQuaternion.X
+        + UnrealQuaternion.Y * UnrealQuaternion.Y
+        + UnrealQuaternion.Z * UnrealQuaternion.Z
+        + UnrealQuaternion.W * UnrealQuaternion.W;
+    if (!IsFiniteQuaternion(UnrealQuaternion) || !FMath::IsFinite(NormSquared)
+        || NormSquared <= UE_DOUBLE_SMALL_NUMBER)
+    {
+        return Fail(OutError, TEXT("Unreal transform rotation must be non-zero and finite"));
+    }
+
+    const FDttMatrix3 CanonicalRotation = ReflectYBasis(
+        CanonicalRotationMatrix(NormalizeQuaternion(UnrealQuaternion)));
+    FQuat4d CanonicalQuaternion;
+    if (!MatrixToQuaternion(CanonicalRotation, CanonicalQuaternion))
+    {
+        return Fail(OutError, TEXT("Unreal rotation could not be converted to canonical"));
+    }
+    const FVector3d CanonicalTranslation(
+        UnrealTranslation.X / 100.0,
+        -UnrealTranslation.Y / 100.0,
+        UnrealTranslation.Z / 100.0);
+
+    OutCanonicalTransform = FDttCanonicalTransform::FromTranslationRotation(
+        CanonicalTranslation,
+        CanonicalQuaternion);
+    return true;
+}
+} // namespace DeferredTeleop::Kinematics
+
+bool UDeferredTeleopKinematicsLibrary::ParseRobotDescriptionJson(
+    const FString& Json,
+    FDttRobotDescription& OutDescription,
+    FString& OutError)
+{
+    return DeferredTeleop::RobotModel::ParseRobotDescriptionJson(Json, OutDescription, OutError);
+}
+
+bool UDeferredTeleopKinematicsLibrary::ValidateRobotDescription(
+    const FDttRobotDescription& Description,
+    FString& OutError)
+{
+    FDttValidatedRobotModel Model;
+    return DeferredTeleop::Kinematics::ValidateRobotDescription(Description, Model, OutError);
+}
+
+bool UDeferredTeleopKinematicsLibrary::EvaluateForwardKinematics(
+    const FDttRobotDescription& Description,
+    const FDttCanonicalTransform& WorldTransformOfRoot,
+    const TArray<FDttNamedJointPosition>& JointPositions,
+    FDttForwardKinematicsResult& OutResult)
+{
+    return DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+        Description,
+        WorldTransformOfRoot,
+        JointPositions,
+        OutResult);
+}
+
+bool UDeferredTeleopKinematicsLibrary::ConvertCanonicalToUnrealTransform(
+    const FDttCanonicalTransform& CanonicalTransform,
+    FTransform& OutUnrealTransform,
+    FString& OutError)
+{
+    return DeferredTeleop::Kinematics::ConvertCanonicalToUnrealTransform(
+        CanonicalTransform,
+        OutUnrealTransform,
+        OutError);
+}
+
+bool UDeferredTeleopKinematicsLibrary::ConvertUnrealToCanonicalTransform(
+    const FTransform& UnrealTransform,
+    FDttCanonicalTransform& OutCanonicalTransform,
+    FString& OutError)
+{
+    return DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+        UnrealTransform,
+        OutCanonicalTransform,
+        OutError);
+}

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
@@ -1,0 +1,669 @@
+#include "RobotModel/DeferredTeleopRobotModelTypes.h"
+
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+namespace DeferredTeleop::RobotModel::Private
+{
+using FJsonObjectPtr = TSharedPtr<FJsonObject>;
+using FJsonValuePtr = TSharedPtr<FJsonValue>;
+
+bool Fail(FString& OutError, const FString& Path, const FString& Detail)
+{
+    OutError = FString::Printf(TEXT("%s: %s"), *Path, *Detail);
+    return false;
+}
+
+bool RequireExactFields(
+    const FJsonObjectPtr& Object,
+    std::initializer_list<const TCHAR*> Names,
+    const FString& Path,
+    FString& OutError)
+{
+    if (!Object.IsValid())
+    {
+        return Fail(OutError, Path, TEXT("expected object"));
+    }
+    if (Object->Values.Num() != static_cast<int32>(Names.size()))
+    {
+        return Fail(OutError, Path, TEXT("missing or unknown field"));
+    }
+    for (const TCHAR* Name : Names)
+    {
+        if (!Object->HasField(FStringView(Name)))
+        {
+            return Fail(OutError, Path, FString::Printf(TEXT("missing field '%s'"), Name));
+        }
+    }
+    return true;
+}
+
+bool ReadString(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const FString& Path,
+    FString& OutValue,
+    FString& OutError)
+{
+    if (!Object->TryGetStringField(FStringView(Name), OutValue) || OutValue.IsEmpty())
+    {
+        return Fail(
+            OutError,
+            Path + TEXT(".") + Name,
+            TEXT("expected non-empty string"));
+    }
+    return true;
+}
+
+bool ReadLiteral(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const TCHAR* Expected,
+    const FString& Path,
+    FString& OutError)
+{
+    FString Value;
+    if (!ReadString(Object, Name, Path, Value, OutError))
+    {
+        return false;
+    }
+    if (Value != Expected)
+    {
+        return Fail(
+            OutError,
+            Path + TEXT(".") + Name,
+            FString::Printf(TEXT("expected '%s'"), Expected));
+    }
+    return true;
+}
+
+bool ReadNumberValue(
+    const FJsonValuePtr& Value,
+    const FString& Path,
+    double& OutValue,
+    FString& OutError)
+{
+    if (!Value.IsValid() || Value->Type != EJson::Number)
+    {
+        return Fail(OutError, Path, TEXT("expected finite number"));
+    }
+    OutValue = Value->AsNumber();
+    if (!FMath::IsFinite(OutValue))
+    {
+        return Fail(OutError, Path, TEXT("expected finite number"));
+    }
+    return true;
+}
+
+bool ReadBoolean(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const FString& Path,
+    bool& OutValue,
+    FString& OutError)
+{
+    if (!Object->TryGetBoolField(FStringView(Name), OutValue))
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("expected boolean"));
+    }
+    return true;
+}
+
+bool ReadObject(
+    const FJsonObjectPtr& Parent,
+    const TCHAR* Name,
+    const FString& Path,
+    FJsonObjectPtr& OutObject,
+    FString& OutError)
+{
+    const FJsonValuePtr Value = Parent->TryGetField(FStringView(Name));
+    if (!Value.IsValid() || Value->Type != EJson::Object || !Value->AsObject().IsValid())
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("expected object"));
+    }
+    OutObject = Value->AsObject();
+    return true;
+}
+
+bool ReadVectorArray(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const FString& Path,
+    FDttCanonicalVector& OutVector,
+    FString& OutError)
+{
+    const TArray<FJsonValuePtr>* Values = nullptr;
+    if (!Object->TryGetArrayField(FStringView(Name), Values) || Values == nullptr)
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("expected three-number array"));
+    }
+    if (Values->Num() != 3)
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("expected exactly three numbers"));
+    }
+
+    double Components[3] = {0.0, 0.0, 0.0};
+    for (int32 Index = 0; Index < 3; ++Index)
+    {
+        if (!ReadNumberValue(
+                (*Values)[Index],
+                FString::Printf(TEXT("%s.%s[%d]"), *Path, Name, Index),
+                Components[Index],
+                OutError))
+        {
+            return false;
+        }
+    }
+    OutVector.X = Components[0];
+    OutVector.Y = Components[1];
+    OutVector.Z = Components[2];
+    return true;
+}
+
+bool ReadNullableVectorArray(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const FString& Path,
+    bool& bOutPresent,
+    FDttCanonicalVector& OutVector,
+    FString& OutError)
+{
+    const FJsonValuePtr Value = Object->TryGetField(FStringView(Name));
+    if (!Value.IsValid())
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("missing field"));
+    }
+    if (Value->Type == EJson::Null)
+    {
+        bOutPresent = false;
+        OutVector = FDttCanonicalVector();
+        return true;
+    }
+    bOutPresent = true;
+    return ReadVectorArray(Object, Name, Path, OutVector, OutError);
+}
+
+bool ReadCanonicalTransform(
+    const FJsonObjectPtr& Object,
+    const FString& Path,
+    FDttCanonicalTransform& OutTransform,
+    FString& OutError)
+{
+    if (!RequireExactFields(
+            Object,
+            {TEXT("translation_m"), TEXT("rotation_xyzw")},
+            Path,
+            OutError))
+    {
+        return false;
+    }
+
+    FDttCanonicalVector Translation;
+    if (!ReadVectorArray(Object, TEXT("translation_m"), Path, Translation, OutError))
+    {
+        return false;
+    }
+    OutTransform.TranslationMetres = Translation;
+
+    const TArray<FJsonValuePtr>* RotationValues = nullptr;
+    if (!Object->TryGetArrayField(FStringView(TEXT("rotation_xyzw")), RotationValues)
+        || RotationValues == nullptr
+        || RotationValues->Num() != 4)
+    {
+        return Fail(
+            OutError,
+            Path + TEXT(".rotation_xyzw"),
+            TEXT("expected exactly four numbers"));
+    }
+    double QuaternionComponents[4] = {0.0, 0.0, 0.0, 0.0};
+    for (int32 Index = 0; Index < 4; ++Index)
+    {
+        if (!ReadNumberValue(
+                (*RotationValues)[Index],
+                FString::Printf(TEXT("%s.rotation_xyzw[%d]"), *Path, Index),
+                QuaternionComponents[Index],
+                OutError))
+        {
+            return false;
+        }
+    }
+    OutTransform.Rotation.X = QuaternionComponents[0];
+    OutTransform.Rotation.Y = QuaternionComponents[1];
+    OutTransform.Rotation.Z = QuaternionComponents[2];
+    OutTransform.Rotation.W = QuaternionComponents[3];
+    if (!OutTransform.IsRigid(1.0e-5))
+    {
+        return Fail(
+            OutError,
+            Path,
+            TEXT("transform must contain finite translation and a unit quaternion"));
+    }
+    return true;
+}
+
+bool ReadArrayField(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    const FString& Path,
+    const TArray<FJsonValuePtr>*& OutValues,
+    FString& OutError)
+{
+    if (!Object->TryGetArrayField(FStringView(Name), OutValues) || OutValues == nullptr)
+    {
+        return Fail(OutError, Path + TEXT(".") + Name, TEXT("expected array"));
+    }
+    return true;
+}
+
+bool ValidateObjectArray(
+    const TArray<FJsonValuePtr>& Values,
+    const FString& Path,
+    FString& OutError)
+{
+    for (int32 Index = 0; Index < Values.Num(); ++Index)
+    {
+        if (!Values[Index].IsValid() || Values[Index]->Type != EJson::Object)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("%s[%d]"), *Path, Index),
+                TEXT("expected object"));
+        }
+    }
+    return true;
+}
+} // namespace DeferredTeleop::RobotModel::Private
+
+namespace DeferredTeleop::RobotModel
+{
+using namespace Private;
+
+bool ParseRobotDescriptionJson(
+    const FString& Json,
+    FDttRobotDescription& OutDescription,
+    FString& OutError)
+{
+    OutError.Reset();
+    TSharedPtr<FJsonObject> Root;
+    const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+    if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+    {
+        return Fail(OutError, TEXT("$"), TEXT("malformed JSON object"));
+    }
+    if (!RequireExactFields(
+            Root,
+            {
+                TEXT("schema_version"),
+                TEXT("model_id"),
+                TEXT("model_revision"),
+                TEXT("source"),
+                TEXT("coordinate_convention"),
+                TEXT("root_link"),
+                TEXT("links"),
+                TEXT("joints"),
+                TEXT("joint_groups"),
+                TEXT("tool_frames"),
+                TEXT("known_limitations"),
+            },
+            TEXT("$"),
+            OutError))
+    {
+        return false;
+    }
+
+    if (!ReadLiteral(
+            Root,
+            TEXT("schema_version"),
+            TEXT("dtt.robot-description/0"),
+            TEXT("$"),
+            OutError))
+    {
+        return false;
+    }
+
+    FDttRobotDescription Parsed;
+    if (!ReadString(Root, TEXT("model_id"), TEXT("$"), Parsed.ModelId, OutError)
+        || !ReadString(Root, TEXT("model_revision"), TEXT("$"), Parsed.ModelRevision, OutError))
+    {
+        return false;
+    }
+
+    // FName cannot be written through FString::ToString().  Re-read root_link
+    // into a temporary after validating it as a non-empty string.
+    FString RootLink;
+    if (!ReadString(Root, TEXT("root_link"), TEXT("$"), RootLink, OutError))
+    {
+        return false;
+    }
+    Parsed.RootLinkName = FName(*RootLink);
+
+    FJsonObjectPtr Source;
+    FJsonObjectPtr Convention;
+    if (!ReadObject(Root, TEXT("source"), TEXT("$"), Source, OutError)
+        || !ReadObject(Root, TEXT("coordinate_convention"), TEXT("$"), Convention, OutError))
+    {
+        return false;
+    }
+    if (!RequireExactFields(
+            Source,
+            {
+                TEXT("repository"),
+                TEXT("commit"),
+                TEXT("path"),
+                TEXT("git_blob_sha1"),
+                TEXT("licence"),
+                TEXT("vendor_modified"),
+            },
+            TEXT("$.source"),
+            OutError)
+        || !RequireExactFields(
+            Convention,
+            {
+                TEXT("handedness"),
+                TEXT("up_axis"),
+                TEXT("length_unit"),
+                TEXT("angle_unit"),
+                TEXT("rotation_representation"),
+                TEXT("transform_notation"),
+            },
+            TEXT("$.coordinate_convention"),
+            OutError))
+    {
+        return false;
+    }
+
+    bool bVendorModified = false;
+    FString SourceMetadata;
+    if (!ReadString(Source, TEXT("repository"), TEXT("$.source"), SourceMetadata, OutError)
+        || !ReadString(Source, TEXT("commit"), TEXT("$.source"), SourceMetadata, OutError)
+        || !ReadString(Source, TEXT("path"), TEXT("$.source"), SourceMetadata, OutError)
+        || !ReadString(Source, TEXT("git_blob_sha1"), TEXT("$.source"), SourceMetadata, OutError)
+        || !ReadString(Source, TEXT("licence"), TEXT("$.source"), SourceMetadata, OutError)
+        || !ReadBoolean(Source, TEXT("vendor_modified"), TEXT("$.source"), bVendorModified, OutError)
+        || !ReadLiteral(Convention, TEXT("handedness"), TEXT("RIGHT_HANDED"), TEXT("$.coordinate_convention"), OutError)
+        || !ReadLiteral(Convention, TEXT("up_axis"), TEXT("Z"), TEXT("$.coordinate_convention"), OutError)
+        || !ReadLiteral(Convention, TEXT("length_unit"), TEXT("metre"), TEXT("$.coordinate_convention"), OutError)
+        || !ReadLiteral(Convention, TEXT("angle_unit"), TEXT("radian"), TEXT("$.coordinate_convention"), OutError)
+        || !ReadLiteral(Convention, TEXT("rotation_representation"), TEXT("quaternion_xyzw"), TEXT("$.coordinate_convention"), OutError)
+        || !ReadLiteral(Convention, TEXT("transform_notation"), TEXT("parent_T_child"), TEXT("$.coordinate_convention"), OutError))
+    {
+        return false;
+    }
+    (void)SourceMetadata;
+    (void)bVendorModified;
+
+    const TArray<FJsonValuePtr>* LinkValues = nullptr;
+    const TArray<FJsonValuePtr>* JointValues = nullptr;
+    const TArray<FJsonValuePtr>* GroupValues = nullptr;
+    const TArray<FJsonValuePtr>* ToolValues = nullptr;
+    const TArray<FJsonValuePtr>* LimitationValues = nullptr;
+    if (!ReadArrayField(Root, TEXT("links"), TEXT("$"), LinkValues, OutError)
+        || !ReadArrayField(Root, TEXT("joints"), TEXT("$"), JointValues, OutError)
+        || !ReadArrayField(Root, TEXT("joint_groups"), TEXT("$"), GroupValues, OutError)
+        || !ReadArrayField(Root, TEXT("tool_frames"), TEXT("$"), ToolValues, OutError)
+        || !ReadArrayField(Root, TEXT("known_limitations"), TEXT("$"), LimitationValues, OutError)
+        || !ValidateObjectArray(*LinkValues, TEXT("$.links"), OutError)
+        || !ValidateObjectArray(*JointValues, TEXT("$.joints"), OutError)
+        || !ValidateObjectArray(*GroupValues, TEXT("$.joint_groups"), OutError)
+        || !ValidateObjectArray(*ToolValues, TEXT("$.tool_frames"), OutError))
+    {
+        return false;
+    }
+
+    for (int32 Index = 0; Index < LimitationValues->Num(); ++Index)
+    {
+        FString Limitation;
+        if (!(*LimitationValues)[Index].IsValid()
+            || !(*LimitationValues)[Index]->TryGetString(Limitation)
+            || Limitation.IsEmpty())
+        {
+            return Fail(
+                OutError,
+                FString::Printf(TEXT("$.known_limitations[%d]"), Index),
+                TEXT("expected non-empty string"));
+        }
+    }
+
+    Parsed.Links.Reserve(LinkValues->Num());
+    for (int32 Index = 0; Index < LinkValues->Num(); ++Index)
+    {
+        const FJsonObjectPtr Link = (*LinkValues)[Index]->AsObject();
+        if (!RequireExactFields(
+                Link,
+                {TEXT("name"), TEXT("visuals")},
+                FString::Printf(TEXT("$.links[%d]"), Index),
+                OutError))
+        {
+            return false;
+        }
+        FDttRobotLinkDescription ParsedLink;
+        FString Name;
+        if (!ReadString(
+                Link,
+                TEXT("name"),
+                FString::Printf(TEXT("$.links[%d]"), Index),
+                Name,
+                OutError))
+        {
+            return false;
+        }
+        const TArray<FJsonValuePtr>* VisualValues = nullptr;
+        if (!ReadArrayField(
+                Link,
+                TEXT("visuals"),
+                FString::Printf(TEXT("$.links[%d]"), Index),
+                VisualValues,
+                OutError)
+            || !ValidateObjectArray(
+                *VisualValues,
+                FString::Printf(TEXT("$.links[%d].visuals"), Index),
+                OutError))
+        {
+            return false;
+        }
+        ParsedLink.Name = FName(*Name);
+        Parsed.Links.Add(MoveTemp(ParsedLink));
+    }
+
+    Parsed.Joints.Reserve(JointValues->Num());
+    for (int32 Index = 0; Index < JointValues->Num(); ++Index)
+    {
+        const FString Path = FString::Printf(TEXT("$.joints[%d]"), Index);
+        const FJsonObjectPtr Joint = (*JointValues)[Index]->AsObject();
+        if (!RequireExactFields(
+                Joint,
+                {
+                    TEXT("name"),
+                    TEXT("type"),
+                    TEXT("parent_link"),
+                    TEXT("child_link"),
+                    TEXT("parent_to_joint"),
+                    TEXT("axis_joint_frame"),
+                    TEXT("position_limits_rad"),
+                },
+                Path,
+                OutError))
+        {
+            return false;
+        }
+
+        FDttRobotJointDescription ParsedJoint;
+        FString Name;
+        FString Type;
+        FString ParentLink;
+        FString ChildLink;
+        if (!ReadString(Joint, TEXT("name"), Path, Name, OutError)
+            || !ReadString(Joint, TEXT("type"), Path, Type, OutError)
+            || !ReadString(Joint, TEXT("parent_link"), Path, ParentLink, OutError)
+            || !ReadString(Joint, TEXT("child_link"), Path, ChildLink, OutError))
+        {
+            return false;
+        }
+        FJsonObjectPtr ParentToJoint;
+        if (!ReadObject(Joint, TEXT("parent_to_joint"), Path, ParentToJoint, OutError)
+            || !ReadCanonicalTransform(ParentToJoint, Path + TEXT(".parent_to_joint"), ParsedJoint.ParentToJoint, OutError))
+        {
+            return false;
+        }
+        bool bHasAxis = false;
+        if (!ReadNullableVectorArray(
+                Joint,
+                TEXT("axis_joint_frame"),
+                Path,
+                bHasAxis,
+                ParsedJoint.AxisJointFrame,
+                OutError))
+        {
+            return false;
+        }
+        const FJsonValuePtr LimitValue = Joint->TryGetField(FStringView(TEXT("position_limits_rad")));
+        if (!LimitValue.IsValid())
+        {
+            return Fail(OutError, Path + TEXT(".position_limits_rad"), TEXT("missing field"));
+        }
+        if (LimitValue->Type == EJson::Null)
+        {
+            ParsedJoint.bHasPositionLimits = false;
+        }
+        else
+        {
+            if (LimitValue->Type != EJson::Object)
+            {
+                return Fail(
+                    OutError,
+                    Path + TEXT(".position_limits_rad"),
+                    TEXT("expected object or null"));
+            }
+            const FJsonObjectPtr Limit = LimitValue->AsObject();
+            if (!Limit.IsValid()
+                || !RequireExactFields(
+                    Limit,
+                    {TEXT("lower"), TEXT("upper")},
+                    Path + TEXT(".position_limits_rad"),
+                    OutError))
+            {
+                return Fail(
+                    OutError,
+                    Path + TEXT(".position_limits_rad"),
+                    TEXT("expected object or null"));
+            }
+            if (!Limit->TryGetNumberField(FStringView(TEXT("lower")), ParsedJoint.LowerPositionRadians)
+                || !FMath::IsFinite(ParsedJoint.LowerPositionRadians)
+                || !Limit->TryGetNumberField(FStringView(TEXT("upper")), ParsedJoint.UpperPositionRadians)
+                || !FMath::IsFinite(ParsedJoint.UpperPositionRadians))
+            {
+                return Fail(
+                    OutError,
+                    Path + TEXT(".position_limits_rad"),
+                    TEXT("limits must be finite numbers"));
+            }
+            ParsedJoint.bHasPositionLimits = true;
+        }
+
+        ParsedJoint.Name = FName(*Name);
+        ParsedJoint.ParentLink = FName(*ParentLink);
+        ParsedJoint.ChildLink = FName(*ChildLink);
+        if (Type == TEXT("fixed"))
+        {
+            if (bHasAxis || ParsedJoint.bHasPositionLimits)
+            {
+                return Fail(
+                    OutError,
+                    Path,
+                    TEXT("fixed joint must have null axis and limits"));
+            }
+            ParsedJoint.Type = EDttRobotJointType::Fixed;
+        }
+        else if (Type == TEXT("revolute"))
+        {
+            if (!bHasAxis)
+            {
+                return Fail(OutError, Path + TEXT(".axis_joint_frame"), TEXT("required for revolute joint"));
+            }
+            ParsedJoint.Type = EDttRobotJointType::Revolute;
+        }
+        else
+        {
+            return Fail(
+                OutError,
+                Path + TEXT(".type"),
+                TEXT("expected 'fixed' or 'revolute'"));
+        }
+        Parsed.Joints.Add(MoveTemp(ParsedJoint));
+    }
+
+    Parsed.JointGroups.Reserve(GroupValues->Num());
+    for (int32 Index = 0; Index < GroupValues->Num(); ++Index)
+    {
+        const FString Path = FString::Printf(TEXT("$.joint_groups[%d]"), Index);
+        const FJsonObjectPtr Group = (*GroupValues)[Index]->AsObject();
+        if (!RequireExactFields(Group, {TEXT("name"), TEXT("joints")}, Path, OutError))
+        {
+            return false;
+        }
+
+        FString Name;
+        if (!ReadString(Group, TEXT("name"), Path, Name, OutError))
+        {
+            return false;
+        }
+        const TArray<FJsonValuePtr>* JointNameValues = nullptr;
+        if (!ReadArrayField(Group, TEXT("joints"), Path, JointNameValues, OutError))
+        {
+            return false;
+        }
+
+        FDttRobotJointGroupDescription ParsedGroup;
+        ParsedGroup.Name = FName(*Name);
+        ParsedGroup.JointNames.Reserve(JointNameValues->Num());
+        for (int32 JointNameIndex = 0; JointNameIndex < JointNameValues->Num(); ++JointNameIndex)
+        {
+            FString JointName;
+            if (!(*JointNameValues)[JointNameIndex].IsValid()
+                || !(*JointNameValues)[JointNameIndex]->TryGetString(JointName)
+                || JointName.IsEmpty())
+            {
+                return Fail(
+                    OutError,
+                    FString::Printf(TEXT("%s.joints[%d]"), *Path, JointNameIndex),
+                    TEXT("expected non-empty string"));
+            }
+            ParsedGroup.JointNames.Add(FName(*JointName));
+        }
+        Parsed.JointGroups.Add(MoveTemp(ParsedGroup));
+    }
+
+    Parsed.ToolFrames.Reserve(ToolValues->Num());
+    for (int32 Index = 0; Index < ToolValues->Num(); ++Index)
+    {
+        const FString Path = FString::Printf(TEXT("$.tool_frames[%d]"), Index);
+        const FJsonObjectPtr Tool = (*ToolValues)[Index]->AsObject();
+        if (!RequireExactFields(Tool, {TEXT("name"), TEXT("link")}, Path, OutError))
+        {
+            return false;
+        }
+        FString Name;
+        FString Link;
+        if (!ReadString(Tool, TEXT("name"), Path, Name, OutError)
+            || !ReadString(Tool, TEXT("link"), Path, Link, OutError))
+        {
+            return false;
+        }
+        FDttRobotToolFrameDescription ParsedTool;
+        ParsedTool.Name = FName(*Name);
+        ParsedTool.LinkName = FName(*Link);
+        ParsedTool.LinkToTool = FDttCanonicalTransform::Identity();
+        Parsed.ToolFrames.Add(MoveTemp(ParsedTool));
+    }
+
+    FDttValidatedRobotModel Validated;
+    if (!DeferredTeleop::Kinematics::ValidateRobotDescription(Parsed, Validated, OutError))
+    {
+        return false;
+    }
+    OutDescription = MoveTemp(Parsed);
+    return true;
+}
+} // namespace DeferredTeleop::RobotModel

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
@@ -233,7 +233,7 @@ bool ReadCanonicalTransform(
     OutTransform.Rotation.Y = QuaternionComponents[1];
     OutTransform.Rotation.Z = QuaternionComponents[2];
     OutTransform.Rotation.W = QuaternionComponents[3];
-    if (!OutTransform.IsRigid(1.0e-5))
+    if (!OutTransform.IsRigid(1.0e-6))
     {
         return Fail(
             OutError,
@@ -374,6 +374,9 @@ bool ParseRobotDescriptionJson(
         return false;
     }
 
+    // Source metadata is checked for the fields and scalar types required by
+    // the generated contract, but it is deliberately not retained in
+    // FDttRobotDescription or used by FK.
     bool bVendorModified = false;
     FString SourceMetadata;
     if (!ReadString(Source, TEXT("repository"), TEXT("$.source"), SourceMetadata, OutError)
@@ -450,6 +453,9 @@ bool ParseRobotDescriptionJson(
             return false;
         }
         const TArray<FJsonValuePtr>* VisualValues = nullptr;
+        // Visual metadata is deliberately bounded to an array of JSON
+        // objects.  Its fields are not part of this kinematics slice and are
+        // neither retained nor used by FK.
         if (!ReadArrayField(
                 Link,
                 TEXT("visuals"),

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelTypes.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelTypes.cpp
@@ -1,0 +1,130 @@
+#include "RobotModel/DeferredTeleopRobotModelTypes.h"
+
+#include "Math/UnrealMathUtility.h"
+
+namespace DeferredTeleop::RobotModel::Private
+{
+FQuat4d MultiplyQuaternions(const FQuat4d& Left, const FQuat4d& Right)
+{
+    return FQuat4d(
+        Left.W * Right.X + Left.X * Right.W + Left.Y * Right.Z - Left.Z * Right.Y,
+        Left.W * Right.Y - Left.X * Right.Z + Left.Y * Right.W + Left.Z * Right.X,
+        Left.W * Right.Z + Left.X * Right.Y - Left.Y * Right.X + Left.Z * Right.W,
+        Left.W * Right.W - Left.X * Right.X - Left.Y * Right.Y - Left.Z * Right.Z);
+}
+
+FVector3d RotateVector(const FQuat4d& Rotation, const FVector3d& Vector)
+{
+    const FVector3d QuaternionVector(Rotation.X, Rotation.Y, Rotation.Z);
+    const FVector3d TwiceCross = 2.0 * FVector3d::CrossProduct(QuaternionVector, Vector);
+    return Vector + Rotation.W * TwiceCross + FVector3d::CrossProduct(QuaternionVector, TwiceCross);
+}
+} // namespace DeferredTeleop::RobotModel::Private
+
+bool FDttCanonicalVector::IsFinite() const
+{
+    return FMath::IsFinite(X) && FMath::IsFinite(Y) && FMath::IsFinite(Z);
+}
+
+FVector3d FDttCanonicalVector::ToVector3d() const
+{
+    return FVector3d(X, Y, Z);
+}
+
+FDttCanonicalVector FDttCanonicalVector::FromVector3d(const FVector3d& Value)
+{
+    FDttCanonicalVector Result;
+    Result.X = Value.X;
+    Result.Y = Value.Y;
+    Result.Z = Value.Z;
+    return Result;
+}
+
+bool FDttCanonicalQuaternion::IsFinite() const
+{
+    return FMath::IsFinite(X) && FMath::IsFinite(Y) && FMath::IsFinite(Z)
+        && FMath::IsFinite(W);
+}
+
+bool FDttCanonicalQuaternion::IsNormalized(double Tolerance) const
+{
+    if (!IsFinite() || !FMath::IsFinite(Tolerance) || Tolerance < 0.0)
+    {
+        return false;
+    }
+
+    const double NormSquared = X * X + Y * Y + Z * Z + W * W;
+    return FMath::IsFinite(NormSquared) && FMath::Abs(NormSquared - 1.0) <= Tolerance;
+}
+
+bool FDttCanonicalTransform::IsFinite() const
+{
+    return TranslationMetres.IsFinite() && Rotation.IsFinite();
+}
+
+bool FDttCanonicalTransform::IsRigid(double Tolerance) const
+{
+    return IsFinite() && Rotation.IsNormalized(Tolerance);
+}
+
+FDttCanonicalTransform FDttCanonicalTransform::Identity()
+{
+    return FDttCanonicalTransform();
+}
+
+FDttCanonicalTransform FDttCanonicalTransform::FromTranslationRotation(
+    const FVector3d& InTranslationMetres,
+    const FQuat4d& InRotation)
+{
+    FDttCanonicalTransform Result;
+    Result.TranslationMetres = FDttCanonicalVector::FromVector3d(InTranslationMetres);
+    Result.Rotation.X = InRotation.X;
+    Result.Rotation.Y = InRotation.Y;
+    Result.Rotation.Z = InRotation.Z;
+    Result.Rotation.W = InRotation.W;
+    return Result;
+}
+
+FDttCanonicalTransform FDttCanonicalTransform::FromAxisAngle(
+    const FVector3d& InTranslationMetres,
+    const FVector3d& Axis,
+    double AngleRadians)
+{
+    const double AxisNormSquared = Axis.SizeSquared();
+    const double AxisNorm = FMath::Sqrt(AxisNormSquared);
+    const double HalfAngle = 0.5 * AngleRadians;
+    const double Sine = FMath::Sin(HalfAngle);
+    const double AxisScale = AxisNorm > UE_DOUBLE_SMALL_NUMBER ? Sine / AxisNorm : 0.0;
+    const FQuat4d Rotation(
+        Axis.X * AxisScale,
+        Axis.Y * AxisScale,
+        Axis.Z * AxisScale,
+        FMath::Cos(HalfAngle));
+    return FromTranslationRotation(InTranslationMetres, Rotation);
+}
+
+FVector3d FDttCanonicalTransform::GetTranslationMetres() const
+{
+    return TranslationMetres.ToVector3d();
+}
+
+FQuat4d FDttCanonicalTransform::GetRotationQuaternion() const
+{
+    return FQuat4d(Rotation.X, Rotation.Y, Rotation.Z, Rotation.W);
+}
+
+FDttCanonicalTransform FDttCanonicalTransform::operator*(
+    const FDttCanonicalTransform& Other) const
+{
+    const FQuat4d LeftRotation = GetRotationQuaternion();
+    const FVector3d ComposedTranslation =
+        GetTranslationMetres()
+        + DeferredTeleop::RobotModel::Private::RotateVector(
+            LeftRotation,
+            Other.GetTranslationMetres());
+    const FQuat4d ComposedRotation =
+        DeferredTeleop::RobotModel::Private::MultiplyQuaternions(
+            LeftRotation,
+            Other.GetRotationQuaternion());
+    return FromTranslationRotation(ComposedTranslation, ComposedRotation);
+}

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp
@@ -2,6 +2,8 @@
 
 #include "Kinematics/DeferredTeleopKinematicsLibrary.h"
 #include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 
 #include <limits>
 
@@ -614,6 +616,231 @@ bool FDeferredTeleopCanonicalConversionTest::RunTest(const FString& Parameters)
             RoundTripOutput,
             Error));
     TestTrue(TEXT("scale rejection exposes an error"), Error.Contains(TEXT("unit scale")));
+
+    FTransform NonUnitQuaternion = FTransform::Identity;
+    NonUnitQuaternion.SetRotation(FQuat(0.0F, 0.0F, 0.0F, 2.0F));
+    Error.Reset();
+    TestFalse(
+        TEXT("non-unit Unreal quaternions are rejected instead of normalized"),
+        DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+            NonUnitQuaternion,
+            RoundTripOutput,
+            Error));
+    TestTrue(
+        TEXT("non-unit quaternion rejection exposes an error"),
+        Error.Contains(TEXT("normalized quaternion")));
+
+    FTransform ZeroQuaternion = FTransform::Identity;
+    ZeroQuaternion.SetRotation(FQuat(0.0F, 0.0F, 0.0F, 0.0F));
+    Error.Reset();
+    TestFalse(
+        TEXT("zero Unreal quaternions are rejected"),
+        DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+            ZeroQuaternion,
+            RoundTripOutput,
+            Error));
+    TestTrue(
+        TEXT("zero quaternion rejection exposes an error"),
+        Error.Contains(TEXT("non-zero")));
+
+    FTransform NonFiniteQuaternion = FTransform::Identity;
+    NonFiniteQuaternion.SetRotation(FQuat(
+        std::numeric_limits<float>::quiet_NaN(),
+        0.0F,
+        0.0F,
+        1.0F));
+    Error.Reset();
+    TestFalse(
+        TEXT("non-finite Unreal quaternions are rejected"),
+        DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+            NonFiniteQuaternion,
+            RoundTripOutput,
+            Error));
+    TestTrue(
+        TEXT("non-finite quaternion rejection exposes an error"),
+        Error.Contains(TEXT("non-finite")));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopGeneratedSo101RobotDescriptionTest,
+    "DeferredTeleop.M2.RobotModel.ParsesGeneratedSo101Description",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopGeneratedSo101RobotDescriptionTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FString GeneratedPath = FPaths::Combine(
+        FPaths::ProjectDir(),
+        TEXT("../../robots/so101/generated/so101.kinematics.json"));
+    FString Json;
+    const bool bLoaded = FFileHelper::LoadFileToString(Json, *GeneratedPath);
+    TestTrue(
+        *FString::Printf(TEXT("committed SO-101 description is readable: %s"), *GeneratedPath),
+        bLoaded);
+    if (!bLoaded)
+    {
+        return false;
+    }
+
+    FDttRobotDescription Description;
+    FString Error;
+    const bool bParsed = TestTrue(
+        TEXT("generated SO-101 description parses"),
+        DeferredTeleop::RobotModel::ParseRobotDescriptionJson(Json, Description, Error));
+    if (!bParsed)
+    {
+        AddError(Error);
+        return false;
+    }
+
+    FDttValidatedRobotModel Validated;
+    const bool bValidated = TestTrue(
+        TEXT("generated SO-101 description validates as one rooted model"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(Description, Validated, Error));
+    if (!bValidated)
+    {
+        AddError(Error);
+        return false;
+    }
+
+    TestEqual(TEXT("generated model id is SO-101"), Description.ModelId, FString(TEXT("so101_new_calib")));
+    TestEqual(TEXT("generated root link is base_link"), Description.RootLinkName, FName(TEXT("base_link")));
+
+    const FName ExpectedLinkNames[] = {
+        FName(TEXT("base_link")),
+        FName(TEXT("shoulder_link")),
+        FName(TEXT("upper_arm_link")),
+        FName(TEXT("lower_arm_link")),
+        FName(TEXT("wrist_link")),
+        FName(TEXT("gripper_link")),
+        FName(TEXT("moving_jaw_so101_v1_link")),
+        FName(TEXT("gripper_frame_link")),
+    };
+    TestEqual(
+        TEXT("generated description has all expected links"),
+        Description.Links.Num(),
+        static_cast<int32>(UE_ARRAY_COUNT(ExpectedLinkNames)));
+    for (const FName ExpectedName : ExpectedLinkNames)
+    {
+        bool bFound = false;
+        for (const FDttRobotLinkDescription& Link : Description.Links)
+        {
+            bFound = Link.Name == ExpectedName;
+            if (bFound)
+            {
+                break;
+            }
+        }
+        TestTrue(
+            *FString::Printf(TEXT("generated link is present: %s"), *ExpectedName.ToString()),
+            bFound);
+    }
+
+    const FName ExpectedJointNames[] = {
+        FName(TEXT("shoulder_pan")),
+        FName(TEXT("shoulder_lift")),
+        FName(TEXT("elbow_flex")),
+        FName(TEXT("wrist_flex")),
+        FName(TEXT("wrist_roll")),
+        FName(TEXT("gripper")),
+        FName(TEXT("gripper_frame_joint")),
+    };
+    TestEqual(
+        TEXT("generated description has all expected joints"),
+        Description.Joints.Num(),
+        static_cast<int32>(UE_ARRAY_COUNT(ExpectedJointNames)));
+    int32 RevoluteCount = 0;
+    int32 FixedCount = 0;
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type == EDttRobotJointType::Revolute)
+        {
+            ++RevoluteCount;
+        }
+        else if (Joint.Type == EDttRobotJointType::Fixed)
+        {
+            ++FixedCount;
+        }
+    }
+    TestEqual(TEXT("generated description has six revolute joints"), RevoluteCount, 6);
+    TestEqual(TEXT("generated description has one fixed tool joint"), FixedCount, 1);
+    for (const FName ExpectedName : ExpectedJointNames)
+    {
+        bool bFound = false;
+        for (const FDttRobotJointDescription& Joint : Description.Joints)
+        {
+            bFound = Joint.Name == ExpectedName;
+            if (bFound)
+            {
+                break;
+            }
+        }
+        TestTrue(
+            *FString::Printf(TEXT("generated joint is present: %s"), *ExpectedName.ToString()),
+            bFound);
+    }
+
+    TestEqual(TEXT("generated description has arm and gripper groups"), Description.JointGroups.Num(), 2);
+    const FDttRobotJointGroupDescription* ArmGroup = nullptr;
+    const FDttRobotJointGroupDescription* GripperGroup = nullptr;
+    for (const FDttRobotJointGroupDescription& Group : Description.JointGroups)
+    {
+        if (Group.Name == FName(TEXT("arm")))
+        {
+            ArmGroup = &Group;
+        }
+        else if (Group.Name == FName(TEXT("gripper")))
+        {
+            GripperGroup = &Group;
+        }
+    }
+    TestTrue(TEXT("generated arm group is present"), ArmGroup != nullptr);
+    TestTrue(TEXT("generated gripper group is present"), GripperGroup != nullptr);
+    if (ArmGroup != nullptr)
+    {
+        const FName ExpectedArmJointNames[] = {
+            FName(TEXT("shoulder_pan")),
+            FName(TEXT("shoulder_lift")),
+            FName(TEXT("elbow_flex")),
+            FName(TEXT("wrist_flex")),
+            FName(TEXT("wrist_roll")),
+        };
+        TestEqual(TEXT("arm group contains five joints"), ArmGroup->JointNames.Num(), 5);
+        for (const FName ExpectedName : ExpectedArmJointNames)
+        {
+            TestTrue(
+                *FString::Printf(TEXT("arm group contains %s"), *ExpectedName.ToString()),
+                ArmGroup->JointNames.Contains(ExpectedName));
+        }
+    }
+    if (GripperGroup != nullptr)
+    {
+        TestEqual(TEXT("gripper group contains one joint"), GripperGroup->JointNames.Num(), 1);
+        if (GripperGroup->JointNames.Num() == 1)
+        {
+            TestEqual(
+                TEXT("gripper group names its gripper joint"),
+                GripperGroup->JointNames[0],
+                FName(TEXT("gripper")));
+        }
+    }
+
+    TestEqual(TEXT("generated description has one tool frame"), Description.ToolFrames.Num(), 1);
+    if (Description.ToolFrames.Num() == 1)
+    {
+        TestEqual(
+            TEXT("generated tool frame name is gripper_frame_link"),
+            Description.ToolFrames[0].Name,
+            FName(TEXT("gripper_frame_link")));
+        TestEqual(
+            TEXT("generated tool frame is attached to gripper_frame_link"),
+            Description.ToolFrames[0].LinkName,
+            FName(TEXT("gripper_frame_link")));
+    }
+
+    // This integration check deliberately asserts model identity and structure
+    // only. It is not a numerical SO-101 FK golden oracle; that belongs to M2.4.
     return true;
 }
 

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp
@@ -1,0 +1,620 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "Misc/AutomationTest.h"
+
+#include <limits>
+
+namespace DeferredTeleop::Tests::Kinematics
+{
+constexpr double Pi = 3.1415926535897932384626433832795;
+
+FDttCanonicalTransform Translation(double X, double Y, double Z)
+{
+    return FDttCanonicalTransform::FromTranslationRotation(
+        FVector3d(X, Y, Z),
+        FQuat4d(0.0, 0.0, 0.0, 1.0));
+}
+
+FDttCanonicalVector Vector(double X, double Y, double Z)
+{
+    FDttCanonicalVector Result;
+    Result.X = X;
+    Result.Y = Y;
+    Result.Z = Z;
+    return Result;
+}
+
+FDttRobotLinkDescription Link(const TCHAR* Name)
+{
+    FDttRobotLinkDescription Result;
+    Result.Name = FName(Name);
+    return Result;
+}
+
+FDttNamedJointPosition JointPosition(const TCHAR* Name, double PositionRadians)
+{
+    FDttNamedJointPosition Result;
+    Result.JointName = FName(Name);
+    Result.PositionRadians = PositionRadians;
+    return Result;
+}
+
+FDttCanonicalTransform RotationAround(
+    const FVector3d& Axis,
+    double AngleRadians)
+{
+    return FDttCanonicalTransform::FromAxisAngle(
+        FVector3d(0.0, 0.0, 0.0),
+        Axis,
+        AngleRadians);
+}
+
+FDttRobotDescription MakeBranchedDescription()
+{
+    FDttRobotDescription Description;
+    Description.ModelId = TEXT("test-branched-model");
+    Description.ModelRevision = TEXT("test-revision");
+    Description.RootLinkName = FName(TEXT("root"));
+
+    Description.Links = {
+        Link(TEXT("root")),
+        Link(TEXT("left")),
+        Link(TEXT("right")),
+        Link(TEXT("tip")),
+        Link(TEXT("tool_link")),
+    };
+
+    FDttRobotJointDescription LeftFixed;
+    LeftFixed.Name = FName(TEXT("root_to_left"));
+    LeftFixed.Type = EDttRobotJointType::Fixed;
+    LeftFixed.ParentLink = FName(TEXT("root"));
+    LeftFixed.ChildLink = FName(TEXT("left"));
+    LeftFixed.ParentToJoint = Translation(0.0, 1.0, 0.0);
+
+    FDttRobotJointDescription RightRevolute;
+    RightRevolute.Name = FName(TEXT("root_to_right"));
+    RightRevolute.Type = EDttRobotJointType::Revolute;
+    RightRevolute.ParentLink = FName(TEXT("root"));
+    RightRevolute.ChildLink = FName(TEXT("right"));
+    RightRevolute.ParentToJoint = Translation(1.0, 0.0, 0.0);
+    RightRevolute.AxisJointFrame = Vector(0.0, 0.0, 1.0);
+    RightRevolute.bHasPositionLimits = true;
+    RightRevolute.LowerPositionRadians = -Pi;
+    RightRevolute.UpperPositionRadians = Pi;
+
+    FDttRobotJointDescription TipRevolute;
+    TipRevolute.Name = FName(TEXT("left_to_tip"));
+    TipRevolute.Type = EDttRobotJointType::Revolute;
+    TipRevolute.ParentLink = FName(TEXT("left"));
+    TipRevolute.ChildLink = FName(TEXT("tip"));
+    TipRevolute.ParentToJoint = Translation(1.0, 0.0, 0.0);
+    TipRevolute.AxisJointFrame = Vector(0.0, 1.0, 0.0);
+    TipRevolute.bHasPositionLimits = true;
+    TipRevolute.LowerPositionRadians = -Pi;
+    TipRevolute.UpperPositionRadians = Pi;
+
+    FDttRobotJointDescription ToolFixed;
+    ToolFixed.Name = FName(TEXT("tip_to_tool"));
+    ToolFixed.Type = EDttRobotJointType::Fixed;
+    ToolFixed.ParentLink = FName(TEXT("tip"));
+    ToolFixed.ChildLink = FName(TEXT("tool_link"));
+    ToolFixed.ParentToJoint = Translation(0.0, 0.0, 1.0);
+
+    // The input order is intentionally not a serialised chain order.  FK uses
+    // validated parent/child indices, not SO-101 names or array positions.
+    Description.Joints = {ToolFixed, RightRevolute, LeftFixed, TipRevolute};
+
+    FDttRobotJointGroupDescription ArmGroup;
+    ArmGroup.Name = FName(TEXT("arm"));
+    ArmGroup.JointNames = {
+        FName(TEXT("root_to_right")),
+        FName(TEXT("left_to_tip")),
+    };
+    Description.JointGroups = {ArmGroup};
+
+    FDttRobotToolFrameDescription Tool;
+    Tool.Name = FName(TEXT("tool_frame"));
+    Tool.LinkName = FName(TEXT("tool_link"));
+    Tool.LinkToTool = Translation(0.25, 0.0, 0.0);
+    Description.ToolFrames = {Tool};
+    return Description;
+}
+
+const FDttNamedCanonicalTransform* FindNamedTransform(
+    const TArray<FDttNamedCanonicalTransform>& Transforms,
+    const TCHAR* Name)
+{
+    for (const FDttNamedCanonicalTransform& Named : Transforms)
+    {
+        if (Named.Name == FName(Name))
+        {
+            return &Named;
+        }
+    }
+    return nullptr;
+}
+
+bool NearlyEqual(double Left, double Right, double Tolerance = 1.0e-8)
+{
+    return FMath::Abs(Left - Right) <= Tolerance;
+}
+
+bool NearlyEqualVector(
+    const FVector3d& Left,
+    const FVector3d& Right,
+    double Tolerance = 1.0e-8)
+{
+    return NearlyEqual(Left.X, Right.X, Tolerance)
+        && NearlyEqual(Left.Y, Right.Y, Tolerance)
+        && NearlyEqual(Left.Z, Right.Z, Tolerance);
+}
+
+FString MinimalDescriptionJson()
+{
+    return TEXT(R"JSON({
+      "schema_version":"dtt.robot-description/0",
+      "model_id":"minimal",
+      "model_revision":"test:0",
+      "source":{
+        "repository":"local",
+        "commit":"test",
+        "path":"minimal.urdf",
+        "git_blob_sha1":"0000000000000000000000000000000000000000",
+        "licence":"Apache-2.0",
+        "vendor_modified":false
+      },
+      "coordinate_convention":{
+        "handedness":"RIGHT_HANDED",
+        "up_axis":"Z",
+        "length_unit":"metre",
+        "angle_unit":"radian",
+        "rotation_representation":"quaternion_xyzw",
+        "transform_notation":"parent_T_child"
+      },
+      "root_link":"base",
+      "links":[
+        {"name":"base","visuals":[]},
+        {"name":"tip","visuals":[]}
+      ],
+      "joints":[{
+        "name":"joint",
+        "type":"revolute",
+        "parent_link":"base",
+        "child_link":"tip",
+        "parent_to_joint":{
+          "translation_m":[0,0,0],
+          "rotation_xyzw":[0,0,0,1]
+        },
+        "axis_joint_frame":[0,0,1],
+        "position_limits_rad":{"lower":-1,"upper":1}
+      }],
+      "joint_groups":[{"name":"arm","joints":["joint"]}],
+      "tool_frames":[{"name":"tool","link":"tip"}],
+      "known_limitations":[]
+    })JSON");
+}
+} // namespace DeferredTeleop::Tests::Kinematics
+
+using namespace DeferredTeleop::Tests::Kinematics;
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopCanonicalCompositionTest,
+    "DeferredTeleop.M2.Kinematics.CanonicalComposition",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopCanonicalCompositionTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttCanonicalTransform First = FDttCanonicalTransform::FromAxisAngle(
+        FVector3d(1.0, 2.0, 3.0),
+        FVector3d(0.0, 0.0, 1.0),
+        Pi / 2.0);
+    const FDttCanonicalTransform Second = Translation(2.0, 0.0, 0.0);
+    const FDttCanonicalTransform Composed = First * Second;
+
+    TestTrue(
+        TEXT("composition rotates the child translation before adding the parent translation"),
+        NearlyEqualVector(Composed.GetTranslationMetres(), FVector3d(1.0, 4.0, 3.0)));
+    TestTrue(TEXT("composition preserves a finite rigid transform"), Composed.IsRigid());
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopGenericForwardKinematicsTest,
+    "DeferredTeleop.M2.Kinematics.GenericTreeForwardKinematics",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopGenericForwardKinematicsTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeBranchedDescription();
+    TArray<FDttNamedJointPosition> State;
+    State.Add(JointPosition(TEXT("left_to_tip"), -Pi / 2.0));
+    State.Add(JointPosition(TEXT("root_to_right"), Pi / 2.0));
+
+    FDttForwardKinematicsResult Result;
+    TestTrue(
+        TEXT("generic fixed/revolute tree evaluates"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            Translation(10.0, 20.0, 30.0),
+            State,
+            Result));
+    if (!Result.bSuccess)
+    {
+        AddError(Result.ErrorMessage);
+        return false;
+    }
+
+    TestEqual(TEXT("model reference is returned"), Result.ModelId, FString(TEXT("test-branched-model")));
+    TestEqual(TEXT("all links are returned"), Result.LinkTransforms.Num(), 5);
+    const FName ExpectedLinkOrder[] = {
+        FName(TEXT("root")),
+        FName(TEXT("left")),
+        FName(TEXT("tip")),
+        FName(TEXT("tool_link")),
+        FName(TEXT("right")),
+    };
+    for (int32 Index = 0; Index < UE_ARRAY_COUNT(ExpectedLinkOrder); ++Index)
+    {
+        TestEqual(
+            *FString::Printf(TEXT("link output %d follows deterministic traversal"), Index),
+            Result.LinkTransforms[Index].Name,
+            ExpectedLinkOrder[Index]);
+    }
+    const FDttNamedCanonicalTransform* Root = FindNamedTransform(Result.LinkTransforms, TEXT("root"));
+    const FDttNamedCanonicalTransform* Left = FindNamedTransform(Result.LinkTransforms, TEXT("left"));
+    const FDttNamedCanonicalTransform* Tip = FindNamedTransform(Result.LinkTransforms, TEXT("tip"));
+    const FDttNamedCanonicalTransform* ToolLink = FindNamedTransform(
+        Result.LinkTransforms,
+        TEXT("tool_link"));
+    const FDttNamedCanonicalTransform* Tool = FindNamedTransform(
+        Result.ToolTransforms,
+        TEXT("tool_frame"));
+    TestTrue(TEXT("root lookup is stable by name"), Root != nullptr);
+    TestTrue(TEXT("branch lookup is stable by name"), Left != nullptr);
+    TestTrue(TEXT("tip lookup is stable by name"), Tip != nullptr);
+    TestTrue(TEXT("fixed tool link lookup is stable by name"), ToolLink != nullptr);
+    TestTrue(TEXT("tool frame lookup is stable by name"), Tool != nullptr);
+    if (Root == nullptr || Left == nullptr || Tip == nullptr || ToolLink == nullptr || Tool == nullptr)
+    {
+        return false;
+    }
+
+    TestTrue(
+        TEXT("root receives the supplied world transform"),
+        NearlyEqualVector(Root->Transform.GetTranslationMetres(), FVector3d(10.0, 20.0, 30.0)));
+    TestTrue(
+        TEXT("fixed branch composes parent_to_joint"),
+        NearlyEqualVector(Left->Transform.GetTranslationMetres(), FVector3d(10.0, 21.0, 30.0)));
+    TestTrue(
+        TEXT("revolute branch composes generic motion"),
+        NearlyEqualVector(Tip->Transform.GetTranslationMetres(), FVector3d(11.0, 21.0, 30.0)));
+    TestTrue(
+        TEXT("fixed tool link propagates after revolute motion"),
+        NearlyEqualVector(ToolLink->Transform.GetTranslationMetres(), FVector3d(10.0, 21.0, 30.0)));
+    TestTrue(
+        TEXT("tool frame uses an explicit link-relative transform"),
+        NearlyEqualVector(Tool->Transform.GetTranslationMetres(), FVector3d(10.0, 21.0, 30.25)));
+    TestTrue(TEXT("valid state has no limit warning"), Result.bWithinJointLimits);
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopRobotModelValidationTest,
+    "DeferredTeleop.M2.Kinematics.RejectsInvalidDescriptions",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopRobotModelValidationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    FString Error;
+    FDttValidatedRobotModel Validated;
+
+    FDttRobotDescription DuplicateLinks = MakeBranchedDescription();
+    DuplicateLinks.Links[1].Name = DuplicateLinks.Links[0].Name;
+    TestFalse(
+        TEXT("duplicate links are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(DuplicateLinks, Validated, Error));
+    TestTrue(TEXT("duplicate link error is explicit"), Error.Contains(TEXT("duplicate link")));
+
+    FDttRobotDescription MissingRoot = MakeBranchedDescription();
+    MissingRoot.RootLinkName = NAME_None;
+    Error.Reset();
+    TestFalse(
+        TEXT("missing root is rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(MissingRoot, Validated, Error));
+    TestTrue(TEXT("missing root error is explicit"), Error.Contains(TEXT("root_link_name")));
+
+    FDttRobotDescription Disconnected = MakeBranchedDescription();
+    Disconnected.Links.Add(Link(TEXT("orphan")));
+    Error.Reset();
+    TestFalse(
+        TEXT("multiple roots and disconnected links are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(Disconnected, Validated, Error));
+    TestTrue(TEXT("root error identifies the tree invariant"), Error.Contains(TEXT("exactly one root")));
+
+    FDttRobotDescription Cyclic = MakeBranchedDescription();
+    Cyclic.Joints[1].ParentLink = FName(TEXT("left"));
+    Cyclic.Joints[1].ChildLink = FName(TEXT("root"));
+    Error.Reset();
+    TestFalse(
+        TEXT("cycles are rejected explicitly"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(Cyclic, Validated, Error));
+    TestTrue(TEXT("cycle error identifies the cycle"), Error.Contains(TEXT("cycle")));
+
+    FDttRobotDescription InvalidAxis = MakeBranchedDescription();
+    InvalidAxis.Joints[1].AxisJointFrame = FDttCanonicalVector();
+    Error.Reset();
+    TestFalse(
+        TEXT("zero revolute axes are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(InvalidAxis, Validated, Error));
+    TestTrue(TEXT("axis error is explicit"), Error.Contains(TEXT("axis_joint_frame")));
+
+    FDttRobotDescription NonFinite = MakeBranchedDescription();
+    NonFinite.Joints[1].ParentToJoint.TranslationMetres.X =
+        std::numeric_limits<double>::quiet_NaN();
+    Error.Reset();
+    TestFalse(
+        TEXT("non-finite transforms are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(NonFinite, Validated, Error));
+    TestTrue(TEXT("non-finite error is explicit"), Error.Contains(TEXT("finite")));
+
+    FDttRobotDescription UnknownGroupedJoint = MakeBranchedDescription();
+    UnknownGroupedJoint.JointGroups[0].JointNames.Add(FName(TEXT("unknown")));
+    Error.Reset();
+    TestFalse(
+        TEXT("unknown grouped joints are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(
+            UnknownGroupedJoint,
+            Validated,
+            Error));
+    TestTrue(TEXT("joint group error is explicit"), Error.Contains(TEXT("joint group")));
+
+    FDttRobotDescription DuplicateGroupedJoint = MakeBranchedDescription();
+    DuplicateGroupedJoint.JointGroups[0].JointNames.Add(FName(TEXT("root_to_right")));
+    Error.Reset();
+    TestFalse(
+        TEXT("duplicate joints inside a group are rejected"),
+        DeferredTeleop::Kinematics::ValidateRobotDescription(
+            DuplicateGroupedJoint,
+            Validated,
+            Error));
+    TestTrue(TEXT("duplicate group entry is explicit"), Error.Contains(TEXT("duplicate joint")));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopJointInputValidationTest,
+    "DeferredTeleop.M2.Kinematics.RejectsInvalidJointInputs",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopJointInputValidationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeBranchedDescription();
+    FString Error;
+    FDttForwardKinematicsResult Result;
+
+    TArray<FDttNamedJointPosition> Unknown;
+    Unknown.Add(JointPosition(TEXT("unknown"), 0.0));
+    Unknown.Add(JointPosition(TEXT("left_to_tip"), 0.0));
+    Unknown.Add(JointPosition(TEXT("root_to_right"), 0.0));
+    TestFalse(
+        TEXT("unknown joint names are rejected"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            FDttCanonicalTransform::Identity(),
+            Unknown,
+            Result));
+    TestTrue(TEXT("unknown joint error is explicit"), Result.ErrorMessage.Contains(TEXT("unknown joint")));
+
+    TArray<FDttNamedJointPosition> Duplicate;
+    Duplicate.Add(JointPosition(TEXT("left_to_tip"), 0.0));
+    Duplicate.Add(JointPosition(TEXT("left_to_tip"), 0.1));
+    Duplicate.Add(JointPosition(TEXT("root_to_right"), 0.0));
+    TestFalse(
+        TEXT("duplicate joint names are rejected"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            FDttCanonicalTransform::Identity(),
+            Duplicate,
+            Result));
+    TestTrue(TEXT("duplicate joint error is explicit"), Result.ErrorMessage.Contains(TEXT("duplicate joint")));
+
+    TArray<FDttNamedJointPosition> Missing;
+    Missing.Add(JointPosition(TEXT("root_to_right"), 0.0));
+    TestFalse(
+        TEXT("missing revolute joint names are rejected"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            FDttCanonicalTransform::Identity(),
+            Missing,
+            Result));
+    TestTrue(TEXT("missing joint error is explicit"), Result.ErrorMessage.Contains(TEXT("missing joint")));
+
+    TArray<FDttNamedJointPosition> NonFinite;
+    NonFinite.Add(JointPosition(TEXT("left_to_tip"), std::numeric_limits<double>::quiet_NaN()));
+    NonFinite.Add(JointPosition(TEXT("root_to_right"), 0.0));
+    TestFalse(
+        TEXT("non-finite joint positions are rejected"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            FDttCanonicalTransform::Identity(),
+            NonFinite,
+            Result));
+    TestTrue(TEXT("non-finite joint error is explicit"), Result.ErrorMessage.Contains(TEXT("non-finite")));
+
+    TArray<FDttNamedJointPosition> OutOfLimits;
+    OutOfLimits.Add(JointPosition(TEXT("left_to_tip"), 2.0 * Pi));
+    OutOfLimits.Add(JointPosition(TEXT("root_to_right"), 0.0));
+    TestTrue(
+        TEXT("limit violations do not silently clamp FK"),
+        DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            FDttCanonicalTransform::Identity(),
+            OutOfLimits,
+            Result));
+    TestFalse(TEXT("limit violation is visible"), Result.bWithinJointLimits);
+    TestEqual(TEXT("one limit diagnostic is emitted"), Result.Diagnostics.Num(), 1);
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopRobotDescriptionJsonTest,
+    "DeferredTeleop.M2.RobotModel.ParsesCanonicalJson",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopRobotDescriptionJsonTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    FDttRobotDescription Description;
+    FString Error;
+    const bool bParsed = TestTrue(
+        TEXT("minimal canonical robot JSON parses"),
+        DeferredTeleop::RobotModel::ParseRobotDescriptionJson(
+            MinimalDescriptionJson(),
+            Description,
+            Error));
+    if (!bParsed)
+    {
+        AddError(Error);
+        return false;
+    }
+    TestEqual(TEXT("JSON model id is loaded"), Description.ModelId, FString(TEXT("minimal")));
+    TestEqual(TEXT("JSON root is loaded"), Description.RootLinkName, FName(TEXT("base")));
+    TestEqual(TEXT("JSON tool frame is loaded"), Description.ToolFrames.Num(), 1);
+    TestEqual(TEXT("JSON model links are loaded"), Description.Links.Num(), 2);
+    TestEqual(TEXT("JSON model joint is loaded"), Description.Joints.Num(), 1);
+    TestEqual(TEXT("JSON joint group is loaded"), Description.JointGroups.Num(), 1);
+    if (Description.JointGroups.Num() == 1
+        && Description.JointGroups[0].JointNames.Num() == 1)
+    {
+        TestEqual(
+            TEXT("JSON joint group preserves semantic order"),
+            Description.JointGroups[0].JointNames[0],
+            FName(TEXT("joint")));
+    }
+
+    FString Tampered = MinimalDescriptionJson().Replace(
+        TEXT("dtt.robot-description/0"),
+        TEXT("dtt.robot-description/1"));
+    Error.Reset();
+    TestFalse(
+        TEXT("unsupported JSON schema is rejected"),
+        DeferredTeleop::RobotModel::ParseRobotDescriptionJson(Tampered, Description, Error));
+    TestTrue(TEXT("schema error is explicit"), Error.Contains(TEXT("schema_version")));
+
+    Tampered = MinimalDescriptionJson().Replace(
+        TEXT("\"position_limits_rad\":{\"lower\":-1,\"upper\":1}"),
+        TEXT("\"position_limits_rad\":\"invalid\""));
+    Error.Reset();
+    TestFalse(
+        TEXT("non-object joint limits are rejected"),
+        DeferredTeleop::RobotModel::ParseRobotDescriptionJson(Tampered, Description, Error));
+    TestTrue(
+        TEXT("joint-limit type error is explicit"),
+        Error.Contains(TEXT("position_limits_rad")));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopCanonicalConversionTest,
+    "DeferredTeleop.M2.Kinematics.CanonicalUnrealConversion",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopCanonicalConversionTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    FString Error;
+    FTransform Unreal;
+    const FDttCanonicalTransform Identity = Translation(1.0, 2.0, 3.0);
+    TestTrue(
+        TEXT("canonical metres convert to Unreal centimetres with reflected Y"),
+        DeferredTeleop::Kinematics::ConvertCanonicalToUnrealTransform(
+            Identity,
+            Unreal,
+            Error));
+    TestTrue(
+        TEXT("metres are scaled exactly once at the boundary"),
+        Unreal.GetLocation().Equals(FVector(100.0F, -200.0F, 300.0F), 1.0e-4F));
+    TestTrue(TEXT("identity rotation remains identity"), Unreal.GetRotation().Equals(FQuat::Identity));
+
+    struct FQuarterTurnCase
+    {
+        FVector3d Axis;
+        double Angle;
+        FVector UnrealInput;
+        FVector ExpectedOutput;
+    };
+    const FQuarterTurnCase Cases[] = {
+        {FVector3d(1.0, 0.0, 0.0), Pi / 2.0, FVector::RightVector, FVector(0.0F, 0.0F, -1.0F)},
+        {FVector3d(1.0, 0.0, 0.0), -Pi / 2.0, FVector::RightVector, FVector(0.0F, 0.0F, 1.0F)},
+        {FVector3d(0.0, 1.0, 0.0), Pi / 2.0, FVector::ForwardVector, FVector(0.0F, 0.0F, -1.0F)},
+        {FVector3d(0.0, 1.0, 0.0), -Pi / 2.0, FVector::ForwardVector, FVector(0.0F, 0.0F, 1.0F)},
+        {FVector3d(0.0, 0.0, 1.0), Pi / 2.0, FVector::ForwardVector, FVector(0.0F, -1.0F, 0.0F)},
+        {FVector3d(0.0, 0.0, 1.0), -Pi / 2.0, FVector::ForwardVector, FVector(0.0F, 1.0F, 0.0F)},
+    };
+    for (int32 Index = 0; Index < UE_ARRAY_COUNT(Cases); ++Index)
+    {
+        Error.Reset();
+        TestTrue(
+            *FString::Printf(TEXT("quarter turn %d converts through S"), Index),
+            DeferredTeleop::Kinematics::ConvertCanonicalToUnrealTransform(
+                RotationAround(Cases[Index].Axis, Cases[Index].Angle),
+                Unreal,
+                Error));
+        const FVector ConvertedVector = Unreal.TransformVector(Cases[Index].UnrealInput).GetSafeNormal();
+        TestTrue(
+            *FString::Printf(TEXT("quarter turn %d preserves basis sign"), Index),
+            ConvertedVector.Equals(Cases[Index].ExpectedOutput, 1.0e-4F));
+    }
+
+    const FDttCanonicalTransform RoundTripInput = FDttCanonicalTransform::FromAxisAngle(
+        FVector3d(1.25, -2.5, 3.75),
+        FVector3d(1.0, 2.0, 3.0).GetSafeNormal(),
+        -0.73);
+    Error.Reset();
+    TestTrue(
+        TEXT("canonical to Unreal conversion succeeds for a non-trivial rigid transform"),
+        DeferredTeleop::Kinematics::ConvertCanonicalToUnrealTransform(
+            RoundTripInput,
+            Unreal,
+            Error));
+    FDttCanonicalTransform RoundTripOutput;
+    TestTrue(
+        TEXT("Unreal to canonical conversion is the inverse basis boundary"),
+        DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+            Unreal,
+            RoundTripOutput,
+            Error));
+    TestTrue(
+        TEXT("canonical translation round-trips"),
+        NearlyEqualVector(
+            RoundTripInput.GetTranslationMetres(),
+            RoundTripOutput.GetTranslationMetres(),
+            1.0e-5));
+    const FQuat4d InputRotation = RoundTripInput.GetRotationQuaternion();
+    const FQuat4d OutputRotation = RoundTripOutput.GetRotationQuaternion();
+    const double RotationDot =
+        InputRotation.X * OutputRotation.X
+        + InputRotation.Y * OutputRotation.Y
+        + InputRotation.Z * OutputRotation.Z
+        + InputRotation.W * OutputRotation.W;
+    TestTrue(TEXT("canonical rotation round-trips up to quaternion sign"), FMath::Abs(RotationDot) >= 1.0 - 1.0e-5);
+
+    FTransform Scaled = FTransform::Identity;
+    Scaled.SetScale3D(FVector(1.0F, -1.0F, 1.0F));
+    Error.Reset();
+    TestFalse(
+        TEXT("arbitrary Unreal scale is rejected at the conversion boundary"),
+        DeferredTeleop::Kinematics::ConvertUnrealToCanonicalTransform(
+            Scaled,
+            RoundTripOutput,
+            Error));
+    TestTrue(TEXT("scale rejection exposes an error"), Error.Contains(TEXT("unit scale")));
+    return true;
+}
+
+#endif

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopStateVisualizationActor.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopStateVisualizationActor.h
@@ -57,49 +57,49 @@ protected:
     virtual void BeginPlay() override;
 
 private:
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<USceneComponent> SceneRoot;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UCameraComponent> DemoCamera;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<USceneCaptureComponent2D> EvidenceCamera;
 
     UPROPERTY(Transient)
     TObjectPtr<UTextureRenderTarget2D> EvidenceRenderTarget;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UPointLightComponent> DemoLight;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UStaticMeshComponent> ConfirmedMesh;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UStaticMeshComponent> ArrivalMesh;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UStaticMeshComponent> TargetMesh;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UTextRenderComponent> ConfirmedLabel;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UTextRenderComponent> ArrivalLabel;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UTextRenderComponent> TargetLabel;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UTextRenderComponent> ConnectionLabel;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<USplineComponent> TrajectorySpline;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UStaticMeshComponent> TrajectoryLine;
 
-    UPROPERTY(VisibleAnywhere)
+    UPROPERTY(VisibleAnywhere, Category = "Deferred Teleoperation|Components")
     TObjectPtr<UStaticMeshComponent> TrajectoryMarker;
 
     UPROPERTY()

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicsLibrary.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicsLibrary.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "RobotModel/DeferredTeleopRobotModelTypes.h"
+#include "DeferredTeleopKinematicsLibrary.generated.h"
+
+/**
+ * Runtime lookup/index data produced from a validated robot description.
+ *
+ * The maps are used only at the semantic boundary.  FK traverses the stable
+ * arrays below, so TMap iteration order can never affect a result.
+ */
+struct DEFERREDTELEOPRUNTIME_API FDttValidatedRobotModel
+{
+    TMap<FName, int32> LinkIndexByName;
+    TMap<FName, int32> JointIndexByName;
+    TMap<FName, int32> ToolIndexByName;
+    TArray<int32> ParentJointByLink;
+    TArray<int32> LinkTraversalOrder;
+    TArray<int32> JointTraversalOrder;
+
+    void Reset();
+    int32 FindLinkIndex(FName LinkName) const;
+    int32 FindJointIndex(FName JointName) const;
+    int32 FindToolIndex(FName ToolName) const;
+};
+
+namespace DeferredTeleop::Kinematics
+{
+/** Validate names, transforms, axes, and the rooted fixed/revolute tree. */
+DEFERREDTELEOPRUNTIME_API bool ValidateRobotDescription(
+    const FDttRobotDescription& Description,
+    FDttValidatedRobotModel& OutModel,
+    FString& OutError);
+
+/**
+ * Evaluate generic tree FK from named revolute positions.
+ *
+ * Fixed joints consume no state entry.  Every revolute joint must have one
+ * finite named state entry.  Limit violations are reported as diagnostics and
+ * never clamped; malformed state or model data returns false.
+ */
+DEFERREDTELEOPRUNTIME_API bool EvaluateForwardKinematics(
+    const FDttRobotDescription& Description,
+    const FDttCanonicalTransform& WorldTransformOfRoot,
+    const TArray<FDttNamedJointPosition>& JointPositions,
+    FDttForwardKinematicsResult& OutResult);
+
+/** Convert the canonical RH/Z-up/metres transform at the single Unreal boundary. */
+DEFERREDTELEOPRUNTIME_API bool ConvertCanonicalToUnrealTransform(
+    const FDttCanonicalTransform& CanonicalTransform,
+    FTransform& OutUnrealTransform,
+    FString& OutError);
+
+/** Inverse boundary conversion used by authoring/tests; it does not accept scale. */
+DEFERREDTELEOPRUNTIME_API bool ConvertUnrealToCanonicalTransform(
+    const FTransform& UnrealTransform,
+    FDttCanonicalTransform& OutCanonicalTransform,
+    FString& OutError);
+} // namespace DeferredTeleop::Kinematics
+
+/** Minimal Blueprint boundary for model validation, FK, and frame conversion. */
+UCLASS()
+class DEFERREDTELEOPRUNTIME_API UDeferredTeleopKinematicsLibrary final
+    : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintCallable, Category = "Deferred Teleoperation|Robot Model")
+    static bool ParseRobotDescriptionJson(
+        const FString& Json,
+        FDttRobotDescription& OutDescription,
+        FString& OutError);
+
+    UFUNCTION(BlueprintCallable, Category = "Deferred Teleoperation|Kinematics")
+    static bool ValidateRobotDescription(
+        const FDttRobotDescription& Description,
+        FString& OutError);
+
+    UFUNCTION(BlueprintCallable, Category = "Deferred Teleoperation|Kinematics")
+    static bool EvaluateForwardKinematics(
+        const FDttRobotDescription& Description,
+        const FDttCanonicalTransform& WorldTransformOfRoot,
+        const TArray<FDttNamedJointPosition>& JointPositions,
+        FDttForwardKinematicsResult& OutResult);
+
+    UFUNCTION(BlueprintPure, Category = "Deferred Teleoperation|Kinematics")
+    static bool ConvertCanonicalToUnrealTransform(
+        const FDttCanonicalTransform& CanonicalTransform,
+        FTransform& OutUnrealTransform,
+        FString& OutError);
+
+    UFUNCTION(BlueprintPure, Category = "Deferred Teleoperation|Kinematics")
+    static bool ConvertUnrealToCanonicalTransform(
+        const FTransform& UnrealTransform,
+        FDttCanonicalTransform& OutCanonicalTransform,
+        FString& OutError);
+};

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h
@@ -258,9 +258,14 @@ namespace DeferredTeleop::RobotModel
 /**
  * Load the committed dtt.robot-description/0 JSON representation.
  *
- * This is intentionally a small strict reader for the generated canonical
- * description; it is not a runtime URDF importer.  The caller owns the JSON
- * text, which keeps file/network policy outside the runtime model core.
+ * This is intentionally a small schema-scoped reader for the generated
+ * canonical description; it is not a runtime URDF importer or a global JSON
+ * validator. Fields consumed by the kinematics model are checked for their
+ * required shape and values. Source metadata is checked structurally for
+ * traceability, while visual entries are only checked to be JSON objects;
+ * neither is retained in FDttRobotDescription or used by FK. The caller owns
+ * the JSON text, which keeps file/network policy outside the runtime model
+ * core.
  */
 DEFERREDTELEOPRUNTIME_API bool ParseRobotDescriptionJson(
     const FString& Json,

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h
@@ -1,0 +1,269 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Math/Quat.h"
+#include "Math/Vector.h"
+#include "DeferredTeleopRobotModelTypes.generated.h"
+
+/**
+ * A three-component value in the canonical robotics coordinate system.
+ *
+ * Canonical vectors are right-handed, Z-up, and use metres where the value is
+ * a translation.  Joint axes use the same storage type but are dimensionless
+ * unit vectors.  The explicit field names keep a Blueprint-authored value
+ * from being mistaken for an Unreal centimetre vector.
+ */
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttCanonicalVector
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double X = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double Y = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double Z = 0.0;
+
+    bool IsFinite() const;
+    FVector3d ToVector3d() const;
+
+    static FDttCanonicalVector FromVector3d(const FVector3d& Value);
+};
+
+/** A unit quaternion in canonical XYZW order. */
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttCanonicalQuaternion
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double X = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double Y = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double Z = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    double W = 1.0;
+
+    bool IsFinite() const;
+    bool IsNormalized(double Tolerance = 1.0e-9) const;
+};
+
+/**
+ * Rigid transform in the canonical robotics convention:
+ * right-handed, Z-up, metres, radians, and column-vector composition.
+ *
+ * A value named ParentToJoint represents ^parent T_joint.  It must not carry
+ * scale; Unreal conversion is deliberately performed at the kinematics
+ * boundary instead of by an Actor or component scale.
+ */
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttCanonicalTransform
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    FDttCanonicalVector TranslationMetres;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Canonical")
+    FDttCanonicalQuaternion Rotation;
+
+    bool IsFinite() const;
+    bool IsRigid(double Tolerance = 1.0e-9) const;
+
+    static FDttCanonicalTransform Identity();
+    static FDttCanonicalTransform FromTranslationRotation(
+        const FVector3d& TranslationMetres,
+        const FQuat4d& Rotation);
+    static FDttCanonicalTransform FromAxisAngle(
+        const FVector3d& TranslationMetres,
+        const FVector3d& Axis,
+        double AngleRadians);
+
+    FVector3d GetTranslationMetres() const;
+    FQuat4d GetRotationQuaternion() const;
+
+    /** Composition uses ^A T_C = ^A T_B * ^B T_C. */
+    FDttCanonicalTransform operator*(const FDttCanonicalTransform& Other) const;
+};
+
+UENUM(BlueprintType)
+enum class EDttRobotJointType : uint8
+{
+    Fixed,
+    Revolute,
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttRobotLinkDescription
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName Name = NAME_None;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttRobotJointDescription
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName Name = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    EDttRobotJointType Type = EDttRobotJointType::Fixed;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName ParentLink = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName ChildLink = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FDttCanonicalTransform ParentToJoint;
+
+    /** Unit axis expressed in the joint frame.  Required for revolute joints. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FDttCanonicalVector AxisJointFrame;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    bool bHasPositionLimits = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    double LowerPositionRadians = 0.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    double UpperPositionRadians = 0.0;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttRobotJointGroupDescription
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName Name = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    TArray<FName> JointNames;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttRobotToolFrameDescription
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName Name = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName LinkName = NAME_None;
+
+    /** ^link T_tool, independent of any visual mesh origin. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FDttCanonicalTransform LinkToTool;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttRobotDescription
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FString ModelId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FString ModelRevision;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    FName RootLinkName = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    TArray<FDttRobotLinkDescription> Links;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    TArray<FDttRobotJointDescription> Joints;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    TArray<FDttRobotJointGroupDescription> JointGroups;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Robot Model")
+    TArray<FDttRobotToolFrameDescription> ToolFrames;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttNamedJointPosition
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics")
+    FName JointName = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics")
+    double PositionRadians = 0.0;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttNamedCanonicalTransform
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    FName Name = NAME_None;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    FDttCanonicalTransform Transform;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttForwardKinematicsResult
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    bool bSuccess = false;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    bool bWithinJointLimits = true;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    FString ErrorMessage;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    FString ModelId;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    FString ModelRevision;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    TArray<FDttNamedCanonicalTransform> LinkTransforms;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    TArray<FDttNamedCanonicalTransform> ToolTransforms;
+
+    /** Non-fatal diagnostics, including joint-limit violations. */
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics")
+    TArray<FString> Diagnostics;
+};
+
+namespace DeferredTeleop::RobotModel
+{
+/**
+ * Load the committed dtt.robot-description/0 JSON representation.
+ *
+ * This is intentionally a small strict reader for the generated canonical
+ * description; it is not a runtime URDF importer.  The caller owns the JSON
+ * text, which keeps file/network policy outside the runtime model core.
+ */
+DEFERREDTELEOPRUNTIME_API bool ParseRobotDescriptionJson(
+    const FString& Json,
+    FDttRobotDescription& OutDescription,
+    FString& OutError);
+} // namespace DeferredTeleop::RobotModel

--- a/unreal/README.md
+++ b/unreal/README.md
@@ -8,10 +8,10 @@ DeferredTeleopDemo/
     └── Source/DeferredTeleopRuntime/
 ```
 
-The plugin exposes the M0 protocol-version function plus the M1 read-only Mission client and
-visualization actor. Its network boundary is limited to the local Mission view endpoint
-(`ws://127.0.0.1:8772` by default). It contains no Field or Robot connection, kinematics,
-robot assets, or hardware control.
+The plugin exposes the M0 protocol-version function, the M1 read-only Mission client and
+visualization actor, and the M2 canonical kinematics core. Its network boundary is limited to the
+local Mission view endpoint (`ws://127.0.0.1:8772` by default). It contains no Field or Robot
+connection, robot assets, or hardware control.
 
 ## Local verification
 
@@ -42,3 +42,14 @@ strict client rejects malformed/version-incompatible frames, retains its last va
 disconnects, and exposes state, connection, and rejection events to Blueprint. See the
 [reproducible M1 proof](../docs/m1/UNREAL_VISUALIZATION.md) for exact generate, build, test,
 run, and capture commands.
+
+## M2 canonical kinematics
+
+`DeferredTeleopRuntime` contains a strict parser for the generated robot-description subset,
+explicit right-handed metre/radian transforms, generic fixed/revolute tree FK, tool-frame
+propagation, and the single canonical-to-Unreal basis boundary. The API is also exposed to
+Blueprint without moving the mathematical core into Blueprint graphs.
+
+See the [M2 canonical kinematics guide](../docs/m2/CANONICAL_KINEMATICS.md) for the contract,
+headless build and Automation Test commands, and the capabilities deliberately left for later
+increments.

--- a/unreal/README.md
+++ b/unreal/README.md
@@ -45,10 +45,19 @@ run, and capture commands.
 
 ## M2 canonical kinematics
 
-`DeferredTeleopRuntime` contains a strict parser for the generated robot-description subset,
+M2.2 covers the articulated robot-state and model-reference protocol (#14). `DeferredTeleopRuntime`
+contains a schema-scoped parser for the generated description subset, and M2.3 implements
 explicit right-handed metre/radian transforms, generic fixed/revolute tree FK, tool-frame
-propagation, and the single canonical-to-Unreal basis boundary. The API is also exposed to
-Blueprint without moving the mathematical core into Blueprint graphs.
+propagation, and the single canonical-to-Unreal basis boundary (#15). The parser checks source
+metadata structurally and only checks visual entries as JSON objects; neither is retained or used
+by FK. The API is also exposed to Blueprint without moving the mathematical core into Blueprint
+graphs.
+
+The generated SO-101 integration test checks the committed artifact's identity and structure,
+without asserting FK coordinates. It does not implement the M2.2 articulated-state protocol or
+the cross-language numerical oracle in M2.4 (#16). Linux and Win64 UE 5.8.2 build and Automation
+evidence is recorded in the M2 guide; both targets pass the 11-test M1/M2 run, which validates
+the M2.3 math core and supports closing #15.
 
 See the [M2 canonical kinematics guide](../docs/m2/CANONICAL_KINEMATICS.md) for the contract,
 headless build and Automation Test commands, and the capabilities deliberately left for later


### PR DESCRIPTION
## Summary

Implements the M2.3 canonical kinematics core for the SO-101 mathematical twin.
The change provides canonical rigid transforms, generic fixed/revolute tree FK,
named tool-frame propagation, the canonical-to-Unreal basis boundary, and a
schema-scoped parser for the generated robot description.

The parser checks the kinematics fields required by this increment. Source
metadata is checked structurally for traceability, while visual entries are only
checked as JSON objects; neither is retained or used by FK. The generated SO-101
test verifies model identity and structure, without asserting SO-101 FK values.

Closes #15

## Validation

- Linux, Unreal Engine 5.8.2 source commit `ff8421f2b8cb4feb76fff57965a1effc53a6eb7b`,
  Clang 20.1.8: project/module build exit code 0; 11 Automation tests passed
  (4 M1 and 7 M2); headless editor exit code 0 with `SoftQuit`.
- Win64, Unreal Engine 5.8.2: project/module build exit code 0; 11 Automation
  tests passed (4 M1 and 7 M2); headless editor exit code 0 with `SoftQuit`.
- Python suite and generated-description drift checks pass separately.

The public validation summary records both reports, toolchains, exits and the hashes of
25 source/model/fixture files verified against both platform snapshots.

The Automation runs use the full monorepo checkout because the tests load the
committed `robots/` description and M1 `fixtures/`; a packaged plugin alone is
insufficient.

## Scope

This closes the M2.3 math-core implementation and its Linux/Win64 UE evidence.
M2.2 articulated robot-state/model-reference protocol (#14), M2.4 numerical
cross-language oracle (#16), Jacobian, IK, articulated rendering, authoring,
and hardware integration remain open. No physical robot or hardware-control
path is introduced.
