### PR TITLE
Add a bounded time-sampled kinematic preview core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
   and a 13-test acceptance selector. Linux and Win64 each record 35 contextual successes (13 IK
   plus 22 contextual tests), with no warnings, failures or not-run tests in process and
   build/editor exit code 0. See the [M2.7 platform record](docs/m2/evidence/constrained-ik-platform-validation.json).
+- bounded M2.8a local `KinematicPreview` math core related to #20: pure C++/Blueprint
+  `BuildPreview`, deterministic time-sampled joint states, FK recomputation for every tool sample,
+  exact endpoints, explicit inactive-joint rejection, opt-in partial IK, declared provenance and
+  bounded preview timing. The eight-test selector passes inside 43-test contextual Linux and Win64
+  Unreal Engine 5.8.2 reports with build/editor exit code 0. See the [preview guide](docs/m2/KINEMATIC_PREVIEW.md)
+  and [platform record](docs/m2/evidence/kinematic-preview-platform-validation.json).
 
 ### Status
 
@@ -53,9 +59,9 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 - M2.2 is complete. Its raw articulated feed does not validate model geometry; an FK consumer must
   call the explicit description-backed validator. The post-rebase integrated validation passes
   141 Python tests; the historical M2.2 135/20 snapshot remains identified in its platform record.
-- M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK is complete with
-  Linux/Win64 evidence; `KinematicPreview` and VR authoring remain open, and no physical or
-  hardware-control path is claimed.
+- M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK and the M2.8a
+  preview math core are complete with Linux/Win64 evidence; desktop/VR authoring and the full
+  #20/#21 integration gates remain open, and no physical or hardware-control path is claimed.
 
 ## 0.1.0 - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 > slices are complete. The bounded M2.7 constrained-IK implementation is complete with Linux and
 > Win64 Unreal Engine 5.8.2 evidence: each run records 35 contextual successes, including all 13
 > IK tests, with build/editor exit code 0.
+> The bounded M2.8a local KinematicPreview math core is implemented; Linux and Win64 Unreal
+> validation each record 43/43 contextual successes, including all eight preview tests, with
+> build/editor exit code 0.
 > The `v0.1.0` release gate is satisfied with portable Python CI;
 > M2.2–M2.5 have separate Unreal Engine 5.8.2 evidence on Linux and Win64. No physical robot path
 > is enabled.
@@ -34,7 +37,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
-| SO-101 twin | M2.2 articulated-state protocol (#14), M2.3 canonical transforms/generic FK code (#15), M2.4 cross-language numerical oracle (#16), and the bounded M2.5 rigid-link actor are complete with Python 3.11/3.12 and Linux/Win64 UE 5.8.2 evidence; the M2.7 constrained-IK implementation is complete with 13 targeted tests and Linux/Win64 UE 5.8.2 evidence; preview and VR authoring remain pending |
+| SO-101 twin | M2.2 articulated-state protocol (#14), M2.3 canonical transforms/generic FK code (#15), M2.4 cross-language numerical oracle (#16), and the bounded M2.5 rigid-link actor are complete with Python 3.11/3.12 and Linux/Win64 UE 5.8.2 evidence; the M2.7 constrained-IK implementation and M2.8a local preview math core are complete with Linux/Win64 UE 5.8.2 evidence; desktop/VR authoring and #20/#21 integration remain open |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |
 
@@ -142,6 +145,19 @@ The M2.7 acceptance slice is complete with a 13-test `DeferredTeleop.M2.IK` sele
 Win64 each record 35 contextual successes (13 IK plus 22 contextual tests), no warnings/failures/
 not-run tests in process, and build/editor exit code 0. See the [constrained IK guide](docs/m2/CONSTRAINED_IK.md)
 and the [M2.7 platform record](docs/m2/evidence/constrained-ik-platform-validation.json).
+
+The bounded M2.8a `KinematicPreview` math core adds a pure `BuildPreview` namespace function and
+Blueprint boundary. It builds bounded time-sampled joint states from a validated start and
+converged or explicitly accepted partial IK result, recomputes FK for the requested tool at every
+sample, preserves exact endpoints, and caps previews at 128 samples and 30 seconds. Per-joint
+velocities are preview timing limits in radians per second; they are not dynamics or motion-control
+limits. Inactive IK joints must equal their start values exactly, and provenance values are carried
+without authenticating the declared description hash. The implementation has eight production
+`DeferredTeleop.M2.KinematicPreview` tests; Linux and Win64 validation each record 43/43
+contextual successes with build/editor exit code 0. See the [preview guide](docs/m2/KINEMATIC_PREVIEW.md)
+and the [platform record](docs/m2/evidence/kinematic-preview-platform-validation.json).
+This bounded math slice does not claim desktop/VR authoring, trajectory visualization, or closure
+of #20/#21.
 
 Verify the portable gate in CI-compatible mode:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -144,7 +144,7 @@ No hardware-control path is introduced by this increment.
 
 ## M2 — Mathematical SO-101 twin in Unreal
 
-Status: **M2.2 protocol, M2.3 math core, M2.4 oracle and M2.5 kinematic actor complete; M2.7 constrained IK complete with Linux/Win64 evidence; preview and VR remain open**
+Status: **M2.2 protocol, M2.3 math core, M2.4 oracle and M2.5 kinematic actor complete; M2.7 constrained IK and M2.8a preview math core complete with Linux/Win64 evidence; desktop/VR authoring and #20/#21 integration remain open**
 Target release: **`v0.2.0`**
 
 - M2.2 articulated robot-state and model-reference protocol (#14), complete with strict Python and
@@ -161,10 +161,14 @@ Target release: **`v0.2.0`**
   groups and tool frames, PositionOnly and PositionPlusApproachAxis tasks, central finite-
   difference Jacobians, structural-limit projection and inspectable result diagnostics, with
   Linux/Win64 Unreal Engine 5.8.2 evidence;
-- Blueprint-accessible target authoring and debugging;
-- confirmed, arrival and target representations with causal provenance;
-- trajectory lines and temporal markers;
-- a `KinematicPreview` that remains a local candidate, not an execution command.
+- M2.8a bounded local time-sampled `KinematicPreview` math core (related to #20), with pure
+  Blueprint/C++ `BuildPreview`, explicit provenance values, partial-result opt-in, exact inactive
+  joint handling, per-joint preview timing limits, FK recomputation for every tool sample, exact
+  endpoints, and bounds of 128 samples and 30 seconds, with Linux/Win64 evidence;
+- planned desktop/VR target authoring and debugging;
+- planned confirmed, arrival and target representations with causal provenance;
+- planned trajectory lines and temporal markers;
+- a `KinematicPreview` consumer remains a local candidate, not an execution command;
 
 The M2.2 platform snapshot records the three targeted ArticulatedView tests as `Success` on
 LinuxEditor and WindowsEditor within a 22-test contextual report; build and headless-editor exit code 0.
@@ -196,6 +200,16 @@ and Win64 each record 35 contextual successes (13 IK plus 22 contextual tests), 
 failures or not-run tests in process, and build/editor exit code 0. See the [constrained IK guide](docs/m2/CONSTRAINED_IK.md)
 and the [M2.7 platform record](docs/m2/evidence/constrained-ik-platform-validation.json) for
 the platform details and source bindings.
+
+The bounded M2.8a preview core is covered by eight production tests under
+`DeferredTeleop.M2.KinematicPreview`. Linux and Win64 Unreal Engine 5.8.2 validation each record
+43/43 contextual successes (35 existing M2 tests plus the eight preview tests), with build and
+headless-editor exit code 0 and no warnings, failures, or not-run tests in process. The [preview guide](docs/m2/KINEMATIC_PREVIEW.md) documents the
+timed joint-space math, FK-per-sample tool poses, 128-sample/30-second bounds, preview velocity
+limits rather than dynamics, exact inactive-joint rejection, partial opt-in, and provenance
+boundary. The [platform record](docs/m2/evidence/kinematic-preview-platform-validation.json)
+binds the platform evidence; this math slice does not claim desktop/VR authoring, trajectory
+visualization, or closure of #20/#21.
 
 ## M3 — Autonomous delayed button press with bounded re-anchoring
 
@@ -273,9 +287,9 @@ replanning policies must retain explicit authorization, effect identity and caus
 
 `v0.1.0` remains the historical M1 release. The M1.7a, M1.7, M1.8, M3a and M3b design increments do not
 retroactively add capabilities or evidence to that tag. `v0.2.0` remains the M2 target; the M2.2,
-M2.3, M2.4 and bounded M2.5 slices are evidenced, and the M2.7 constrained-IK slice is complete
-with Linux/Win64 evidence; preview and VR gates stay open. The target does not require a
-physical SO-101 or claim hardware control.
+M2.3, M2.4 and bounded M2.5 slices are evidenced, M2.7 and M2.8a are complete with Linux/Win64
+evidence, and desktop/VR authoring with the #20/#21 integration gates remains open. The target does
+not require a physical SO-101 or claim hardware control.
 
 Every status claim in this roadmap distinguishes an implemented increment from planned or
 in-progress work. A design document, fixture or proposed oracle is not reported as an

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,7 +12,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
 | M1.8 | **In progress; M1.8b combined proof implemented** | External device runs through delayed Mission/Field domain; durable budget and cross-revision identity remain open |
-| M2 | **In progress; target `v0.2.0`** | M2.1 structural model, M2.2 articulated-state protocol, M2.3 FK math core, M2.4 oracle, and the bounded M2.5 actor are complete with Linux/Win64 UE evidence; M2.7 constrained IK is complete with Linux/Win64 UE evidence; preview and VR authoring remain |
+| M2 | **In progress; target `v0.2.0`** | M2.1 structural model, M2.2 articulated-state protocol, M2.3 FK math core, M2.4 oracle, M2.5 actor, and M2.8a local preview math core are complete with Linux/Win64 UE evidence; M2.7 constrained IK is complete with Linux/Win64 UE evidence; desktop/VR authoring and #20/#21 remain |
 | M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
 
@@ -108,6 +108,13 @@ independent external effect, or concurrent-operation causal coherence.
   the acceptance selector contains 13 automation tests. Linux and Win64 each record 35 contextual
   successes (13 IK plus 22 contextual tests), no warnings, failures or not-run tests in process,
   and build/editor exit code 0. See the [M2.7 platform record](m2/evidence/constrained-ik-platform-validation.json).
+- M2.8a bounded local time-sampled `KinematicPreview` math core: pure C++/Blueprint
+  `BuildPreview`, explicit provenance values, partial-result opt-in, exact inactive-joint
+  rejection, preview velocity limits in radians per second, FK recomputation for every tool
+  sample, exact endpoints, and bounds of 128 samples and 30 seconds. Its eight-test selector
+  passes within the 43-test contextual Linux and Win64 Unreal Engine 5.8.2 reports, with build
+  and editor exit code 0 and no warnings, failures, or not-run tests. See the [preview guide](m2/KINEMATIC_PREVIEW.md)
+  and the [platform record](m2/evidence/kinematic-preview-platform-validation.json).
 
 The [M2.4 fixture contract](m2/KINEMATICS_FIXTURES.md) documents the numerical oracle and the
 mandatory Python `--check` gate. The [M2.4 platform summary](m2/evidence/fk-oracle-platform-validation.json)
@@ -135,6 +142,29 @@ successes on both Linux and Win64 (13 IK plus 22 contextual tests), with no warn
 not-run tests in process and build/editor exit code 0. The slice is a local kinematic preview aid
 and does not add hardware, collision or motion-control behavior. The [platform record](m2/evidence/constrained-ik-platform-validation.json)
 binds the report hashes and source details.
+
+### M2.8a local kinematic preview
+
+The bounded #20 support slice converts one explicit articulated start state and a validated
+converged or opt-in partial IK result into deterministic joint-space samples. It computes
+`T = max(abs(goal-start) / preview_velocity)` in radians, rejects non-finite or over-30-second
+durations, returns one sample for zero duration, and caps non-zero previews at 128 samples.
+Endpoints use the copied start and goal values exactly. Every sample recomputes canonical FK for
+the requested IK tool frame; tool poses are never interpolated. Preview velocity limits only bound
+presentation timing and do not model dynamics or authorize motion.
+
+The goal uses active IK joints. Every inactive revolute IK value must equal its start value exactly;
+an inactive gripper mismatch is rejected before goal FK and sampling. `Partial` and `IterationLimit`
+results require explicit opt-in and `bSuccess=false`. Source and evidence identifiers, provenance,
+frame, calibration and declared model hash shape are carried as values; the hash is not authenticated.
+The builder resets failed output and leaves retention of the last valid preview to its caller.
+
+The selector contains eight production `DeferredTeleop.M2.KinematicPreview` tests. Linux and Win64
+UE 5.8.2 each report 43/43 contextual successes (35 existing M2 tests plus the eight preview tests),
+zero warnings/failures/not-run tests in process, and build/editor exit code 0. The
+[machine-readable record](m2/evidence/kinematic-preview-platform-validation.json) binds the
+platform reports and selected source hashes. This is the M2.8a math core only; desktop/VR authoring,
+trajectory visualization, and the full M2 integration gates in #20/#21 remain open.
 
 ## Implemented in M1.7a
 
@@ -184,7 +214,7 @@ The remaining full M1.8 gate requires:
 
 ### Remaining M2 work
 
-- desktop/VR target authoring and time-sampled `KinematicPreview`;
+- desktop/VR target authoring and consumption of the time-sampled `KinematicPreview`;
 - available provenance connecting confirmed, arrival and target branches, with missing references
   shown explicitly and without treating a preview as an execution command; complete multi-operation
   lineage remains the later M1.7 gate.
@@ -227,8 +257,9 @@ The M2.5 runtime actor, public scene recipe, platform reports, and synthetic PNG
 in this bounded tranche; they introduce no hardware path. M1.7a has the separate implementation
 and validation cited above; the bounded M1.8b proof is implemented while the full M1.8 gate remains
 open. M2.2, M2.3, M2.4, and M2.5 have their implementation and machine-readable Linux/Win64
-platform records. M2.7 is complete with machine-readable Linux/Win64 platform records; preview
-and VR authoring remain open. A milestone is complete
+platform records. M2.7 and the M2.8a preview math core are complete with machine-readable
+Linux/Win64 platform records; desktop/VR authoring and the full #20/#21 integration gates remain
+open. A milestone is complete
 only after its deterministic replay, machine-readable artifacts and visible result satisfy the gate
 in the [roadmap](../ROADMAP.md).
 
@@ -243,6 +274,6 @@ M3b's physical-fixture evidence is not present.
 No public hardware-control path exists. Nothing in the current repository should command a
 physical robot. The M1 release gate operates entirely on the public dummy path. Unreal Engine
 5.8.2 is verified on the reference Windows platform for `v0.1.0` and on Linux/Win64 for the M2.2
-protocol, M2.3 math-core, M2.4 oracle, and M2.5 actor evidence; `v0.1.0` does not claim Unreal
-support on Linux. M2.7 has Linux/Win64 platform evidence, and the IK slice introduces no
-hardware-control path.
+protocol, M2.3 math-core, M2.4 oracle, M2.5 actor, M2.7 IK, and M2.8a preview evidence;
+`v0.1.0` does not claim Unreal support on Linux. M2.7 and M2.8a introduce no hardware-control
+path.

--- a/docs/m2/KINEMATIC_PREVIEW.md
+++ b/docs/m2/KINEMATIC_PREVIEW.md
@@ -1,0 +1,113 @@
+# M2.8a — local kinematic preview
+
+M2.8a provides a small, deterministic `KinematicPreview` math core for future
+desktop authoring. `BuildPreview` consumes a validated robot description, one explicit
+articulated start state, and an already computed `FDttIKResult`. It returns
+named joint samples and a canonical tool pose produced by forward kinematics at
+each sample.
+
+The API is available through `DeferredTeleop::Kinematics::BuildPreview` and the
+`UDeferredTeleopKinematicPreviewLibrary` Blueprint function library. It does not
+read a world, actor, WebSocket, clock, physics scene, VR controller, or
+hardware, and it does not execute a command. The result is a local candidate for
+presentation; it is not a motion plan, collision check, safety proof, or
+admission decision.
+
+## Inputs and validation
+
+`PreviewId` and `GoalId` must be non-zero `FGuid` values. The supplied model
+reference must match the description and the IK result. Its description hash is
+required to have the structural form `sha256:` followed by 64 lowercase hex
+digits. The function checks this shape only; it does not read description bytes
+or authenticate that hash.
+
+The source reference carries a message id, correlation id, frame id,
+calibration version, and an `FDeferredTeleopEvidence` value. Evidence must have
+at least one source id, valid ordered dates, and a positive world revision.
+`Measured`, `Fused`, `Synthetic`, and `OperatorAsserted` map explicitly to
+`Measured`, `Fused`, `Simulated`, and `OperatorAsserted` evidence provenance.
+The mapping records provenance and does not prove origin.
+
+The robot description is passed through `ValidateRobotDescription`. The root
+transform must be finite, rigid, and canonical (right-handed, Z-up, metres and
+radians). Start and IK states must contain exactly one finite value for every
+revolute description joint, with no unknown, fixed, or duplicate name and no
+limit violation. The output uses description order. Active names from the IK
+result must be distinct revolute joints. For an inactive revolute, the supplied
+IK value must equal the start value exactly; otherwise `BuildPreview` rejects
+the request before interpolation. The preview goal is exactly the start value,
+which also prevents an inactive gripper from changing.
+
+Only a converged IK result with `bSuccess=true` is accepted by default. A
+`Partial` or `IterationLimit` result is accepted only when
+`Settings.bAcceptPartial` is true and its `bSuccess` flag is false. Other
+statuses and incoherent status/success pairs are rejected. Residuals must be
+finite and non-negative, the tool frame must be known, and the achieved tool
+transform must be finite and rigid.
+
+Each revolute joint has one finite, strictly positive maximum speed in rad/s.
+The sample rate is in `(0, 1000]` Hz, the duration bound is in `(0, 30]` s, and
+the sample cap is in `[2, 128]`.
+
+## Timing and poses
+
+For each revolute joint, the duration is computed in radians:
+
+```text
+T = max(abs(goal_i - start_i) / velocity_i)
+```
+
+`T` must be finite and no greater than the configured maximum; the builder does
+not silently slow or clamp it. If `T` is zero, exactly one sample at `t=0` is
+returned. Otherwise the requested count is:
+
+```text
+N = min(MaximumSamples, max(2, ceil(T * SampleRateHz) + 1))
+t_k = T * k / (N - 1)
+q_i(t_k) = start_i + (goal_i - start_i) * t_k / T
+```
+
+The first and last times and joint values are assigned directly from the start
+and goal snapshots, preserving exact endpoints. Intermediate values are checked
+against joint limits. Every sample calls canonical FK with the supplied root
+and IK tool frame; tool poses are never interpolated.
+
+Before sampling, FK is recomputed for the final preview goal and compared with
+`IKResult.AchievedToolTransform`. Position error must be at most `1e-9` metres
+and rotation error at most `1e-9` radians. This catches an incompatible root or
+tool frame and a forged or stale achieved transform before output is committed.
+
+The output is assembled in a temporary value and assigned only after all checks
+and samples succeed. Each call first resets the output to its default invalid
+state and clears its error string, so a caller can retain its last valid value
+transactionally outside this pure function.
+
+## Verification
+
+The eight automation tests under `DeferredTeleop.M2.KinematicPreview` cover:
+
+1. converged identity/reference/source/root snapshots, exact endpoints, and FK
+   tool poses;
+2. multi-joint maximum travel time, radians, linear joint interpolation, and
+   inactive gripper preservation;
+3. the zero-duration one-sample path;
+4. the 128-sample cap and exact endpoint preservation;
+5. missing, duplicate, zero, and non-finite speeds plus rate, duration, and cap
+   bounds;
+6. forged achieved poses, wrong root/tool, model identity, revision, and hash
+   shape;
+7. all four provenance mappings, source/frame/calibration identifiers, evidence
+   dates, and GUID validation;
+8. unknown, fixed, duplicate, non-finite, and out-of-limit joints, inactive
+   gripper handling, and accepted/rejected IK statuses.
+
+Linux and Win64 Unreal Engine 5.8.2 validation each report 43/43 contextual
+successes (35 existing M2 successes plus the eight preview oracles), with build
+and headless-editor exit code 0 and no warnings, failures, or not-run tests in
+process. The machine-readable [platform record](evidence/kinematic-preview-platform-validation.json)
+binds the selected source hashes and both report hashes. The eight tests call
+the production `DeferredTeleop::Kinematics::BuildPreview` function.
+
+This document covers the bounded #20 support in M2.8a only. It does not claim
+desktop or VR authoring, trajectory visualization, or closure of #20/#21; those
+integration slices remain open.

--- a/docs/m2/evidence/kinematic-preview-platform-validation.json
+++ b/docs/m2/evidence/kinematic-preview-platform-validation.json
@@ -1,0 +1,307 @@
+{
+  "schema": "deferred-teleoperation/m2.8a-kinematic-preview-platform-validation.v1",
+  "status": "complete_for_bounded_core",
+  "scope": "Pure time-sampled joint/tool preview generation and validation; eight preview tests within each 43-test contextual report.",
+  "related_issue": 20,
+  "closes_related_issue": false,
+  "integration_base_commit": "c8992a253ab6aa1586a527b7cbff7df568cf603b",
+  "source_identity_note": "The selected compiled sources and fixture bytes are identified by these hashes; this core does not implement goal-authoring interactions or visualization.",
+  "selected_source_count": 43,
+  "sources": [
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/DeferredTeleopRuntime.Build.cs",
+      "sha256": "94cce8c400553ffb84b8a34ebe419276c8d9c86b868df8eddf51fe7479d25f3f"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.cpp",
+      "sha256": "83d5a66e3d7047cdbef5080b8324764b55b84bb40b11d41f920d7eb2f52b73ad"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.h",
+      "sha256": "6803ec5686544aa6f40f0af52979262bc9c5f921fc275216c911ed46962579e9"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionClientComponent.cpp",
+      "sha256": "fbda6aab08076de4dbc02216c263a7aa75d8bbc2db7c20ed68e73cbac821532d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.cpp",
+      "sha256": "e7a26dc0306c317070aab990731f037a144fc8494133fcedd197d951553e4ab5"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.h",
+      "sha256": "7a00e323cf9a27a07e0af16833d71746b7ec20b72e865b6d17b880a35bc0f38d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopRuntime.cpp",
+      "sha256": "c3e3c943960d18a1d9a34742aae5fe9770061191187b39bc5517c5d9b90ae887"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStateVisualizationActor.cpp",
+      "sha256": "e6bf490426bfe6a8610a64747d12d2dc1d5bfa00e047daa37b41d67aea576235"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVersionLibrary.cpp",
+      "sha256": "cbb763125de0ae7830795d16860140a1e0bc18038ec7f2fdf15ab3b6dfdbeeef"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVisualizationLibrary.cpp",
+      "sha256": "e88d55a276d4de67d09969db610049732ff6a17b9476846b1e08ddc6ec1e4a3c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopIKLibrary.cpp",
+      "sha256": "1074e64b7dabe1a637e057381388b3bc923a550c3a8ad7ca87e4f24acd3a749a"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopIKTestBridge.h",
+      "sha256": "89b216145d9eb9cd8cbfe945b356eab21e5339798b58b3ca4ec42b7fb880e254"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicPreviewLibrary.cpp",
+      "sha256": "43c24aa92a94666b258c4b1ee387086e605fc945840e9f54f2b8bec7c1624178"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp",
+      "sha256": "17e07edf30e6bda519da3c0415f0f0cf0563403ac33b9ae0c0ad32a079900773"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp",
+      "sha256": "1de65b1bac4359120f668ec146dada0016c1b6809c1e9c50adb757bbe30083cd"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelTypes.cpp",
+      "sha256": "ca9693125f9ff761105c67cf165b5c16bbc2ee43dc6b8fd58fee4cacbd8a74e0"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopArticulatedViewTests.cpp",
+      "sha256": "2ff481a948507c5f0008132c5fe7b7a71245bc5adc870818f02e7d370c95c488"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopFrameConversionContractTests.cpp",
+      "sha256": "9aa5cf021b6839fa54165630d9e3915d82d91c41ae1b359955f9832eb49e1fbc"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopIKTests.cpp",
+      "sha256": "2ce22c575d5495a62f449a16c9844b0c079eb59a23849d23a2b064bc98d6b84e"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicPreviewTests.cpp",
+      "sha256": "b7f6cd404af78819cb77b45da4b78c6a838dba56d39a833a74de8052c970d395"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicRobotActorTests.cpp",
+      "sha256": "3a65cb8b94521c0b7d4d76b6b59d033c3f788c41bc6581cee14fed3580e3742e"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsFixtureTests.cpp",
+      "sha256": "489c209cba968cf198750cf7228844092ad7c1d93613e1208f5c499f5248300b"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp",
+      "sha256": "d2a96bbba4dde2d677918c29d02a90dea085660534f4b64a47b1f547fc827da9"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopMissionViewTests.cpp",
+      "sha256": "40a56f91054898732a26a9b1958c06a9279bc2e07a94ce374fda27fe7bd152e2"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Visualization/DeferredTeleopKinematicRobotActor.cpp",
+      "sha256": "8d5012779aba60b2a369f4c79e003a87eb72c18a953f5b4c7afdd6191d0b76bd"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Articulated/DeferredTeleopArticulatedViewTypes.h",
+      "sha256": "4ded7520fb560d9d4d42f8d76fef53cbbd1fc1e9e9b6c9e3b0a45e8991ba6c3d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionClientComponent.h",
+      "sha256": "9323d041d73879e54feee96ffd21d2e7e7ca242981157ef370a2b597ea164c9c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionViewTypes.h",
+      "sha256": "a6ab1e5b9b9d23d8693b99b59ae3ed20eee71e6dd71742f43189e329467378ce"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopRuntime.h",
+      "sha256": "5ab43d0e84c526acd869d73a2ea98391de5635e7fd75e10663a532051c0a128d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopStateVisualizationActor.h",
+      "sha256": "4c7123a741f1108cdb1f5abfcc502b125ebe5d19f338b352bdce6169df8eb734"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVersionLibrary.h",
+      "sha256": "903971ea5a3b55d07a45751acbad2fbf9114a8865d5490d4a286756a19d54f04"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVisualizationLibrary.h",
+      "sha256": "0669fd5f9123f8eafc8e7bca5913822a6c3f8cb1efae1da459d8f75eb40fd93c"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopIKLibrary.h",
+      "sha256": "e7e0444ffa6400a8c68098c1487dd234989c7e8083b6945a4c69e6e4fa454b2d"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopIKTypes.h",
+      "sha256": "637ab3db0b187ea8eb046e24668dd79d0e21b4dc6e947f7592e932d034610035"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewLibrary.h",
+      "sha256": "08bfa2b6e9caed7dada7cbb412094f18875bbaf568c771d41164ce6a7325e7e5"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewTypes.h",
+      "sha256": "e3e41dd5faaef980b1e8f9a5cad6d2a6d65df27ddef68ff9b3b4d83160c4b1cf"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicsLibrary.h",
+      "sha256": "697f41e5611ba0f35c564d779e5e5a3d8ec447dc258afd428725c3bfeb5ec705"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h",
+      "sha256": "b10aea77aac60a5b8d539d4c00c481250ca465564cf7f83a118d7e287e8939d4"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Visualization/DeferredTeleopKinematicRobotActor.h",
+      "sha256": "18a41f6569c8ba405214adf8690932ef5bf2f2387741bf5ab7fe61c4d989901b"
+    },
+    {
+      "path": "robots/so101/generated/so101.kinematics.json",
+      "sha256": "36ce321332248351f5304630a9ccc4887d6665666e17b6933e3302874735e5f2"
+    },
+    {
+      "path": "fixtures/m2/kinematics/so101-fk.json",
+      "sha256": "2fd05f90c8f0344d8687b06d11086d8ba4bc1e43b0fc248869b19369bfa8c3b8"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/DeferredTeleopDemo.uproject",
+      "sha256": "86ba4cc0c07997bdf0b8083b43236a7b79ea642144105aa6263e6bfba24e1b39"
+    },
+    {
+      "path": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/DeferredTeleop.uplugin",
+      "sha256": "5587a5d087cf44eabdea70e2d9de4edc157c20989ba75d9c7cc6221d8c0b6427"
+    }
+  ],
+  "platforms": {
+    "linux": {
+      "platform": "LinuxEditor",
+      "engine": "Unreal Engine 5.8.2",
+      "toolchain": {
+        "compiler": "Clang 20.1.8",
+        "engine_commit": "ff8421f2b8cb4feb76fff57965a1effc53a6eb7b"
+      },
+      "build_exit_code": 0,
+      "editor_exit_code": 0,
+      "build_result_sha256": "465190d34bf518ba9a8672e62b1243cb93755c54b471c6b03f77ce20840e100b",
+      "editor_result_sha256": "9e0da659c08e5e675432f134ea78f22630c06a654f3c16f729aceb61569350f1",
+      "report_sha256": "a1224db46694821ea3cbdcebb1cf942289eae1894a938622d0f811597af69dc4",
+      "full_suite_counts": {
+        "succeeded": 43,
+        "succeededWithWarnings": 0,
+        "failed": 0,
+        "notRun": 0,
+        "inProcess": 0
+      },
+      "scope_test_count": 8,
+      "tests": [
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.CapsSamplesAndPreservesEndpoints",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ConvergedSnapshotAndFK",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.DurationUsesMaxJointTime",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.RejectsForgedOrMismatchedIK",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.RejectsInvalidSettings",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ValidatesJointsAndStatuses",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ValidatesSourceEvidence",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ZeroDuration",
+          "state": "Success"
+        }
+      ],
+      "source_hashes_verified": true
+    },
+    "windows": {
+      "platform": "WindowsEditor",
+      "engine": "Unreal Engine 5.8.2",
+      "toolchain": {
+        "compiler": "MSVC 19.50.35737.0",
+        "windows_sdk": "10.0.26100.0",
+        "engine_commit": null,
+        "engine_commit_note": "The guest engine source commit was not independently verified."
+      },
+      "build_exit_code": 0,
+      "editor_exit_code": 0,
+      "build_result_sha256": "3fa8ef6c211eb292ec4a3c2b3ac33f1ccadb0becb7d34fd1ebf20362d1a28ac3",
+      "editor_result_sha256": "c5c2df605f259ff47656f5ab323945cc1a1db7142413c880901c51f37ddbc526",
+      "report_sha256": "7727b227d5ef800576bbbc6f02c0e656bb956abab418beecbc7b48d816501f35",
+      "full_suite_counts": {
+        "succeeded": 43,
+        "succeededWithWarnings": 0,
+        "failed": 0,
+        "notRun": 0,
+        "inProcess": 0
+      },
+      "scope_test_count": 8,
+      "tests": [
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.CapsSamplesAndPreservesEndpoints",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ConvergedSnapshotAndFK",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.DurationUsesMaxJointTime",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.RejectsForgedOrMismatchedIK",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.RejectsInvalidSettings",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ValidatesJointsAndStatuses",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ValidatesSourceEvidence",
+          "state": "Success"
+        },
+        {
+          "name": "DeferredTeleop.M2.KinematicPreview.ZeroDuration",
+          "state": "Success"
+        }
+      ],
+      "source_hashes_verified": true
+    }
+  },
+  "limits": [
+    "Joint-linear samples and tool FK are local kinematic candidates, not executable or collision-safe motion plans.",
+    "The declared source reference and model digest are validated as data; this pure API does not authenticate an observation or load and hash a model file.",
+    "Inactive IK goal joints must equal the supplied start exactly; partial IK results require explicit opt-in.",
+    "At most 128 samples and 30 seconds under explicit preview velocity limits; no dynamics, controller, or wall-clock feasibility claim.",
+    "Desktop/VR goal authoring, trajectory rendering, profiling and the M2 release gate remain outside this core."
+  ]
+}

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicPreviewLibrary.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicPreviewLibrary.cpp
@@ -1,0 +1,1060 @@
+#include "Kinematics/DeferredTeleopKinematicPreviewLibrary.h"
+
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "Math/UnrealMathUtility.h"
+
+namespace DeferredTeleop::KinematicPreview::Private
+{
+constexpr double ToolPositionToleranceMetres = 1.0e-9;
+constexpr double ToolRotationToleranceRadians = 1.0e-9;
+constexpr double MaximumPreviewRateHz = 1000.0;
+constexpr double MaximumPreviewDurationSeconds = 30.0;
+constexpr int32 MinimumPreviewSamples = 2;
+constexpr int32 MaximumPreviewSamples = 128;
+
+bool Fail(FString& OutError, const FString& Message)
+{
+    OutError = Message;
+    return false;
+}
+
+bool IsValidDescriptionHash(const FString& DescriptionHash)
+{
+    constexpr int32 PrefixLength = 7; // "sha256:"
+    constexpr int32 DigestLength = 64;
+    if (DescriptionHash.Len() != PrefixLength + DigestLength
+        || !DescriptionHash.StartsWith(TEXT("sha256:")))
+    {
+        return false;
+    }
+
+    for (int32 Index = PrefixLength; Index < DescriptionHash.Len(); ++Index)
+    {
+        const TCHAR Character = DescriptionHash[Index];
+        const bool bLowerHex =
+            (Character >= TEXT('0') && Character <= TEXT('9'))
+            || (Character >= TEXT('a') && Character <= TEXT('f'));
+        if (!bLowerHex)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ValidateIdsAndModelReference(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    FString& OutError)
+{
+    if (!Request.PreviewId.IsValid() || !Request.GoalId.IsValid())
+    {
+        return Fail(OutError, TEXT("preview_id and goal_id must be valid non-zero GUIDs"));
+    }
+    if (Request.ModelReference.ModelId.IsEmpty()
+        || Request.ModelReference.ModelRevision.IsEmpty())
+    {
+        return Fail(
+            OutError,
+            TEXT("preview model reference model_id and model_revision are required"));
+    }
+    if (!IsValidDescriptionHash(Request.ModelReference.DescriptionHash))
+    {
+        return Fail(
+            OutError,
+            TEXT("preview model reference description_hash must be sha256: followed by 64 lowercase hex digits"));
+    }
+    if (Request.ModelReference.ModelId != Description.ModelId
+        || Request.ModelReference.ModelRevision != Description.ModelRevision)
+    {
+        return Fail(OutError, TEXT("preview model reference does not match the description"));
+    }
+    if (Request.IKResult.ModelId != Description.ModelId
+        || Request.IKResult.ModelRevision != Description.ModelRevision)
+    {
+        return Fail(OutError, TEXT("IK result model reference does not match the description"));
+    }
+    return true;
+}
+
+bool ValidateSourceReference(
+    const FDttPreviewSourceReference& Source,
+    FString& OutError)
+{
+    if (Source.SourceMessageId.IsEmpty()
+        || Source.CorrelationId.IsEmpty()
+        || Source.FrameId.IsEmpty()
+        || Source.CalibrationVersion.IsEmpty())
+    {
+        return Fail(
+            OutError,
+            TEXT("preview source message, correlation, frame, and calibration identifiers are required"));
+    }
+
+    const FDeferredTeleopEvidence& Evidence = Source.Evidence;
+    if (Evidence.SourceIds.Num() == 0)
+    {
+        return Fail(OutError, TEXT("preview source evidence must contain at least one source id"));
+    }
+    for (const FString& SourceId : Evidence.SourceIds)
+    {
+        if (SourceId.IsEmpty())
+        {
+            return Fail(OutError, TEXT("preview source evidence source ids must be non-empty"));
+        }
+    }
+    const int64 MinimumDateTicks = FDateTime::MinValue().GetTicks();
+    const int64 MaximumDateTicks = FDateTime::MaxValue().GetTicks();
+    const bool bObservedDateInRange =
+        Evidence.ObservedAt.GetTicks() >= MinimumDateTicks
+        && Evidence.ObservedAt.GetTicks() <= MaximumDateTicks;
+    const bool bProducedDateInRange =
+        Evidence.ProducedAt.GetTicks() >= MinimumDateTicks
+        && Evidence.ProducedAt.GetTicks() <= MaximumDateTicks;
+    if (!bObservedDateInRange || !bProducedDateInRange)
+    {
+        return Fail(OutError, TEXT("preview source evidence dates must be valid"));
+    }
+    if (Evidence.ProducedAt < Evidence.ObservedAt)
+    {
+        return Fail(OutError, TEXT("preview source evidence produced_at precedes observed_at"));
+    }
+    if (Evidence.WorldRevision <= 0)
+    {
+        return Fail(OutError, TEXT("preview source evidence world_revision must be positive"));
+    }
+
+    EDeferredTeleopProvenance ExpectedProvenance = EDeferredTeleopProvenance::Unknown;
+    switch (Source.SourceKind)
+    {
+    case EDttPreviewSourceKind::Measured:
+        ExpectedProvenance = EDeferredTeleopProvenance::Measured;
+        break;
+    case EDttPreviewSourceKind::Fused:
+        ExpectedProvenance = EDeferredTeleopProvenance::Fused;
+        break;
+    case EDttPreviewSourceKind::Synthetic:
+        ExpectedProvenance = EDeferredTeleopProvenance::Simulated;
+        break;
+    case EDttPreviewSourceKind::OperatorAsserted:
+        ExpectedProvenance = EDeferredTeleopProvenance::OperatorAsserted;
+        break;
+    default:
+        return Fail(OutError, TEXT("preview source kind is unsupported"));
+    }
+    if (Evidence.Provenance != ExpectedProvenance)
+    {
+        return Fail(OutError, TEXT("preview source kind and evidence provenance do not match"));
+    }
+    return true;
+}
+
+bool ValidateSettings(
+    const FDttRobotDescription& Description,
+    const FDttValidatedRobotModel& Model,
+    const FDttKinematicPreviewSettings& Settings,
+    TMap<FName, double>& OutVelocities,
+    FString& OutError)
+{
+    if (!FMath::IsFinite(Settings.SampleRateHz)
+        || Settings.SampleRateHz <= 0.0
+        || Settings.SampleRateHz > MaximumPreviewRateHz)
+    {
+        return Fail(OutError, TEXT("preview sample_rate_hz must be in (0, 1000]"));
+    }
+    if (!FMath::IsFinite(Settings.MaximumDurationSeconds)
+        || Settings.MaximumDurationSeconds <= 0.0
+        || Settings.MaximumDurationSeconds > MaximumPreviewDurationSeconds)
+    {
+        return Fail(OutError, TEXT("preview maximum_duration_seconds must be in (0, 30]"));
+    }
+    if (Settings.MaximumSamples < MinimumPreviewSamples
+        || Settings.MaximumSamples > MaximumPreviewSamples)
+    {
+        return Fail(OutError, TEXT("preview maximum_samples must be in [2, 128]"));
+    }
+
+    OutVelocities.Reset();
+    OutVelocities.Reserve(Settings.JointVelocities.Num());
+    TSet<FName> SeenNames;
+    SeenNames.Reserve(Settings.JointVelocities.Num());
+    for (const FDttPreviewJointVelocity& Velocity : Settings.JointVelocities)
+    {
+        if (Velocity.JointName.IsNone())
+        {
+            return Fail(OutError, TEXT("preview joint velocity name must be non-empty"));
+        }
+        const int32 JointIndex = Model.FindJointIndex(Velocity.JointName);
+        if (JointIndex == INDEX_NONE)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview joint velocity references unknown joint: %s"),
+                    *Velocity.JointName.ToString()));
+        }
+        if (Description.Joints[JointIndex].Type != EDttRobotJointType::Revolute)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview joint velocity references fixed joint: %s"),
+                    *Velocity.JointName.ToString()));
+        }
+        if (SeenNames.Contains(Velocity.JointName))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview joint velocity is duplicated: %s"),
+                    *Velocity.JointName.ToString()));
+        }
+        if (!FMath::IsFinite(Velocity.MaximumRadiansPerSecond)
+            || Velocity.MaximumRadiansPerSecond <= 0.0)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview joint velocity must be finite and positive in radians per second: %s"),
+                    *Velocity.JointName.ToString()));
+        }
+        SeenNames.Add(Velocity.JointName);
+        OutVelocities.Add(Velocity.JointName, Velocity.MaximumRadiansPerSecond);
+    }
+
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type == EDttRobotJointType::Revolute
+            && !SeenNames.Contains(Joint.Name))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview joint velocity is missing for revolute joint: %s"),
+                    *Joint.Name.ToString()));
+        }
+    }
+    return true;
+}
+
+bool ValidateJointLimit(
+    const FDttRobotJointDescription& Joint,
+    double PositionRadians,
+    const TCHAR* StateLabel,
+    FString& OutError)
+{
+    if (!FMath::IsFinite(PositionRadians))
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("%s joint position is non-finite: %s"),
+                StateLabel,
+                *Joint.Name.ToString()));
+    }
+    if (Joint.bHasPositionLimits
+        && (PositionRadians < Joint.LowerPositionRadians
+            || PositionRadians > Joint.UpperPositionRadians))
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("%s joint position is outside limits: %s"),
+                StateLabel,
+                *Joint.Name.ToString()));
+    }
+    return true;
+}
+
+bool AddValidatedJointValue(
+    const FDttRobotDescription& Description,
+    const FDttValidatedRobotModel& Model,
+    FName JointName,
+    double PositionRadians,
+    const TCHAR* StateLabel,
+    TSet<FName>& InOutSeenNames,
+    TMap<FName, double>& InOutValues,
+    FString& OutError)
+{
+    if (JointName.IsNone())
+    {
+        return Fail(
+            OutError,
+            FString::Printf(TEXT("%s joint name must be non-empty"), StateLabel));
+    }
+    const int32 JointIndex = Model.FindJointIndex(JointName);
+    if (JointIndex == INDEX_NONE)
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("%s references unknown joint: %s"),
+                StateLabel,
+                *JointName.ToString()));
+    }
+    if (Description.Joints[JointIndex].Type != EDttRobotJointType::Revolute)
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("%s references fixed joint: %s"),
+                StateLabel,
+                *JointName.ToString()));
+    }
+    if (InOutSeenNames.Contains(JointName))
+    {
+        return Fail(
+            OutError,
+            FString::Printf(
+                TEXT("%s contains duplicate joint: %s"),
+                StateLabel,
+                *JointName.ToString()));
+    }
+    if (!ValidateJointLimit(
+            Description.Joints[JointIndex],
+            PositionRadians,
+            StateLabel,
+            OutError))
+    {
+        return false;
+    }
+    InOutSeenNames.Add(JointName);
+    InOutValues.Add(JointName, PositionRadians);
+    return true;
+}
+
+bool EnsureAllRevoluteJointsPresent(
+    const FDttRobotDescription& Description,
+    const TSet<FName>& SeenNames,
+    const TCHAR* StateLabel,
+    FString& OutError)
+{
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type == EDttRobotJointType::Revolute
+            && !SeenNames.Contains(Joint.Name))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("%s is missing revolute joint: %s"),
+                    StateLabel,
+                    *Joint.Name.ToString()));
+        }
+    }
+    return true;
+}
+
+bool ValidateStartJointPositions(
+    const FDttRobotDescription& Description,
+    const FDttValidatedRobotModel& Model,
+    const TArray<FDeferredTeleopArticulatedJointPosition>& Input,
+    TMap<FName, double>& OutValues,
+    FString& OutError)
+{
+    OutValues.Reset();
+    OutValues.Reserve(Input.Num());
+    TSet<FName> SeenNames;
+    SeenNames.Reserve(Input.Num());
+    for (const FDeferredTeleopArticulatedJointPosition& Position : Input)
+    {
+        if (Position.JointName.IsEmpty())
+        {
+            return Fail(OutError, TEXT("start joint name must be non-empty"));
+        }
+        const FName JointName(*Position.JointName);
+        if (!AddValidatedJointValue(
+                Description,
+                Model,
+                JointName,
+                Position.PositionRadians,
+                TEXT("start state"),
+                SeenNames,
+                OutValues,
+                OutError))
+        {
+            return false;
+        }
+    }
+    return EnsureAllRevoluteJointsPresent(
+        Description,
+        SeenNames,
+        TEXT("start state"),
+        OutError);
+}
+
+bool ValidateIKJointPositions(
+    const FDttRobotDescription& Description,
+    const FDttValidatedRobotModel& Model,
+    const TArray<FDttNamedJointPosition>& Input,
+    TMap<FName, double>& OutValues,
+    FString& OutError)
+{
+    OutValues.Reset();
+    OutValues.Reserve(Input.Num());
+    TSet<FName> SeenNames;
+    SeenNames.Reserve(Input.Num());
+    for (const FDttNamedJointPosition& Position : Input)
+    {
+        if (!AddValidatedJointValue(
+                Description,
+                Model,
+                Position.JointName,
+                Position.PositionRadians,
+                TEXT("IK result"),
+                SeenNames,
+                OutValues,
+                OutError))
+        {
+            return false;
+        }
+    }
+    return EnsureAllRevoluteJointsPresent(
+        Description,
+        SeenNames,
+        TEXT("IK result"),
+        OutError);
+}
+
+bool ValidateActiveJointNames(
+    const FDttRobotDescription& Description,
+    const FDttValidatedRobotModel& Model,
+    const TArray<FName>& ActiveNames,
+    TSet<FName>& OutActiveNames,
+    FString& OutError)
+{
+    OutActiveNames.Reset();
+    OutActiveNames.Reserve(ActiveNames.Num());
+    for (const FName JointName : ActiveNames)
+    {
+        if (JointName.IsNone())
+        {
+            return Fail(OutError, TEXT("IK active joint name must be non-empty"));
+        }
+        const int32 JointIndex = Model.FindJointIndex(JointName);
+        if (JointIndex == INDEX_NONE)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("IK active joint is unknown: %s"),
+                    *JointName.ToString()));
+        }
+        if (Description.Joints[JointIndex].Type != EDttRobotJointType::Revolute)
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("IK active joint is fixed: %s"),
+                    *JointName.ToString()));
+        }
+        if (OutActiveNames.Contains(JointName))
+        {
+            return Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("IK active joint is duplicated: %s"),
+                    *JointName.ToString()));
+        }
+        OutActiveNames.Add(JointName);
+    }
+    return true;
+}
+
+bool ValidateIKStatus(
+    const FDttIKResult& IKResult,
+    bool bAcceptPartial,
+    bool& OutAcceptedPartial,
+    FString& OutError)
+{
+    OutAcceptedPartial = false;
+    switch (IKResult.Status)
+    {
+    case EDttIKStatus::Converged:
+        if (!IKResult.bSuccess)
+        {
+            return Fail(OutError, TEXT("converged IK result must have bSuccess=true"));
+        }
+        return true;
+    case EDttIKStatus::Partial:
+    case EDttIKStatus::IterationLimit:
+        if (IKResult.bSuccess)
+        {
+            return Fail(OutError, TEXT("partial IK result must have bSuccess=false"));
+        }
+        if (!bAcceptPartial)
+        {
+            return Fail(OutError, TEXT("partial IK result requires bAcceptPartial=true"));
+        }
+        OutAcceptedPartial = true;
+        return true;
+    default:
+        return Fail(OutError, TEXT("IK result status is not accepted by a kinematic preview"));
+    }
+}
+
+TArray<FDttNamedJointPosition> MakeNamedJointState(
+    const FDttRobotDescription& Description,
+    const TMap<FName, double>& Values)
+{
+    TArray<FDttNamedJointPosition> Result;
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        const double* Value = Values.Find(Joint.Name);
+        if (Value == nullptr)
+        {
+            continue;
+        }
+        FDttNamedJointPosition& Position = Result.AddDefaulted_GetRef();
+        Position.JointName = Joint.Name;
+        Position.PositionRadians = *Value;
+    }
+    return Result;
+}
+
+TArray<FDeferredTeleopArticulatedJointPosition> MakeArticulatedJointState(
+    const FDttRobotDescription& Description,
+    const TMap<FName, double>& Values)
+{
+    TArray<FDeferredTeleopArticulatedJointPosition> Result;
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        const double* Value = Values.Find(Joint.Name);
+        if (Value == nullptr)
+        {
+            continue;
+        }
+        FDeferredTeleopArticulatedJointPosition& Position = Result.AddDefaulted_GetRef();
+        Position.JointName = Joint.Name.ToString();
+        Position.PositionRadians = *Value;
+    }
+    return Result;
+}
+
+bool FindToolTransform(
+    const TArray<FDttNamedCanonicalTransform>& ToolTransforms,
+    FName ToolFrameName,
+    FDttCanonicalTransform& OutToolTransform,
+    FString& OutError)
+{
+    for (const FDttNamedCanonicalTransform& NamedTransform : ToolTransforms)
+    {
+        if (NamedTransform.Name == ToolFrameName)
+        {
+            if (!NamedTransform.Transform.IsRigid())
+            {
+                return Fail(OutError, TEXT("FK returned a non-rigid tool transform"));
+            }
+            OutToolTransform = NamedTransform.Transform;
+            return true;
+        }
+    }
+    return Fail(
+        OutError,
+        FString::Printf(
+            TEXT("FK did not return the requested tool frame: %s"),
+            *ToolFrameName.ToString()));
+}
+
+bool EvaluateToolTransform(
+    const FDttRobotDescription& Description,
+    const FDttCanonicalTransform& WorldTransformOfRoot,
+    FName ToolFrameName,
+    const TArray<FDttNamedJointPosition>& JointPositions,
+    FDttCanonicalTransform& OutToolTransform,
+    FString& OutError)
+{
+    FDttForwardKinematicsResult FKResult;
+    if (!DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            WorldTransformOfRoot,
+            JointPositions,
+            FKResult))
+    {
+        const FString FKError = FKResult.ErrorMessage.IsEmpty()
+            ? FString(TEXT("FK rejected a preview joint state"))
+            : FKResult.ErrorMessage;
+        return Fail(OutError, FKError);
+    }
+    if (!FKResult.bSuccess)
+    {
+        return Fail(OutError, TEXT("FK returned an unsuccessful preview joint state"));
+    }
+    if (!FKResult.bWithinJointLimits)
+    {
+        return Fail(OutError, TEXT("FK reported a preview joint state outside limits"));
+    }
+    return FindToolTransform(FKResult.ToolTransforms, ToolFrameName, OutToolTransform, OutError);
+}
+
+bool CompareRigidTransforms(
+    const FDttCanonicalTransform& Expected,
+    const FDttCanonicalTransform& Actual,
+    double& OutPositionErrorMetres,
+    double& OutRotationErrorRadians,
+    FString& OutError)
+{
+    const FVector3d TranslationDelta =
+        Expected.GetTranslationMetres() - Actual.GetTranslationMetres();
+    const double PositionErrorSquared =
+        TranslationDelta.X * TranslationDelta.X
+        + TranslationDelta.Y * TranslationDelta.Y
+        + TranslationDelta.Z * TranslationDelta.Z;
+    if (!FMath::IsFinite(PositionErrorSquared) || PositionErrorSquared < 0.0)
+    {
+        return Fail(OutError, TEXT("tool transform position comparison is non-finite"));
+    }
+    OutPositionErrorMetres = FMath::Sqrt(PositionErrorSquared);
+
+    const FQuat4d ExpectedRotation = Expected.GetRotationQuaternion();
+    const FQuat4d ActualRotation = Actual.GetRotationQuaternion();
+    const double ExpectedNormSquared =
+        ExpectedRotation.X * ExpectedRotation.X
+        + ExpectedRotation.Y * ExpectedRotation.Y
+        + ExpectedRotation.Z * ExpectedRotation.Z
+        + ExpectedRotation.W * ExpectedRotation.W;
+    const double ActualNormSquared =
+        ActualRotation.X * ActualRotation.X
+        + ActualRotation.Y * ActualRotation.Y
+        + ActualRotation.Z * ActualRotation.Z
+        + ActualRotation.W * ActualRotation.W;
+    const double NormProduct = FMath::Sqrt(ExpectedNormSquared * ActualNormSquared);
+    if (!FMath::IsFinite(ExpectedNormSquared)
+        || !FMath::IsFinite(ActualNormSquared)
+        || !FMath::IsFinite(NormProduct)
+        || NormProduct <= UE_DOUBLE_SMALL_NUMBER)
+    {
+        return Fail(OutError, TEXT("tool transform rotation comparison is non-finite"));
+    }
+
+    const double ExpectedInverseScale = 1.0 / FMath::Sqrt(ExpectedNormSquared);
+    const double ActualScale = 1.0 / FMath::Sqrt(ActualNormSquared);
+    const FQuat4d ExpectedUnit(
+        -ExpectedRotation.X * ExpectedInverseScale,
+        -ExpectedRotation.Y * ExpectedInverseScale,
+        -ExpectedRotation.Z * ExpectedInverseScale,
+        ExpectedRotation.W * ExpectedInverseScale);
+    const FQuat4d ActualUnit(
+        ActualRotation.X * ActualScale,
+        ActualRotation.Y * ActualScale,
+        ActualRotation.Z * ActualScale,
+        ActualRotation.W * ActualScale);
+    // Use the relative quaternion's vector norm so very small rotations are
+    // measured without losing the 1e-9-radian tolerance in acos(1 - eps).
+    const FQuat4d Relative(
+        ExpectedUnit.W * ActualUnit.X
+            + ExpectedUnit.X * ActualUnit.W
+            + ExpectedUnit.Y * ActualUnit.Z
+            - ExpectedUnit.Z * ActualUnit.Y,
+        ExpectedUnit.W * ActualUnit.Y
+            - ExpectedUnit.X * ActualUnit.Z
+            + ExpectedUnit.Y * ActualUnit.W
+            + ExpectedUnit.Z * ActualUnit.X,
+        ExpectedUnit.W * ActualUnit.Z
+            + ExpectedUnit.X * ActualUnit.Y
+            - ExpectedUnit.Y * ActualUnit.X
+            + ExpectedUnit.Z * ActualUnit.W,
+        ExpectedUnit.W * ActualUnit.W
+            - ExpectedUnit.X * ActualUnit.X
+            - ExpectedUnit.Y * ActualUnit.Y
+            - ExpectedUnit.Z * ActualUnit.Z);
+    const double RelativeVectorNormSquared =
+        Relative.X * Relative.X
+        + Relative.Y * Relative.Y
+        + Relative.Z * Relative.Z;
+    if (!FMath::IsFinite(Relative.W)
+        || !FMath::IsFinite(RelativeVectorNormSquared)
+        || RelativeVectorNormSquared < 0.0)
+    {
+        return Fail(OutError, TEXT("tool transform rotation comparison is non-finite"));
+    }
+    OutRotationErrorRadians = 2.0 * FMath::Atan2(
+        FMath::Sqrt(RelativeVectorNormSquared),
+        FMath::Abs(Relative.W));
+    if (!FMath::IsFinite(OutPositionErrorMetres)
+        || !FMath::IsFinite(OutRotationErrorRadians))
+    {
+        return Fail(OutError, TEXT("tool transform comparison is non-finite"));
+    }
+    return true;
+}
+
+} // namespace DeferredTeleop::KinematicPreview::Private
+
+namespace DeferredTeleop::Kinematics
+{
+namespace PreviewPrivate = ::DeferredTeleop::KinematicPreview::Private;
+
+bool BuildPreview(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    FDttKinematicPreview& OutPreview,
+    FString& OutError)
+{
+    OutPreview = FDttKinematicPreview();
+    OutError.Reset();
+
+    FDttValidatedRobotModel Model;
+    if (!ValidateRobotDescription(Description, Model, OutError))
+    {
+        return false;
+    }
+    if (!PreviewPrivate::ValidateIdsAndModelReference(Description, Request, OutError)
+        || !PreviewPrivate::ValidateSourceReference(Request.SourceReference, OutError))
+    {
+        return false;
+    }
+    if (!Request.WorldTransformOfRoot.IsRigid())
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            TEXT("world_transform_of_root must be a finite rigid canonical transform"));
+    }
+
+    TMap<FName, double> Velocities;
+    if (!PreviewPrivate::ValidateSettings(Description, Model, Request.Settings, Velocities, OutError))
+    {
+        return false;
+    }
+
+    TMap<FName, double> StartValues;
+    if (!PreviewPrivate::ValidateStartJointPositions(
+            Description,
+            Model,
+            Request.StartJointPositions,
+            StartValues,
+            OutError))
+    {
+        return false;
+    }
+
+    TMap<FName, double> IKValues;
+    if (!PreviewPrivate::ValidateIKJointPositions(
+            Description,
+            Model,
+            Request.IKResult.JointPositions,
+            IKValues,
+            OutError))
+    {
+        return false;
+    }
+
+    bool bAcceptedPartial = false;
+    if (!PreviewPrivate::ValidateIKStatus(
+            Request.IKResult,
+            Request.Settings.bAcceptPartial,
+            bAcceptedPartial,
+            OutError))
+    {
+        return false;
+    }
+
+    TSet<FName> ActiveNames;
+    if (!PreviewPrivate::ValidateActiveJointNames(
+            Description,
+            Model,
+            Request.IKResult.ActiveJointNames,
+            ActiveNames,
+            OutError))
+    {
+        return false;
+    }
+    if (Request.IKResult.ToolFrameName.IsNone()
+        || Model.FindToolIndex(Request.IKResult.ToolFrameName) == INDEX_NONE)
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            TEXT("IK result tool frame is required and must be known to the description"));
+    }
+    if (!FMath::IsFinite(Request.IKResult.PositionResidualMetres)
+        || Request.IKResult.PositionResidualMetres < 0.0
+        || !FMath::IsFinite(Request.IKResult.ApproachResidualRadians)
+        || Request.IKResult.ApproachResidualRadians < 0.0)
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            TEXT("IK residuals must be finite and non-negative"));
+    }
+    if (!Request.IKResult.AchievedToolTransform.IsRigid())
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            TEXT("IK achieved tool transform must be a finite rigid transform"));
+    }
+
+    TMap<FName, double> GoalValues;
+    GoalValues.Reserve(Description.Joints.Num());
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        const double* StartValue = StartValues.Find(Joint.Name);
+        const double* IKValue = IKValues.Find(Joint.Name);
+        if (StartValue == nullptr || IKValue == nullptr)
+        {
+            return PreviewPrivate::Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview state is missing revolute joint: %s"),
+                    *Joint.Name.ToString()));
+        }
+        if (!ActiveNames.Contains(Joint.Name) && *IKValue != *StartValue)
+        {
+            return PreviewPrivate::Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("inactive IK goal must equal start exactly: %s"),
+                    *Joint.Name.ToString()));
+        }
+        const double GoalValue = ActiveNames.Contains(Joint.Name) ? *IKValue : *StartValue;
+        if (!PreviewPrivate::ValidateJointLimit(
+                Joint,
+                GoalValue,
+                TEXT("goal state"),
+                OutError))
+        {
+            return false;
+        }
+        GoalValues.Add(Joint.Name, GoalValue);
+    }
+
+    const TArray<FDttNamedJointPosition> GoalNamedState =
+        PreviewPrivate::MakeNamedJointState(Description, GoalValues);
+    FDttCanonicalTransform RecomputedToolTransform;
+    if (!PreviewPrivate::EvaluateToolTransform(
+            Description,
+            Request.WorldTransformOfRoot,
+            Request.IKResult.ToolFrameName,
+            GoalNamedState,
+            RecomputedToolTransform,
+            OutError))
+    {
+        return false;
+    }
+
+    double GoalPositionErrorMetres = 0.0;
+    double GoalRotationErrorRadians = 0.0;
+    if (!PreviewPrivate::CompareRigidTransforms(
+            Request.IKResult.AchievedToolTransform,
+            RecomputedToolTransform,
+            GoalPositionErrorMetres,
+            GoalRotationErrorRadians,
+            OutError))
+    {
+        return false;
+    }
+    if (GoalPositionErrorMetres > PreviewPrivate::ToolPositionToleranceMetres
+        || GoalRotationErrorRadians > PreviewPrivate::ToolRotationToleranceRadians)
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            FString::Printf(
+                TEXT("IK achieved tool transform does not match FK goal within tolerance (position=%0.17g m, rotation=%0.17g rad)"),
+                GoalPositionErrorMetres,
+                GoalRotationErrorRadians));
+    }
+
+    double DurationSeconds = 0.0;
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        const double* StartValue = StartValues.Find(Joint.Name);
+        const double* GoalValue = GoalValues.Find(Joint.Name);
+        const double* Velocity = Velocities.Find(Joint.Name);
+        if (StartValue == nullptr || GoalValue == nullptr || Velocity == nullptr)
+        {
+            return PreviewPrivate::Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview timing is missing revolute joint data: %s"),
+                    *Joint.Name.ToString()));
+        }
+        const double DeltaRadians = FMath::Abs(*GoalValue - *StartValue);
+        const double JointDuration = DeltaRadians / *Velocity;
+        if (!FMath::IsFinite(DeltaRadians) || !FMath::IsFinite(JointDuration))
+        {
+            return PreviewPrivate::Fail(
+                OutError,
+                FString::Printf(
+                    TEXT("preview timing is non-finite for joint: %s"),
+                    *Joint.Name.ToString()));
+        }
+        DurationSeconds = FMath::Max(DurationSeconds, JointDuration);
+    }
+    if (!FMath::IsFinite(DurationSeconds) || DurationSeconds < 0.0)
+    {
+        return PreviewPrivate::Fail(OutError, TEXT("preview duration must be finite and non-negative"));
+    }
+    if (DurationSeconds > Request.Settings.MaximumDurationSeconds)
+    {
+        return PreviewPrivate::Fail(
+            OutError,
+            TEXT("preview duration exceeds maximum_duration_seconds"));
+    }
+
+    int32 SampleCount = 1;
+    if (DurationSeconds > 0.0)
+    {
+        const double RateProduct = DurationSeconds * Request.Settings.SampleRateHz;
+        if (!FMath::IsFinite(RateProduct))
+        {
+            return PreviewPrivate::Fail(OutError, TEXT("preview sample count calculation is non-finite"));
+        }
+        // The validated 30-second and 1000-Hz bounds make this conversion safe.
+        const int64 RequiredSamples64 = FMath::Max(
+            static_cast<int64>(PreviewPrivate::MinimumPreviewSamples),
+            FMath::CeilToInt(RateProduct) + 1);
+        if (RequiredSamples64 > static_cast<int64>(MAX_int32))
+        {
+            return PreviewPrivate::Fail(OutError, TEXT("preview sample count exceeds integer range"));
+        }
+        const int32 RequiredSamples = static_cast<int32>(RequiredSamples64);
+        SampleCount = FMath::Min(Request.Settings.MaximumSamples, RequiredSamples);
+        if (SampleCount < PreviewPrivate::MinimumPreviewSamples
+            || SampleCount > PreviewPrivate::MaximumPreviewSamples)
+        {
+            return PreviewPrivate::Fail(OutError, TEXT("preview sample count is outside the bounded range"));
+        }
+    }
+
+    FDttKinematicPreview Candidate;
+    Candidate.PreviewId = Request.PreviewId;
+    Candidate.GoalId = Request.GoalId;
+    Candidate.ModelReference = Request.ModelReference;
+    Candidate.SourceReference = Request.SourceReference;
+    Candidate.WorldTransformOfRoot = Request.WorldTransformOfRoot;
+    Candidate.StartJointPositions =
+        PreviewPrivate::MakeArticulatedJointState(Description, StartValues);
+    Candidate.GoalJointPositions =
+        PreviewPrivate::MakeArticulatedJointState(Description, GoalValues);
+    Candidate.ToolFrameName = Request.IKResult.ToolFrameName;
+    Candidate.IKStatus = Request.IKResult.Status;
+    Candidate.bAcceptedPartial = bAcceptedPartial;
+    Candidate.PositionResidualMetres = Request.IKResult.PositionResidualMetres;
+    Candidate.ApproachResidualRadians = Request.IKResult.ApproachResidualRadians;
+    Candidate.DurationSeconds = DurationSeconds;
+    Candidate.Diagnostic = Request.IKResult.Diagnostic;
+    Candidate.Diagnostics = Request.IKResult.Diagnostics;
+    Candidate.Samples.Reserve(SampleCount);
+
+    const int32 LastSampleIndex = SampleCount - 1;
+    for (int32 SampleIndex = 0; SampleIndex < SampleCount; ++SampleIndex)
+    {
+        FDttKinematicPreviewSample Sample;
+        if (SampleIndex == 0)
+        {
+            Sample.TimeSeconds = 0.0;
+        }
+        else if (SampleIndex == LastSampleIndex)
+        {
+            Sample.TimeSeconds = DurationSeconds;
+        }
+        else
+        {
+            Sample.TimeSeconds =
+                DurationSeconds * static_cast<double>(SampleIndex)
+                / static_cast<double>(LastSampleIndex);
+        }
+        if (!FMath::IsFinite(Sample.TimeSeconds)
+            || Sample.TimeSeconds < 0.0
+            || Sample.TimeSeconds > DurationSeconds)
+        {
+            return PreviewPrivate::Fail(OutError, TEXT("preview sample time is invalid"));
+        }
+
+        TArray<FDttNamedJointPosition> FKJointState;
+        FKJointState.Reserve(Description.Joints.Num());
+        Sample.JointPositions.Reserve(Description.Joints.Num());
+        for (const FDttRobotJointDescription& Joint : Description.Joints)
+        {
+            if (Joint.Type != EDttRobotJointType::Revolute)
+            {
+                continue;
+            }
+            const double* StartValue = StartValues.Find(Joint.Name);
+            const double* GoalValue = GoalValues.Find(Joint.Name);
+            if (StartValue == nullptr || GoalValue == nullptr)
+            {
+                return PreviewPrivate::Fail(
+                    OutError,
+                    FString::Printf(
+                        TEXT("preview sample is missing revolute joint data: %s"),
+                        *Joint.Name.ToString()));
+            }
+
+            double PositionRadians = 0.0;
+            if (SampleIndex == 0)
+            {
+                PositionRadians = *StartValue;
+            }
+            else if (SampleIndex == LastSampleIndex)
+            {
+                PositionRadians = *GoalValue;
+            }
+            else
+            {
+                PositionRadians = *StartValue
+                    + (*GoalValue - *StartValue) * Sample.TimeSeconds / DurationSeconds;
+            }
+            if (!PreviewPrivate::ValidateJointLimit(
+                    Joint,
+                    PositionRadians,
+                    TEXT("preview sample"),
+                    OutError))
+            {
+                return false;
+            }
+
+            FDttNamedJointPosition& FKPosition = FKJointState.AddDefaulted_GetRef();
+            FKPosition.JointName = Joint.Name;
+            FKPosition.PositionRadians = PositionRadians;
+            FDeferredTeleopArticulatedJointPosition& OutputPosition =
+                Sample.JointPositions.AddDefaulted_GetRef();
+            OutputPosition.JointName = Joint.Name.ToString();
+            OutputPosition.PositionRadians = PositionRadians;
+        }
+
+        if (!PreviewPrivate::EvaluateToolTransform(
+                Description,
+                Request.WorldTransformOfRoot,
+                Request.IKResult.ToolFrameName,
+                FKJointState,
+                Sample.ToolTransform,
+                OutError))
+        {
+            return false;
+        }
+        Candidate.Samples.Add(MoveTemp(Sample));
+    }
+
+    Candidate.bValid = true;
+    OutPreview = MoveTemp(Candidate);
+    return true;
+}
+} // namespace DeferredTeleop::Kinematics
+
+bool UDeferredTeleopKinematicPreviewLibrary::BuildPreview(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    FDttKinematicPreview& OutPreview,
+    FString& OutError)
+{
+    return DeferredTeleop::Kinematics::BuildPreview(
+        Description,
+        Request,
+        OutPreview,
+        OutError);
+}

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicPreviewTests.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicPreviewTests.cpp
@@ -1,0 +1,858 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Kinematics/DeferredTeleopKinematicPreviewLibrary.h"
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "Misc/AutomationTest.h"
+
+#include <limits>
+
+namespace DeferredTeleop::Tests::KinematicPreview
+{
+constexpr double Pi = 3.1415926535897932384626433832795;
+
+FDttCanonicalTransform Translation(double X, double Y, double Z)
+{
+    return FDttCanonicalTransform::FromTranslationRotation(
+        FVector3d(X, Y, Z),
+        FQuat4d(0.0, 0.0, 0.0, 1.0));
+}
+
+FDttCanonicalTransform RootTransform()
+{
+    return FDttCanonicalTransform::FromAxisAngle(
+        FVector3d(0.4, -0.2, 0.7),
+        FVector3d(0.0, 0.0, 1.0),
+        0.17);
+}
+
+FDttCanonicalVector AxisZ()
+{
+    FDttCanonicalVector Result;
+    Result.Z = 1.0;
+    return Result;
+}
+
+FDttRobotLinkDescription Link(const TCHAR* Name)
+{
+    FDttRobotLinkDescription Result;
+    Result.Name = FName(Name);
+    return Result;
+}
+
+FDttRobotJointDescription FixedJoint(
+    const TCHAR* Name,
+    const TCHAR* Parent,
+    const TCHAR* Child)
+{
+    FDttRobotJointDescription Result;
+    Result.Name = FName(Name);
+    Result.Type = EDttRobotJointType::Fixed;
+    Result.ParentLink = FName(Parent);
+    Result.ChildLink = FName(Child);
+    Result.ParentToJoint = Translation(0.0, 0.0, 0.0);
+    return Result;
+}
+
+FDttRobotJointDescription RevoluteJoint(
+    const TCHAR* Name,
+    const TCHAR* Parent,
+    const TCHAR* Child,
+    double Lower,
+    double Upper)
+{
+    FDttRobotJointDescription Result;
+    Result.Name = FName(Name);
+    Result.Type = EDttRobotJointType::Revolute;
+    Result.ParentLink = FName(Parent);
+    Result.ChildLink = FName(Child);
+    Result.ParentToJoint = Translation(1.0, 0.0, 0.0);
+    Result.AxisJointFrame = AxisZ();
+    Result.bHasPositionLimits = true;
+    Result.LowerPositionRadians = Lower;
+    Result.UpperPositionRadians = Upper;
+    return Result;
+}
+
+FDttRobotDescription MakeDescription()
+{
+    FDttRobotDescription Description;
+    Description.ModelId = TEXT("preview-test-model");
+    Description.ModelRevision = TEXT("preview:test:1");
+    Description.RootLinkName = FName(TEXT("root"));
+    Description.Links = {
+        Link(TEXT("root")),
+        Link(TEXT("mount")),
+        Link(TEXT("link_a")),
+        Link(TEXT("link_b")),
+        Link(TEXT("tool_link")),
+    };
+    Description.Joints = {
+        FixedJoint(TEXT("root_to_mount"), TEXT("root"), TEXT("mount")),
+        RevoluteJoint(TEXT("joint_a"), TEXT("mount"), TEXT("link_a"), -Pi, Pi),
+        RevoluteJoint(TEXT("joint_b"), TEXT("link_a"), TEXT("link_b"), -Pi, Pi),
+        RevoluteJoint(TEXT("gripper"), TEXT("link_b"), TEXT("tool_link"), 0.0, 1.0),
+    };
+
+    FDttRobotJointGroupDescription Group;
+    Group.Name = FName(TEXT("arm"));
+    Group.JointNames = {FName(TEXT("joint_a")), FName(TEXT("joint_b"))};
+    Description.JointGroups = {Group};
+
+    FDttRobotToolFrameDescription Tool;
+    Tool.Name = FName(TEXT("tool"));
+    Tool.LinkName = FName(TEXT("tool_link"));
+    Tool.LinkToTool = Translation(0.25, 0.0, 0.0);
+    Description.ToolFrames = {Tool};
+    return Description;
+}
+
+FDeferredTeleopArticulatedJointPosition ArticulatedJoint(
+    const TCHAR* Name,
+    double PositionRadians)
+{
+    FDeferredTeleopArticulatedJointPosition Result;
+    Result.JointName = Name;
+    Result.PositionRadians = PositionRadians;
+    return Result;
+}
+
+FDttNamedJointPosition NamedJoint(const TCHAR* Name, double PositionRadians)
+{
+    FDttNamedJointPosition Result;
+    Result.JointName = FName(Name);
+    Result.PositionRadians = PositionRadians;
+    return Result;
+}
+
+FDttPreviewJointVelocity PreviewVelocity(const TCHAR* Name, double MaximumRadiansPerSecond)
+{
+    FDttPreviewJointVelocity Result;
+    Result.JointName = FName(Name);
+    Result.MaximumRadiansPerSecond = MaximumRadiansPerSecond;
+    return Result;
+}
+
+void SetIKJointPositions(
+    FDttIKResult& IKResult,
+    double JointA,
+    double JointB,
+    double Gripper)
+{
+    IKResult.JointPositions = {
+        NamedJoint(TEXT("joint_a"), JointA),
+        NamedJoint(TEXT("joint_b"), JointB),
+        NamedJoint(TEXT("gripper"), Gripper),
+    };
+}
+
+FDttKinematicPreviewRequest MakeRequest()
+{
+    FDttKinematicPreviewRequest Request;
+    Request.PreviewId = FGuid(0x11111111, 0x22222222, 0x33333333, 0x44444444);
+    Request.GoalId = FGuid(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd);
+    Request.ModelReference.ModelId = TEXT("preview-test-model");
+    Request.ModelReference.ModelRevision = TEXT("preview:test:1");
+    Request.ModelReference.DescriptionHash =
+        TEXT("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    Request.WorldTransformOfRoot = RootTransform();
+    Request.StartJointPositions = {
+        ArticulatedJoint(TEXT("joint_a"), 0.0),
+        ArticulatedJoint(TEXT("joint_b"), 0.2),
+        ArticulatedJoint(TEXT("gripper"), 0.3),
+    };
+
+    Request.IKResult.bSuccess = true;
+    Request.IKResult.Status = EDttIKStatus::Converged;
+    Request.IKResult.ModelId = TEXT("preview-test-model");
+    Request.IKResult.ModelRevision = TEXT("preview:test:1");
+    Request.IKResult.ToolFrameName = FName(TEXT("tool"));
+    Request.IKResult.ActiveJointNames = {
+        FName(TEXT("joint_a")),
+        FName(TEXT("joint_b")),
+    };
+    Request.IKResult.PositionResidualMetres = 1.0e-10;
+    Request.IKResult.ApproachResidualRadians = 2.0e-10;
+    Request.IKResult.Diagnostic = TEXT("fixture IK");
+    Request.IKResult.Diagnostics = {TEXT("fixture diagnostic")};
+    SetIKJointPositions(Request.IKResult, 1.0, 0.6, 0.3);
+
+    Request.SourceReference.SourceMessageId = TEXT("source-message-1");
+    Request.SourceReference.CorrelationId = TEXT("correlation-1");
+    Request.SourceReference.SourceKind = EDttPreviewSourceKind::Measured;
+    Request.SourceReference.FrameId = TEXT("field-world");
+    Request.SourceReference.CalibrationVersion = TEXT("calibration-1");
+    Request.SourceReference.Evidence.SourceIds = {TEXT("camera-1")};
+    Request.SourceReference.Evidence.ObservedAt = FDateTime(2026, 9, 4, 12, 0, 0);
+    Request.SourceReference.Evidence.ProducedAt = FDateTime(2026, 9, 4, 12, 0, 1);
+    Request.SourceReference.Evidence.Provenance = EDeferredTeleopProvenance::Measured;
+    Request.SourceReference.Evidence.WorldRevision = 7;
+
+    Request.Settings.JointVelocities = {
+        PreviewVelocity(TEXT("joint_a"), 1.0),
+        PreviewVelocity(TEXT("joint_b"), 1.0),
+        PreviewVelocity(TEXT("gripper"), 1.0),
+    };
+    Request.Settings.SampleRateHz = 10.0;
+    Request.Settings.MaximumDurationSeconds = 30.0;
+    Request.Settings.MaximumSamples = 128;
+    Request.Settings.bAcceptPartial = false;
+    return Request;
+}
+
+bool FindToolTransform(
+    const TArray<FDttNamedCanonicalTransform>& ToolTransforms,
+    FName ToolName,
+    FDttCanonicalTransform& OutTransform)
+{
+    for (const FDttNamedCanonicalTransform& NamedTransform : ToolTransforms)
+    {
+        if (NamedTransform.Name == ToolName)
+        {
+            OutTransform = NamedTransform.Transform;
+            return true;
+        }
+    }
+    return false;
+}
+
+TArray<FDttNamedJointPosition> PreviewGoalState(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request)
+{
+    TMap<FName, double> IKValues;
+    for (const FDttNamedJointPosition& Position : Request.IKResult.JointPositions)
+    {
+        IKValues.Add(Position.JointName, Position.PositionRadians);
+    }
+    TMap<FName, double> StartValues;
+    for (const FDeferredTeleopArticulatedJointPosition& Position : Request.StartJointPositions)
+    {
+        StartValues.Add(FName(*Position.JointName), Position.PositionRadians);
+    }
+    TSet<FName> ActiveNames;
+    for (const FName ActiveName : Request.IKResult.ActiveJointNames)
+    {
+        ActiveNames.Add(ActiveName);
+    }
+
+    TArray<FDttNamedJointPosition> Result;
+    for (const FDttRobotJointDescription& Joint : Description.Joints)
+    {
+        if (Joint.Type != EDttRobotJointType::Revolute)
+        {
+            continue;
+        }
+        const double* IKValue = IKValues.Find(Joint.Name);
+        const double* StartValue = StartValues.Find(Joint.Name);
+        if (IKValue == nullptr || StartValue == nullptr)
+        {
+            continue;
+        }
+        Result.Add(NamedJoint(
+            *Joint.Name.ToString(),
+            ActiveNames.Contains(Joint.Name) ? *IKValue : *StartValue));
+    }
+    return Result;
+}
+
+bool RefreshAchievedTransform(
+    const FDttRobotDescription& Description,
+    FDttKinematicPreviewRequest& Request)
+{
+    FDttForwardKinematicsResult FKResult;
+    if (!DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+            Description,
+            Request.WorldTransformOfRoot,
+            PreviewGoalState(Description, Request),
+            FKResult))
+    {
+        return false;
+    }
+    return FindToolTransform(
+        FKResult.ToolTransforms,
+        Request.IKResult.ToolFrameName,
+        Request.IKResult.AchievedToolTransform);
+}
+
+bool Build(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    FDttKinematicPreview& OutPreview,
+    FString& OutError)
+{
+    return DeferredTeleop::Kinematics::BuildPreview(
+        Description,
+        Request,
+        OutPreview,
+        OutError);
+}
+
+bool NearlyEqualTransform(
+    const FDttCanonicalTransform& Left,
+    const FDttCanonicalTransform& Right,
+    double Tolerance = 1.0e-12)
+{
+    const FVector3d LeftTranslation = Left.GetTranslationMetres();
+    const FVector3d RightTranslation = Right.GetTranslationMetres();
+    const FQuat4d LeftRotation = Left.GetRotationQuaternion();
+    const FQuat4d RightRotation = Right.GetRotationQuaternion();
+    return FMath::Abs(LeftTranslation.X - RightTranslation.X) <= Tolerance
+        && FMath::Abs(LeftTranslation.Y - RightTranslation.Y) <= Tolerance
+        && FMath::Abs(LeftTranslation.Z - RightTranslation.Z) <= Tolerance
+        && FMath::Abs(LeftRotation.X - RightRotation.X) <= Tolerance
+        && FMath::Abs(LeftRotation.Y - RightRotation.Y) <= Tolerance
+        && FMath::Abs(LeftRotation.Z - RightRotation.Z) <= Tolerance
+        && FMath::Abs(LeftRotation.W - RightRotation.W) <= Tolerance;
+}
+
+void ExpectRejected(
+    FAutomationTestBase& Test,
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    const TCHAR* Label)
+{
+    FDttKinematicPreview Preview;
+    Preview.bValid = true;
+    FString Error;
+    Test.TestFalse(Label, Build(Description, Request, Preview, Error));
+    Test.TestFalse(TEXT("rejected preview is reset to invalid"), Preview.bValid);
+    Test.TestTrue(TEXT("rejected preview has no samples"), Preview.Samples.Num() == 0);
+    Test.TestTrue(
+        TEXT("rejected preview has no snapshot identifiers"),
+        !Preview.PreviewId.IsValid() && !Preview.GoalId.IsValid());
+    Test.TestTrue(TEXT("rejection provides a diagnostic"), !Error.IsEmpty());
+}
+
+} // namespace DeferredTeleop::Tests::KinematicPreview
+
+namespace DeferredTeleop::Tests::KinematicPreview
+{
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewConvergedTest,
+    "DeferredTeleop.M2.KinematicPreview.ConvergedSnapshotAndFK",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewConvergedTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest Request = MakeRequest();
+    TestTrue(TEXT("fixture achieved transform is FK-derived"), RefreshAchievedTransform(Description, Request));
+
+    FDttKinematicPreview Preview;
+    FString Error;
+    TestTrue(TEXT("converged IK builds a preview"), Build(Description, Request, Preview, Error));
+    if (!Preview.bValid)
+    {
+        AddError(Error);
+        return false;
+    }
+
+    TestEqual(TEXT("preview id is copied"), Preview.PreviewId, Request.PreviewId);
+    TestEqual(TEXT("goal id is copied"), Preview.GoalId, Request.GoalId);
+    TestTrue(TEXT("preview and goal IDs are distinct fixture identities"), Preview.PreviewId != Preview.GoalId);
+    TestEqual(TEXT("model id is copied"), Preview.ModelReference.ModelId, Request.ModelReference.ModelId);
+    TestEqual(
+        TEXT("model revision is copied"),
+        Preview.ModelReference.ModelRevision,
+        Request.ModelReference.ModelRevision);
+    TestEqual(
+        TEXT("source message is copied"),
+        Preview.SourceReference.SourceMessageId,
+        Request.SourceReference.SourceMessageId);
+    TestEqual(
+        TEXT("source evidence is copied by value"),
+        Preview.SourceReference.Evidence.SourceIds[0],
+        Request.SourceReference.Evidence.SourceIds[0]);
+    TestTrue(
+        TEXT("root transform is copied"),
+        NearlyEqualTransform(Preview.WorldTransformOfRoot, Request.WorldTransformOfRoot));
+    TestEqual(TEXT("IK status is exposed"), Preview.IKStatus, EDttIKStatus::Converged);
+    TestFalse(TEXT("converged result is not marked partial"), Preview.bAcceptedPartial);
+    TestEqual(TEXT("tool frame is copied"), Preview.ToolFrameName, FName(TEXT("tool")));
+    TestEqual(TEXT("start state is description ordered"), Preview.StartJointPositions.Num(), 3);
+    TestEqual(TEXT("goal state is description ordered"), Preview.GoalJointPositions.Num(), 3);
+    TestTrue(TEXT("preview has multiple samples"), Preview.Samples.Num() >= 2);
+
+    if (Preview.Samples.Num() >= 2)
+    {
+        const FDttKinematicPreviewSample& First = Preview.Samples[0];
+        const FDttKinematicPreviewSample& Last = Preview.Samples.Last();
+        TestTrue(TEXT("first sample time is exactly zero"), First.TimeSeconds == 0.0);
+        TestTrue(
+            TEXT("last sample time is exactly the preview duration"),
+            Last.TimeSeconds == Preview.DurationSeconds);
+        for (int32 JointIndex = 0; JointIndex < 3; ++JointIndex)
+        {
+            TestTrue(
+                *FString::Printf(TEXT("first sample preserves start joint %d exactly"), JointIndex),
+                First.JointPositions[JointIndex].PositionRadians
+                    == Preview.StartJointPositions[JointIndex].PositionRadians);
+            TestTrue(
+                *FString::Printf(TEXT("last sample preserves goal joint %d exactly"), JointIndex),
+                Last.JointPositions[JointIndex].PositionRadians
+                    == Preview.GoalJointPositions[JointIndex].PositionRadians);
+        }
+    }
+
+    for (const FDttKinematicPreviewSample& Sample : Preview.Samples)
+    {
+        TArray<FDttNamedJointPosition> JointState;
+        for (const FDeferredTeleopArticulatedJointPosition& Position : Sample.JointPositions)
+        {
+            JointState.Add(NamedJoint(*Position.JointName, Position.PositionRadians));
+        }
+        FDttForwardKinematicsResult FKResult;
+        TestTrue(
+            TEXT("each sample has an independently FK-evaluable joint state"),
+            DeferredTeleop::Kinematics::EvaluateForwardKinematics(
+                Description,
+                Request.WorldTransformOfRoot,
+                JointState,
+                FKResult));
+        FDttCanonicalTransform ExpectedTool;
+        TestTrue(TEXT("each sample contains the requested tool"), FindToolTransform(FKResult.ToolTransforms, FName(TEXT("tool")), ExpectedTool));
+        TestTrue(TEXT("sample tool pose is the FK pose"), NearlyEqualTransform(Sample.ToolTransform, ExpectedTool));
+        TestTrue(TEXT("every sample tool pose remains rigid"), Sample.ToolTransform.IsRigid());
+    }
+
+    Request.SourceReference.SourceMessageId = TEXT("mutated-after-build");
+    Request.StartJointPositions[0].PositionRadians = 1.5;
+    TestEqual(
+        TEXT("source snapshot is independent of request mutation"),
+        Preview.SourceReference.SourceMessageId,
+        FString(TEXT("source-message-1")));
+    TestTrue(
+        TEXT("joint snapshot is independent of request mutation"),
+        Preview.StartJointPositions[0].PositionRadians == 0.0);
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewDurationTest,
+    "DeferredTeleop.M2.KinematicPreview.DurationUsesMaxJointTime",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewDurationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest Request = MakeRequest();
+    SetIKJointPositions(Request.IKResult, 1.0, 1.2, 0.3);
+    Request.Settings.JointVelocities[0].MaximumRadiansPerSecond = 2.0;
+    Request.Settings.JointVelocities[1].MaximumRadiansPerSecond = 0.5;
+    Request.Settings.SampleRateHz = 2.0;
+    TestTrue(TEXT("fixture achieved transform is refreshed"), RefreshAchievedTransform(Description, Request));
+
+    FDttKinematicPreview Preview;
+    FString Error;
+    TestTrue(TEXT("multi-joint preview builds"), Build(Description, Request, Preview, Error));
+    TestTrue(TEXT("duration is the maximum joint travel time"), FMath::IsNearlyEqual(Preview.DurationSeconds, 2.0, 1.0e-12));
+    TestEqual(TEXT("ceil duration*rate plus endpoint determines samples"), Preview.Samples.Num(), 5);
+    if (Preview.Samples.Num() == 5)
+    {
+        const FDttKinematicPreviewSample& Middle = Preview.Samples[2];
+        TestTrue(TEXT("sample time uses seconds"), FMath::IsNearlyEqual(Middle.TimeSeconds, 1.0, 1.0e-12));
+        TestTrue(
+            TEXT("joint_a is linearly interpolated in radians"),
+            FMath::IsNearlyEqual(Middle.JointPositions[0].PositionRadians, 0.5, 1.0e-12));
+        TestTrue(
+            TEXT("joint_b is linearly interpolated in radians"),
+            FMath::IsNearlyEqual(Middle.JointPositions[1].PositionRadians, 0.7, 1.0e-12));
+        TestTrue(
+            TEXT("inactive gripper remains at its start value"),
+            Middle.JointPositions[2].PositionRadians == 0.3);
+    }
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewZeroDurationTest,
+    "DeferredTeleop.M2.KinematicPreview.ZeroDuration",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewZeroDurationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest Request = MakeRequest();
+    SetIKJointPositions(Request.IKResult, 0.0, 0.2, 0.3);
+    TestTrue(TEXT("zero-duration achieved transform is refreshed"), RefreshAchievedTransform(Description, Request));
+
+    FDttKinematicPreview Preview;
+    FString Error;
+    TestTrue(TEXT("zero-duration preview builds"), Build(Description, Request, Preview, Error));
+    TestTrue(TEXT("duration is exactly zero"), Preview.DurationSeconds == 0.0);
+    TestEqual(TEXT("zero duration emits one sample"), Preview.Samples.Num(), 1);
+    if (Preview.Samples.Num() == 1)
+    {
+        TestTrue(TEXT("zero-duration sample time is exactly zero"), Preview.Samples[0].TimeSeconds == 0.0);
+        TestTrue(
+            TEXT("zero-duration sample preserves the start state"),
+            Preview.Samples[0].JointPositions[1].PositionRadians == 0.2);
+    }
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewCapTest,
+    "DeferredTeleop.M2.KinematicPreview.CapsSamplesAndPreservesEndpoints",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewCapTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest Request = MakeRequest();
+    SetIKJointPositions(Request.IKResult, 2.0, 0.6, 0.3);
+    Request.Settings.JointVelocities[0].MaximumRadiansPerSecond = 0.1;
+    Request.Settings.SampleRateHz = 1000.0;
+    Request.Settings.MaximumSamples = 128;
+    TestTrue(TEXT("high-frequency fixture achieved transform is refreshed"), RefreshAchievedTransform(Description, Request));
+
+    FDttKinematicPreview Preview;
+    FString Error;
+    TestTrue(TEXT("high-frequency preview builds"), Build(Description, Request, Preview, Error));
+    TestTrue(TEXT("duration remains within the configured bound"), Preview.DurationSeconds <= 30.0);
+    TestEqual(TEXT("intermediate samples are capped at 128"), Preview.Samples.Num(), 128);
+    if (Preview.Samples.Num() == 128)
+    {
+        TestTrue(TEXT("cap keeps exact zero endpoint"), Preview.Samples[0].TimeSeconds == 0.0);
+        TestTrue(
+            TEXT("cap keeps exact duration endpoint"),
+            Preview.Samples.Last().TimeSeconds == Preview.DurationSeconds);
+        TestTrue(
+            TEXT("cap keeps exact first joint start"),
+            Preview.Samples[0].JointPositions[0].PositionRadians
+                == Preview.StartJointPositions[0].PositionRadians);
+        TestTrue(
+            TEXT("cap keeps exact first joint goal"),
+            Preview.Samples.Last().JointPositions[0].PositionRadians
+                == Preview.GoalJointPositions[0].PositionRadians);
+        for (int32 Index = 1; Index < Preview.Samples.Num(); ++Index)
+        {
+            TestTrue(
+                *FString::Printf(TEXT("capped sample %d has increasing time"), Index),
+                Preview.Samples[Index].TimeSeconds > Preview.Samples[Index - 1].TimeSeconds);
+        }
+    }
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewSettingsValidationTest,
+    "DeferredTeleop.M2.KinematicPreview.RejectsInvalidSettings",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewSettingsValidationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    const FDttKinematicPreviewRequest BaseRequest = MakeRequest();
+    struct FInvalidCase
+    {
+        const TCHAR* Label;
+        void (*Mutate)(FDttKinematicPreviewRequest&);
+    };
+    const FInvalidCase Cases[] = {
+        {TEXT("missing velocity"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.JointVelocities.RemoveAt(2);
+         }},
+        {TEXT("duplicate velocity"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.JointVelocities.Add(PreviewVelocity(TEXT("joint_a"), 1.0));
+         }},
+        {TEXT("zero velocity"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.JointVelocities[0].MaximumRadiansPerSecond = 0.0;
+         }},
+        {TEXT("NaN velocity"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.JointVelocities[0].MaximumRadiansPerSecond =
+                 std::numeric_limits<double>::quiet_NaN();
+         }},
+        {TEXT("zero sample rate"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.SampleRateHz = 0.0;
+         }},
+        {TEXT("sample rate over bound"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.SampleRateHz = 1000.0001;
+         }},
+        {TEXT("zero duration bound"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.MaximumDurationSeconds = 0.0;
+         }},
+        {TEXT("duration over bound"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.MaximumDurationSeconds = 30.0001;
+         }},
+        {TEXT("sample cap below bound"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.MaximumSamples = 1;
+         }},
+        {TEXT("sample cap above bound"), [](FDttKinematicPreviewRequest& Request)
+         {
+             Request.Settings.MaximumSamples = 129;
+         }},
+    };
+    for (const FInvalidCase& InvalidCase : Cases)
+    {
+        FDttKinematicPreviewRequest Request = BaseRequest;
+        InvalidCase.Mutate(Request);
+        ExpectRejected(*this, Description, Request, InvalidCase.Label);
+    }
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewForgedResultTest,
+    "DeferredTeleop.M2.KinematicPreview.RejectsForgedOrMismatchedIK",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewForgedResultTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest BaseRequest = MakeRequest();
+    TestTrue(TEXT("base achieved transform is FK-derived"), RefreshAchievedTransform(Description, BaseRequest));
+
+    FDttKinematicPreviewRequest Forged = BaseRequest;
+    Forged.IKResult.AchievedToolTransform.TranslationMetres.X += 1.0e-6;
+    ExpectRejected(*this, Description, Forged, TEXT("forged achieved transform"));
+
+    Forged = BaseRequest;
+    Forged.WorldTransformOfRoot.TranslationMetres.X += 0.01;
+    ExpectRejected(*this, Description, Forged, TEXT("wrong root transform"));
+
+    Forged = BaseRequest;
+    Forged.IKResult.ToolFrameName = FName(TEXT("unknown-tool"));
+    ExpectRejected(*this, Description, Forged, TEXT("wrong tool frame"));
+
+    Forged = BaseRequest;
+    Forged.ModelReference.DescriptionHash = TEXT("sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    ExpectRejected(*this, Description, Forged, TEXT("uppercase description hash"));
+
+    Forged = BaseRequest;
+    Forged.ModelReference.ModelId = TEXT("other-model");
+    ExpectRejected(*this, Description, Forged, TEXT("model id mismatch"));
+
+    Forged = BaseRequest;
+    Forged.GoalId = FGuid();
+    ExpectRejected(*this, Description, Forged, TEXT("zero goal id"));
+
+    Forged = BaseRequest;
+    Forged.ModelReference.ModelRevision = TEXT("other-revision");
+    ExpectRejected(*this, Description, Forged, TEXT("model revision mismatch"));
+
+    Forged = BaseRequest;
+    Forged.IKResult.ModelId = TEXT("other-model");
+    ExpectRejected(*this, Description, Forged, TEXT("IK model id mismatch"));
+
+    Forged = BaseRequest;
+    Forged.IKResult.ModelRevision = TEXT("other-revision");
+    ExpectRejected(*this, Description, Forged, TEXT("IK model revision mismatch"));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewSourceValidationTest,
+    "DeferredTeleop.M2.KinematicPreview.ValidatesSourceEvidence",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewSourceValidationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest BaseRequest = MakeRequest();
+    TestTrue(TEXT("source fixture achieved transform is FK-derived"), RefreshAchievedTransform(Description, BaseRequest));
+    const EDttPreviewSourceKind SourceKinds[] = {
+        EDttPreviewSourceKind::Measured,
+        EDttPreviewSourceKind::Fused,
+        EDttPreviewSourceKind::Synthetic,
+        EDttPreviewSourceKind::OperatorAsserted,
+    };
+    const EDeferredTeleopProvenance Provenances[] = {
+        EDeferredTeleopProvenance::Measured,
+        EDeferredTeleopProvenance::Fused,
+        EDeferredTeleopProvenance::Simulated,
+        EDeferredTeleopProvenance::OperatorAsserted,
+    };
+    for (int32 Index = 0; Index < UE_ARRAY_COUNT(SourceKinds); ++Index)
+    {
+        FDttKinematicPreviewRequest Request = BaseRequest;
+        Request.SourceReference.SourceKind = SourceKinds[Index];
+        Request.SourceReference.Evidence.Provenance = Provenances[Index];
+        FDttKinematicPreview Preview;
+        FString Error;
+        TestTrue(
+            *FString::Printf(TEXT("source kind %d with matching provenance passes"), Index),
+            Build(Description, Request, Preview, Error));
+        TestTrue(
+            *FString::Printf(TEXT("source kind %d remains visible in the snapshot"), Index),
+            Preview.SourceReference.SourceKind == SourceKinds[Index]);
+    }
+
+    FDttKinematicPreviewRequest Invalid = BaseRequest;
+    Invalid.SourceReference.SourceKind = EDttPreviewSourceKind::Synthetic;
+    Invalid.SourceReference.Evidence.Provenance = EDeferredTeleopProvenance::Measured;
+    ExpectRejected(*this, Description, Invalid, TEXT("inconsistent source mapping"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.Evidence.ProducedAt = FDateTime(2026, 9, 4, 11, 59, 59);
+    ExpectRejected(*this, Description, Invalid, TEXT("inverted evidence dates"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.Evidence.SourceIds.Reset();
+    ExpectRejected(*this, Description, Invalid, TEXT("missing evidence source"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.SourceMessageId.Reset();
+    ExpectRejected(*this, Description, Invalid, TEXT("missing source message id"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.CorrelationId.Reset();
+    ExpectRejected(*this, Description, Invalid, TEXT("missing correlation id"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.Evidence.WorldRevision = 0;
+    ExpectRejected(*this, Description, Invalid, TEXT("zero world revision"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.FrameId.Reset();
+    ExpectRejected(*this, Description, Invalid, TEXT("missing frame id"));
+
+    Invalid = BaseRequest;
+    Invalid.SourceReference.CalibrationVersion.Reset();
+    ExpectRejected(*this, Description, Invalid, TEXT("missing calibration version"));
+
+    Invalid = BaseRequest;
+    Invalid.PreviewId = FGuid();
+    ExpectRejected(*this, Description, Invalid, TEXT("zero preview id"));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopKinematicPreviewJointAndStatusValidationTest,
+    "DeferredTeleop.M2.KinematicPreview.ValidatesJointsAndStatuses",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopKinematicPreviewJointAndStatusValidationTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    const FDttRobotDescription Description = MakeDescription();
+    FDttKinematicPreviewRequest BaseRequest = MakeRequest();
+    TestTrue(TEXT("base achieved transform is FK-derived"), RefreshAchievedTransform(Description, BaseRequest));
+
+    FDttKinematicPreviewRequest Invalid = BaseRequest;
+    Invalid.StartJointPositions[0].JointName = TEXT("unknown");
+    ExpectRejected(*this, Description, Invalid, TEXT("unknown start joint"));
+
+    Invalid = BaseRequest;
+    Invalid.StartJointPositions[0].JointName = TEXT("root_to_mount");
+    ExpectRejected(*this, Description, Invalid, TEXT("fixed start joint"));
+
+    Invalid = BaseRequest;
+    Invalid.StartJointPositions.Add(ArticulatedJoint(TEXT("joint_a"), 0.0));
+    ExpectRejected(*this, Description, Invalid, TEXT("duplicate start joint"));
+
+    Invalid = BaseRequest;
+    Invalid.StartJointPositions[0].PositionRadians = std::numeric_limits<double>::quiet_NaN();
+    ExpectRejected(*this, Description, Invalid, TEXT("non-finite start joint"));
+
+    Invalid = BaseRequest;
+    Invalid.StartJointPositions[0].PositionRadians = 4.0;
+    ExpectRejected(*this, Description, Invalid, TEXT("out-of-limit start joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.JointPositions[0].JointName = FName(TEXT("unknown"));
+    ExpectRejected(*this, Description, Invalid, TEXT("unknown IK joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.JointPositions.Add(NamedJoint(TEXT("joint_a"), 0.0));
+    ExpectRejected(*this, Description, Invalid, TEXT("duplicate IK joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.JointPositions[0].PositionRadians = std::numeric_limits<double>::quiet_NaN();
+    ExpectRejected(*this, Description, Invalid, TEXT("non-finite IK joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.JointPositions[0].PositionRadians = 4.0;
+    ExpectRejected(*this, Description, Invalid, TEXT("out-of-limit IK joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.ActiveJointNames.Add(FName(TEXT("root_to_mount")));
+    ExpectRejected(*this, Description, Invalid, TEXT("fixed active joint"));
+
+    Invalid = BaseRequest;
+    Invalid.IKResult.ActiveJointNames.Add(FName(TEXT("joint_a")));
+    ExpectRejected(*this, Description, Invalid, TEXT("duplicate active joint"));
+
+    FDttKinematicPreviewRequest InactiveGripper = BaseRequest;
+    FDttKinematicPreview EqualInactivePreview;
+    FString EqualInactiveError;
+    TestTrue(
+        TEXT("inactive gripper equal to start is accepted"),
+        Build(Description, BaseRequest, EqualInactivePreview, EqualInactiveError));
+    if (EqualInactivePreview.bValid)
+    {
+        TestTrue(
+            TEXT("accepted inactive gripper goal equals start exactly"),
+            EqualInactivePreview.GoalJointPositions[2].PositionRadians
+                == EqualInactivePreview.StartJointPositions[2].PositionRadians);
+    }
+
+    InactiveGripper.IKResult.JointPositions[2].PositionRadians = 0.8;
+    TestTrue(
+        TEXT("inactive gripper fixture retains a valid FK achieved goal"),
+        RefreshAchievedTransform(Description, InactiveGripper));
+    ExpectRejected(*this, Description, InactiveGripper, TEXT("inactive gripper goal differs from start"));
+
+    FDttKinematicPreview Preview;
+    FString Error;
+
+    FDttKinematicPreviewRequest Partial = BaseRequest;
+    Partial.IKResult.Status = EDttIKStatus::Partial;
+    Partial.IKResult.bSuccess = false;
+    ExpectRejected(*this, Description, Partial, TEXT("partial without opt-in"));
+
+    Partial.Settings.bAcceptPartial = true;
+    TestTrue(TEXT("partial result passes with explicit opt-in"), Build(Description, Partial, Preview, Error));
+    TestTrue(TEXT("partial opt-in is exposed"), Preview.bAcceptedPartial);
+
+    FDttKinematicPreviewRequest PartialSuccess = BaseRequest;
+    PartialSuccess.IKResult.Status = EDttIKStatus::Partial;
+    PartialSuccess.IKResult.bSuccess = true;
+    PartialSuccess.Settings.bAcceptPartial = true;
+    ExpectRejected(*this, Description, PartialSuccess, TEXT("partial result with bSuccess=true"));
+
+    FDttKinematicPreviewRequest IterationLimit = BaseRequest;
+    IterationLimit.IKResult.Status = EDttIKStatus::IterationLimit;
+    IterationLimit.IKResult.bSuccess = false;
+    IterationLimit.Settings.bAcceptPartial = true;
+    TestTrue(TEXT("iteration-limit result passes with explicit opt-in"), Build(Description, IterationLimit, Preview, Error));
+    TestTrue(TEXT("iteration-limit opt-in is exposed"), Preview.bAcceptedPartial);
+
+    const EDttIKStatus RejectedStatuses[] = {
+        EDttIKStatus::InvalidInput,
+        EDttIKStatus::NumericalFailure,
+        EDttIKStatus::Unreachable,
+    };
+    for (const EDttIKStatus Status : RejectedStatuses)
+    {
+        FDttKinematicPreviewRequest Rejected = BaseRequest;
+        Rejected.IKResult.Status = Status;
+        Rejected.IKResult.bSuccess = false;
+        ExpectRejected(*this, Description, Rejected, TEXT("unsupported IK status"));
+    }
+
+    FDttKinematicPreviewRequest Incoherent = BaseRequest;
+    Incoherent.IKResult.Status = EDttIKStatus::Converged;
+    Incoherent.IKResult.bSuccess = false;
+    ExpectRejected(*this, Description, Incoherent, TEXT("incoherent converged status"));
+    return true;
+}
+} // namespace DeferredTeleop::Tests::KinematicPreview
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewLibrary.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewLibrary.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Kinematics/DeferredTeleopKinematicPreviewTypes.h"
+#include "DeferredTeleopKinematicPreviewLibrary.generated.h"
+
+namespace DeferredTeleop::Kinematics
+{
+/** Build a bounded, local, FK-backed joint-space kinematic preview. */
+DEFERREDTELEOPRUNTIME_API bool BuildPreview(
+    const FDttRobotDescription& Description,
+    const FDttKinematicPreviewRequest& Request,
+    FDttKinematicPreview& OutPreview,
+    FString& OutError);
+} // namespace DeferredTeleop::Kinematics
+
+/** Blueprint boundary for the pure, deterministic kinematic preview builder. */
+UCLASS()
+class DEFERREDTELEOPRUNTIME_API UDeferredTeleopKinematicPreviewLibrary final
+    : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintCallable, Category = "Deferred Teleoperation|Kinematics|Preview")
+    static bool BuildPreview(
+        const FDttRobotDescription& Description,
+        const FDttKinematicPreviewRequest& Request,
+        FDttKinematicPreview& OutPreview,
+        FString& OutError);
+};

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewTypes.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewTypes.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Articulated/DeferredTeleopArticulatedViewTypes.h"
+#include "Kinematics/DeferredTeleopIKTypes.h"
+#include "DeferredTeleopKinematicPreviewTypes.generated.h"
+
+/** Provenance explicitly attached to a locally generated kinematic preview. */
+UENUM(BlueprintType)
+enum class EDttPreviewSourceKind : uint8
+{
+    Measured,
+    Fused,
+    Synthetic,
+    OperatorAsserted,
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttPreviewSourceReference
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FString SourceMessageId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FString CorrelationId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    EDttPreviewSourceKind SourceKind = EDttPreviewSourceKind::Measured;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDeferredTeleopEvidence Evidence;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FString FrameId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FString CalibrationVersion;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttPreviewJointVelocity
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FName JointName = NAME_None;
+
+    /** Presentation timing limit in radians per second. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double MaximumRadiansPerSecond = 0.0;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttKinematicPreviewSettings
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDttPreviewJointVelocity> JointVelocities;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double SampleRateHz = 60.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double MaximumDurationSeconds = 30.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    int32 MaximumSamples = 128;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    bool bAcceptPartial = false;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttKinematicPreviewRequest
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FGuid PreviewId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FGuid GoalId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDeferredTeleopRobotModelReference ModelReference;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttCanonicalTransform WorldTransformOfRoot;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDeferredTeleopArticulatedJointPosition> StartJointPositions;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttIKResult IKResult;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttPreviewSourceReference SourceReference;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttKinematicPreviewSettings Settings;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttKinematicPreviewSample
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double TimeSeconds = 0.0;
+
+    /** Joint values are in description order and in radians. */
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDeferredTeleopArticulatedJointPosition> JointPositions;
+
+    /** Canonical ^world T_tool produced by FK for this sample. */
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttCanonicalTransform ToolTransform;
+};
+
+USTRUCT(BlueprintType)
+struct DEFERREDTELEOPRUNTIME_API FDttKinematicPreview
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    bool bValid = false;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FGuid PreviewId;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FGuid GoalId;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDeferredTeleopRobotModelReference ModelReference;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttPreviewSourceReference SourceReference;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FDttCanonicalTransform WorldTransformOfRoot;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDeferredTeleopArticulatedJointPosition> StartJointPositions;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDeferredTeleopArticulatedJointPosition> GoalJointPositions;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FName ToolFrameName = NAME_None;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    EDttIKStatus IKStatus = EDttIKStatus::InvalidInput;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    bool bAcceptedPartial = false;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double PositionResidualMetres = 0.0;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double ApproachResidualRadians = 0.0;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    double DurationSeconds = 0.0;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FDttKinematicPreviewSample> Samples;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    FString Diagnostic;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Deferred Teleoperation|Kinematics|Preview")
+    TArray<FString> Diagnostics;
+};


### PR DESCRIPTION
# Bounded M2.8a local kinematic preview math core

This branch adds a pure, deterministic `KinematicPreview` builder behind a C++ namespace
function and Blueprint boundary. It converts a validated articulated start state and a converged
or explicitly accepted partial IK result into bounded, time-sampled joint states. Duration uses
the maximum `abs(delta radians) / preview velocity`, with a 30-second limit and a 128-sample cap;
the velocity values bound preview timing only and do not model dynamics or authorize motion.

Every sample recomputes canonical FK for the requested tool frame. Start and goal endpoints are
copied exactly, inactive IK joints must equal their start values exactly, partial results require
opt-in, and source provenance is preserved as declared values. The description hash is shape
checked but not authenticated. Rejected preview requests clear the output; callers retain any last valid
preview themselves.

Linux and Win64 Unreal Engine 5.8.2 each pass the eight production preview tests within a 43-test
contextual report, with build/editor exit code 0 and no warnings, failures, or not-run tests.
The [platform record](https://github.com/YannickPr/Deferred-Teleoperation/blob/codex/time-sampled-kinematic-preview/docs/m2/evidence/kinematic-preview-platform-validation.json)
binds both reports and selected source hashes. This slice has no Python runtime changes; the existing portable CI suite remains required.

Related to [#20](https://github.com/YannickPr/Deferred-Teleoperation/issues/20). Both #20 and #21 remain open. Desktop/VR authoring and trajectory visualization remain outside this slice. Branch: [codex/time-sampled-kinematic-preview](https://github.com/YannickPr/Deferred-Teleoperation/tree/codex/time-sampled-kinematic-preview).
