### PR TITLE
Persist one-reservation external-action budgets across restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 - combined M1.8b virtual-time proof that drives the independent non-idempotent device through
   symmetric 1200-second and asymmetric 900-second outbound / 1200-second return delays, including
   duplicate-contract recovery and receiving-site expiry boundaries;
+- bounded M1.8c Robot-local external-action budget for one revision-1 reservation per operation,
+  a finite service-clock window, atomic dispatch/device binding, durable pre-dispatch holds, and
+  conservative v3-to-v4 legacy classification; cross-revision identity and multiprocess fencing
+  remain open;
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
 - strict M2.2 articulated robot-state/model-reference protocol (#14), including finite canonical
   pose/joint values, provenance-preserving Field relay, the opt-in Mission articulated view, and
@@ -51,14 +55,14 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ### Status
 
-- M1.8 remains in progress after M1.8b: durable autonomy-budget accounting and stable effect
-  identity across contract revisions are not implemented, and no physical hardware validation is
+- M1.8 remains in progress after the bounded M1.8c budget slice: stable effect identity across
+  contract revisions and multiprocess fencing remain open, and no physical hardware validation is
   claimed.
 - M2.4 is complete, including the cross-version reference check and native Linux/Win64 Kinematics
   validation.
 - M2.2 is complete. Its raw articulated feed does not validate model geometry; an FK consumer must
-  call the explicit description-backed validator. The post-rebase integrated validation passes
-  141 Python tests; the historical M2.2 135/20 snapshot remains identified in its platform record.
+  call the explicit description-backed validator. The integrated Python suite passes 152 tests;
+  the historical M2.2 135/20 snapshot remains identified in its platform record.
 - M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK and the M2.8a
   preview math core are complete with Linux/Win64 evidence; desktop/VR authoring and the full
   #20/#21 integration gates remain open, and no physical or hardware-control path is claimed.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > The bounded M2.8a local KinematicPreview math core is implemented; Linux and Win64 Unreal
 > validation each record 43/43 contextual successes, including all eight preview tests, with
 > build/editor exit code 0.
+> The bounded M1.8c local external-action budget supports one revision-1 reservation/window;
+> cross-revision effect identity and multiprocess fencing remain open.
 > The `v0.1.0` release gate is satisfied with portable Python CI;
 > M2.2–M2.5 have separate Unreal Engine 5.8.2 evidence on Linux and Win64. No physical robot path
 > is enabled.
@@ -37,6 +39,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
+| M1.8 external effect | M1.8b delayed proof and bounded M1.8c one-reservation local budget implemented; cross-revision identity and multiprocess fencing remain open |
 | SO-101 twin | M2.2 articulated-state protocol (#14), M2.3 canonical transforms/generic FK code (#15), M2.4 cross-language numerical oracle (#16), and the bounded M2.5 rigid-link actor are complete with Python 3.11/3.12 and Linux/Win64 UE 5.8.2 evidence; the M2.7 constrained-IK implementation and M2.8a local preview math core are complete with Linux/Win64 UE 5.8.2 evidence; desktop/VR authoring and #20/#21 integration remain open |
 | Autonomous delayed button press | Planned for M3 |
 | Hardware control | Disabled by default; not implemented publicly |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,7 +96,7 @@ general perception system. M1.7a is a prerequisite correction, not a substitute 
 
 ## M1.8 — External effect and long-delay evidence
 
-Status: **in progress; M1.8b combined external-effect/long-delay proof implemented**
+Status: **in progress; M1.8b proof and bounded M1.8c budget implemented**
 
 The [long-delay domain tests](docs/m1/LONG_DELAY_DOMAIN.md) cover 0, 30, 900 and 1200 seconds
 of one-way transit, blackout, expiry and persisted-service restart with the M1 dummy effect. The
@@ -111,7 +111,15 @@ outcome is unknown or not applied. Missing or substituted adapters are rejected 
 The M1.8b proof combines that adapter with the delayed domain and verifies independent pulse
 history, duplicate contract delivery after Robot-store recovery, receiving-site expiry, and the
 absence of a fabricated completion snapshot. Stable effect identity across plan revisions and a
-durable autonomy budget remain unimplemented.
+full cross-revision effect identity remain open. The [M1.8c durable budget](docs/m1/DURABLE_EXTERNAL_ACTION_BUDGET.md)
+adds one local attempt/action reservation for each revision-1 operation, a configurable finite
+service-clock window (60 seconds by default), atomic reservation/dispatch/device binding, and
+durable pre-dispatch holds with v3-to-v4 legacy classification.
+
+M1.8c assumes one active Robot instance per SQLite database and external adapter. SQLite serializes
+the durable reservation, but it does not fence external I/O after that commit; two active workers
+can still produce an observe-versus-press race. Fencing or an exclusive process lock and a
+multiprocess oracle remain future work ([issue #45](https://github.com/YannickPr/Deferred-Teleoperation/issues/45)).
 
 M1.8 adds the smallest deterministic proof that a recorded execution event is not itself proof
 of an external effect. A fake button device keeps an effect counter or state in storage separate
@@ -125,12 +133,13 @@ fifteen-minute delay must configure and record at least 900 seconds of one-way t
 validity so that admission, execution and expiry are evaluated at the receiving site rather than
 inferred from a link profile name.
 
-The M1.8b bounded combined slice is implemented and covered by six focused tests in the 115-test
-Python suite. It does not validate physical hardware, a real network, or a whole-OS restart.
+The M1.8b bounded combined slice is implemented and covered by six focused tests. M1.8c adds
+eleven persistent budget cases; the current Python suite passes 152 tests. These slices do not
+validate physical hardware, a real network, or a whole-OS restart.
 Positive and ambiguous observation recovery are covered under long delay; absent external
 evidence remains covered by the separate M1.8a recovery proof. It covers contract revision 1;
-cross-revision identity and durable budget accounting remain open. Expiry or cancellation after
-external dispatch and before Robot recovery is outside this proof.
+cross-revision semantic identity remains open. Expiry or cancellation after external dispatch and
+before Robot recovery is outside this proof.
 
 M1.8 closes when deterministic evidence shows that:
 
@@ -139,6 +148,10 @@ M1.8 closes when deterministic evidence shows that:
   and no blind duplicate effect;
 - a long-delay run records virtual transit, local queue age, validity and the resulting decision;
 - restart and retransmission do not reset the effect identity or autonomy budget.
+
+The bounded budget portion satisfies the one-reservation invariant for revision 1. Full M1.8
+remains open for stable effect identity across plan revisions, multiprocess fencing, and the
+machine-readable evidence that joins those decisions to the independent effect record.
 
 No hardware-control path is introduced by this increment.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1 | **Implemented; `v0.1.0` historical** | Delay-tolerant dummy, persistence, replay and Mission reconciliation |
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
-| M1.8 | **In progress; M1.8b combined proof implemented** | External device runs through delayed Mission/Field domain; durable budget and cross-revision identity remain open |
+| M1.8 | **In progress; M1.8b proof and bounded M1.8c budget implemented** | One revision-1 local reservation/window is durable; cross-revision identity and multiprocess fencing remain open |
 | M2 | **In progress; target `v0.2.0`** | M2.1 structural model, M2.2 articulated-state protocol, M2.3 FK math core, M2.4 oracle, M2.5 actor, and M2.8a local preview math core are complete with Linux/Win64 UE evidence; M2.7 constrained IK is complete with Linux/Win64 UE evidence; desktop/VR authoring and #20/#21 remain |
 | M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
@@ -20,7 +20,8 @@ M1.7a, M1.7, M1.8 and the enriched M3a/M3b slices are specified in the [delayed-
 validation design](design/DELAYED_INTENT_VALIDATION.md). M1.7a is implemented in
 [PR #30](https://github.com/YannickPr/Deferred-Teleoperation/pull/30), and the bounded M1.8b
 combined proof is implemented in [the external long-delay evidence](m1/EXTERNAL_EFFECT_LONG_DELAY.md).
-The remaining M1.7 and full M1.8 gates are not established by the design document.
+The bounded M1.8c local budget is documented in [the durable budget guide](m1/DURABLE_EXTERNAL_ACTION_BUDGET.md).
+The remaining M1.7 and full M1.8 gates are not established by these bounded slices.
 
 ## Implemented in M0
 
@@ -191,7 +192,7 @@ All 72 Python tests, Ruff and the unchanged M1 CI release gate passed in
 - explicit handling for missing or incompatible parent references;
 - deterministic machine-readable and visible evidence without cross-operation association.
 
-### M1.8 combined external-effect and long-delay gate
+### M1.8 remaining combined external-effect and long-delay gate
 
 The [long-delay domain tests](m1/LONG_DELAY_DOMAIN.md) exercise the real M1 services and
 deterministic link with up to 1200 seconds of one-way transit. The
@@ -202,14 +203,16 @@ durably; recovery observes without blind replay and rejects a missing or substit
 unknown outcome remains held, and a terminal event alone does not manufacture measured completion
 telemetry in the normal Field.
 
-The integrated Python suite passes 115 tests, including six focused M1.8b scenarios. The historical
-golden session and its six committed files remain unchanged, and the release gate remains
-unchanged. Its explicit dummy fixture compatibility is documented; it is not an external
-observation guarantee.
+The integrated Python suite passes 152 tests, including six M1.8b scenarios and eleven persistent
+M1.8c budget cases. The historical golden session and its six committed files remain unchanged,
+and the release gate remains unchanged. Its explicit dummy fixture compatibility is documented;
+it is not an external observation guarantee. M1.8c assumes one active Robot instance per SQLite
+database and adapter: SQLite serializes the reservation, but does not fence external I/O between
+active workers.
 
 The remaining full M1.8 gate requires:
 
-- stable effect identity across plan revisions and durable autonomy-budget accounting;
+- stable effect identity across plan revisions and multiprocess fencing for the external I/O race;
 - machine-readable evidence connecting those decisions and the independently recorded effect.
 
 ### Remaining M2 work
@@ -255,7 +258,7 @@ M3 remains incomplete until both M3a and M3b pass. Neither gate is currently imp
 
 The M2.5 runtime actor, public scene recipe, platform reports, and synthetic PNG are implemented
 in this bounded tranche; they introduce no hardware path. M1.7a has the separate implementation
-and validation cited above; the bounded M1.8b proof is implemented while the full M1.8 gate remains
+and validation cited above; the bounded M1.8b proof and M1.8c budget are implemented while the full M1.8 gate remains
 open. M2.2, M2.3, M2.4, and M2.5 have their implementation and machine-readable Linux/Win64
 platform records. M2.7 and the M2.8a preview math core are complete with machine-readable
 Linux/Win64 platform records; desktop/VR authoring and the full #20/#21 integration gates remain

--- a/docs/m1/DURABLE_EXTERNAL_ACTION_BUDGET.md
+++ b/docs/m1/DURABLE_EXTERNAL_ACTION_BUDGET.md
@@ -1,0 +1,58 @@
+# M1.8c durable external-action budget
+
+The Robot runtime gives an external adapter one local autonomous reservation per
+`operation_id`. This is a Robot policy snapshot; it is not a Mission permission
+and it does not add a protocol field or execution revision.
+
+For an external adapter, admission creates an `autonomy_budget` row with the
+immutable contract binding, literal `attempt_limit = 1` and `action_limit = 1`,
+and a positive finite `max_elapsed_seconds` window (60 seconds by default).
+`window_started_at` is the durable journal acceptance time. The reservation
+transaction validates the persisted policy and trusted service clock, then
+sets both counters to one and records `DISPATCH_RECORDED` with the adapter
+`device_id` in one SQLite `BEGIN IMMEDIATE` transaction. The adapter is called
+only after that commit. A crash after the reservation therefore burns the one
+action; recovery observes the addressed device and never presses again.
+The focused proof covers crashes before adapter I/O and after the device effect;
+both paths reopen and observe without a second press.
+
+The scope assumes one active Robot instance per SQLite database and external
+adapter. `BEGIN IMMEDIATE` serializes the durable reservation, but it cannot
+fence an external I/O call after the commit. Two active workers can therefore
+still race between one worker's observe and another worker's press; fencing or
+an exclusive process lock and a multiprocess oracle remain outside M1.8c.
+The follow-up is tracked in [issue #45](https://github.com/YannickPr/Deferred-Teleoperation/issues/45).
+
+The policy is compared only before a new press. A changed restart configuration
+holds an unreserved accepted contract with `BUDGET_POLICY_CONFLICT`; it cannot
+rewrite a snapshot. A contract whose dispatch is already durable, or whose
+outcome is terminal, follows the existing attributed observe/replay path even
+when its deadline or current configuration has changed. The existing clock
+rollback guard remains in force before external observation.
+
+A bound budget requires its external adapter even before dispatch and during
+terminal replay; a missing adapter or a different durable device identity is
+rejected before any dummy fallback.
+
+If the service clock is behind durable acceptance or dispatch, processing waits
+for a trusted catch-up and leaves the journal unchanged; rollback does not
+invent an early terminal `HELD` event.
+
+The dtt/0 transition table admits `ACCEPTED -> HELD` for a pre-dispatch
+budget refusal; all other protocol states and payloads remain unchanged.
+Operation scope is bound to the first revision-1 contract. A different
+contract for the same operation is denied before the journal `effect_key`
+constraint is reached. Its denial, stable HELD event, first envelope JSON, and
+inbox completion are committed together. Repeated fresh envelopes reuse the
+stored event bytes. Revision 2 is held before budget admission.
+
+Schema migration 4 records v3 dispatches with a durable device identity as
+`LEGACY_OBSERVE_ONLY`; these rows receive no invented policy or reservation.
+An old `ACCEPTED` row without a budget becomes
+`LEGACY_UNBUDGETED_HOLD`, with no adapter call or external proof. v3 dispatches
+without a device identity retain the refusal to guess an adapter. Because v3
+does not identify dummy versus external mode, every historical `ACCEPTED` row
+is conservatively held; that legacy dummy distinction cannot be recovered.
+
+This tranche deliberately leaves cross-revision semantic effect identity and
+retry or multi-action execution open.

--- a/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
+++ b/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
@@ -44,6 +44,12 @@ zero. The counter belongs only to the historical database dummy path. The
 fixture's persistent press record is the independent evidence used by
 `observe`; the runtime never reads a test counter.
 
+The bounded M1.8c budget assumes one active Robot instance per SQLite database
+and external adapter. SQLite serializes the reservation commit, but it cannot
+fence external I/O after that commit; two active workers can still race between
+one worker's observation and another worker's press. Multiprocess fencing or an
+exclusive process lock remains future work.
+
 The Field only emits a reconciled site snapshot for `SUCCEEDED` when it has a
 compatible measured or fused `RobotState` with the same correlation and robot
 identifier. A `HELD` result or telemetry from a different operation does not

--- a/docs/m1/evidence/durable-external-action-budget-proof.json
+++ b/docs/m1/evidence/durable-external-action-budget-proof.json
@@ -1,0 +1,46 @@
+{
+  "evidence_version": 1,
+  "slice": "M1.8c",
+  "status": "bounded_implementation",
+  "scope": {
+    "external_adapter_only": true,
+    "contract_revision": 1,
+    "attempt_limit": 1,
+    "action_limit": 1,
+    "default_max_elapsed_seconds": 60.0,
+    "one_active_robot_instance_per_database_and_adapter": true,
+    "cross_revision_effect_identity": "open",
+    "multiprocess_fencing": "open"
+  },
+  "migration": {
+    "from_schema": 3,
+    "to_schema": 4,
+    "dispatch_with_device": "LEGACY_OBSERVE_ONLY",
+    "accepted_without_budget": "LEGACY_UNBUDGETED_HOLD"
+  },
+  "validation": {
+    "focused_budget_tests": {
+      "command": "PYTHONPATH=python/src python -m pytest -q tests/test_autonomy_budget.py",
+      "passed": 11
+    },
+    "full_python_tests": {
+      "command": "PYTHONPATH=python/src python -m pytest -q",
+      "passed": 152
+    },
+    "ruff": "passed",
+    "schema_check": "passed",
+    "so101_check": "passed",
+    "kinematics_reference_check": "passed",
+    "release_gate_ci_skip_pytest": "passed",
+    "golden_files_byte_identical": 6,
+    "golden_files_changed": 0
+  },
+  "open_follow_up": {
+    "issue": "https://github.com/YannickPr/Deferred-Teleoperation/issues/45",
+    "items": [
+      "exclusive owner or fencing for concurrent Robot processes",
+      "multiprocess Linux and Windows oracle",
+      "stable effect identity across contract revisions"
+    ]
+  }
+}

--- a/python/src/deferred_teleop/protocol.py
+++ b/python/src/deferred_teleop/protocol.py
@@ -173,7 +173,9 @@ class ExecutionContract(WireModel):
 
 CONTRACT_TRANSITIONS: dict[ContractState, frozenset[ContractState]] = {
     ContractState.RECEIVED: frozenset({ContractState.ACCEPTED, ContractState.HELD}),
-    ContractState.ACCEPTED: frozenset({ContractState.DISPATCH_RECORDED, ContractState.CANCELLED}),
+    ContractState.ACCEPTED: frozenset(
+        {ContractState.DISPATCH_RECORDED, ContractState.CANCELLED, ContractState.HELD}
+    ),
     ContractState.DISPATCH_RECORDED: frozenset({ContractState.RUNNING}),
     ContractState.RUNNING: frozenset(
         {ContractState.SUCCEEDED, ContractState.FAILED, ContractState.HELD, ContractState.CANCELLED}

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -53,7 +53,20 @@ from deferred_teleop.protocol import (
     Vector3,
     WireModel,
 )
-from deferred_teleop.storage import NodeStore, RecordConflictError
+from deferred_teleop.storage import (
+    BUDGET_DEADLINE_EXPIRED,
+    BUDGET_LIMIT_EXHAUSTED,
+    BUDGET_POLICY_CONFLICT,
+    BUDGET_SCOPE_CONFLICT,
+    LEGACY_OBSERVE_ONLY,
+    LEGACY_UNBUDGETED_HOLD,
+    BudgetDeadlineError,
+    BudgetLimitError,
+    BudgetPolicyConflictError,
+    BudgetScopeConflictError,
+    NodeStore,
+    RecordConflictError,
+)
 
 TERMINAL_STATES = frozenset(
     {
@@ -1127,6 +1140,8 @@ class FieldService(RuntimeService):
 
 
 class DummyRobotService(RuntimeService):
+    DEFAULT_EXTERNAL_MAX_ELAPSED_SECONDS = 60.0
+
     def __init__(
         self,
         store: NodeStore,
@@ -1135,12 +1150,31 @@ class DummyRobotService(RuntimeService):
         field_id: str = "field-1",
         phase_duration: float = 0.05,
         external_effect_adapter: ExternalEffectAdapter | None = None,
+        max_elapsed_seconds: float = DEFAULT_EXTERNAL_MAX_ELAPSED_SECONDS,
         emit: EventSink = _ignore_event,
     ) -> None:
         super().__init__(store, factory, emit=emit)
         self.field_id = field_id
         self.phase_duration = phase_duration
         self.external_effect_adapter = external_effect_adapter
+        if external_effect_adapter is not None:
+            if isinstance(max_elapsed_seconds, bool):
+                raise ValueError("max_elapsed_seconds must be a finite positive float")
+            try:
+                import math
+
+                valid_window = float(max_elapsed_seconds)
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    "max_elapsed_seconds must be a finite positive float"
+                ) from error
+            if not math.isfinite(valid_window) or valid_window <= 0.0:
+                raise ValueError("max_elapsed_seconds must be a finite positive float")
+            self.max_elapsed_seconds = valid_window
+        else:
+            # The local policy is external-adapter-only.  Retain the value for
+            # introspection while leaving the historical dummy path untouched.
+            self.max_elapsed_seconds = max_elapsed_seconds
 
     @property
     def capabilities(self) -> tuple[str, ...]:
@@ -1221,18 +1255,101 @@ class DummyRobotService(RuntimeService):
         external_device_id = self._external_device_id()
         external_mode = self.external_effect_adapter is not None
         effect_key = f"press:{contract.operation_id}:{contract.contract_revision}"
-        accepted_now = self.store.accept_contract(
-            contract_id=contract.contract_id,
-            contract_revision=contract.contract_revision,
-            operation_id=contract.operation_id,
-            task_id=assignment.task_id,
-            effect_key=effect_key,
-            accepted_at=self.clock.now(),
+        existing_journal = self.store.find_execution_journal(
+            contract.contract_id, contract.contract_revision
         )
+        legacy_classification = self.store.budget_legacy_classification(
+            contract.contract_id, contract.contract_revision
+        )
+        if legacy_classification == LEGACY_UNBUDGETED_HOLD:
+            self._complete_budget_denial(
+                envelope,
+                operation_id=contract.operation_id,
+                reason=LEGACY_UNBUDGETED_HOLD,
+                previous_state=ContractState.ACCEPTED,
+            )
+            return
+        if not external_mode and self.store.find_autonomy_budget(
+            contract.contract_id, contract.contract_revision
+        ) is not None:
+            raise RecordConflictError(
+                "durable external autonomy budget requires its original adapter"
+            )
+        # A pre-v4 dispatch without a durable device identity cannot be
+        # admitted as a new budget.  Let the immutable recovery guard below
+        # reject an injected adapter with the historical, precise reason.
+        historical_dispatch_without_device = (
+            existing_journal is not None
+            and existing_journal["dispatch_recorded_at"] is not None
+            and existing_journal["dispatch_device_id"] is None
+        )
+        if (
+            external_mode
+            and legacy_classification != LEGACY_OBSERVE_ONLY
+            and not historical_dispatch_without_device
+        ):
+            try:
+                accepted_now = self.store.admit_external_budget_contract(
+                    contract_id=contract.contract_id,
+                    contract_revision=contract.contract_revision,
+                    operation_id=contract.operation_id,
+                    task_id=assignment.task_id,
+                    effect_key=effect_key,
+                    accepted_at=self.clock.now(),
+                    max_elapsed_seconds=self.max_elapsed_seconds,
+                )
+            except BudgetScopeConflictError as error:
+                self._complete_budget_denial(
+                    envelope,
+                    operation_id=contract.operation_id,
+                    reason=BUDGET_SCOPE_CONFLICT,
+                    previous_state=ContractState.RECEIVED,
+                )
+                self.emit(
+                    "robot.contract_held",
+                    {
+                        "contract_id": str(contract.contract_id),
+                        "reason": BUDGET_SCOPE_CONFLICT,
+                        "bound_contract_id": error.bound_contract_id,
+                    },
+                )
+                return
+        elif external_mode:
+            # A v3 dispatch with a durable device identity has no policy
+            # snapshot.  Migration marks it observe-only; skip admission and
+            # all current-policy comparisons during replay/recovery.
+            accepted_now = False
+        else:
+            accepted_now = self.store.accept_contract(
+                contract_id=contract.contract_id,
+                contract_revision=contract.contract_revision,
+                operation_id=contract.operation_id,
+                task_id=assignment.task_id,
+                effect_key=effect_key,
+                accepted_at=self.clock.now(),
+            )
+            # Recheck after the atomic journal admission as another Robot
+            # process may have admitted this contract's external budget between
+            # the initial read above and this transaction.
+            if self.store.find_autonomy_budget(
+                contract.contract_id, contract.contract_revision
+            ) is not None:
+                raise RecordConflictError(
+                    "durable external autonomy budget requires its original adapter"
+                )
         journal = self._journal(contract)
         self._assert_external_dispatch_configuration(journal, external_device_id)
         if journal["state"] in {state.value for state in TERMINAL_STATES}:
-            self._enqueue_terminal_replay(envelope, journal)
+            if external_mode and journal["dispatch_recorded_at"] is None:
+                denial_event = self.store.budget_denial_event(
+                    contract.contract_id, contract.contract_revision
+                )
+                if denial_event is not None:
+                    self._enqueue_if_absent(denial_event)
+                else:
+                    self._enqueue_terminal_replay(envelope, journal)
+            else:
+                self._enqueue_terminal_replay(envelope, journal)
             self.store.complete_inbox(
                 envelope.message_id,
                 processed_at=self.clock.now(),
@@ -1253,6 +1370,74 @@ class DummyRobotService(RuntimeService):
                 ),
             )
         dispatch_recorded_now = False
+        if external_mode:
+            if journal["state"] == ContractState.ACCEPTED.value:
+                try:
+                    dispatch_recorded_now = self.store.reserve_external_dispatch_with_budget(
+                        contract.contract_id,
+                        contract.contract_revision,
+                        recorded_at=self.clock.now(),
+                        device_id=external_device_id or "",
+                        max_elapsed_seconds=self.max_elapsed_seconds,
+                    )
+                except (
+                    BudgetPolicyConflictError,
+                    BudgetDeadlineError,
+                    BudgetLimitError,
+                ) as error:
+                    reason = self._budget_denial_reason(error)
+                    self._complete_budget_denial(
+                        envelope,
+                        operation_id=contract.operation_id,
+                        reason=reason,
+                        previous_state=ContractState.ACCEPTED,
+                    )
+                    self.emit(
+                        "robot.contract_held",
+                        {"contract_id": str(contract.contract_id), "reason": reason},
+                    )
+                    return
+                journal = self._journal(contract)
+                self._enqueue_transition(
+                    envelope,
+                    ContractState.ACCEPTED,
+                    ContractState.DISPATCH_RECORDED,
+                    ordinal=2,
+                    occurred_at=_durable_timestamp(
+                        journal["dispatch_recorded_at"],
+                        field_name="dispatch_recorded_at",
+                    ),
+                )
+                invocation_id = uuid5(
+                    NAMESPACE_URL,
+                    f"dtt-skill:{contract.contract_id}:{contract.contract_revision}",
+                )
+                invocation = {
+                    "invocation_id": str(invocation_id),
+                    "skill": OperationType.PRESS_BUTTON.value,
+                    "target_entity_id": "dummy-button-1",
+                }
+                self.store.append_execution_audit(
+                    contract.contract_id,
+                    contract.contract_revision,
+                    event_type="skill-invocation",
+                    metadata=invocation,
+                    recorded_at=self.clock.now(),
+                )
+                self.emit(
+                    "robot.skill_invoked",
+                    {"contract_id": str(contract.contract_id), **invocation},
+                )
+            journal = self._journal(contract)
+            self._assert_external_dispatch_configuration(journal, external_device_id)
+            await self._process_external_contract(
+                envelope,
+                effect_key=effect_key,
+                dispatch_recorded_now=dispatch_recorded_now,
+                expected_device_id=external_device_id,
+            )
+            return
+
         if journal["state"] == ContractState.ACCEPTED.value:
             dispatch_recorded_now = self.store.record_dispatch(
                 contract.contract_id,
@@ -1266,14 +1451,6 @@ class DummyRobotService(RuntimeService):
                 ContractState.ACCEPTED,
                 ContractState.DISPATCH_RECORDED,
                 ordinal=2,
-                occurred_at=(
-                    _durable_timestamp(
-                        journal["dispatch_recorded_at"],
-                        field_name="dispatch_recorded_at",
-                    )
-                    if external_mode
-                    else None
-                ),
             )
             invocation_id = uuid5(
                 NAMESPACE_URL,
@@ -1295,17 +1472,6 @@ class DummyRobotService(RuntimeService):
                 "robot.skill_invoked",
                 {"contract_id": str(contract.contract_id), **invocation},
             )
-
-        if self.external_effect_adapter is not None:
-            journal = self._journal(contract)
-            self._assert_external_dispatch_configuration(journal, external_device_id)
-            await self._process_external_contract(
-                envelope,
-                effect_key=effect_key,
-                dispatch_recorded_now=dispatch_recorded_now,
-                expected_device_id=external_device_id,
-            )
-            return
 
         self._enqueue_transition(
             envelope,
@@ -1394,6 +1560,46 @@ class DummyRobotService(RuntimeService):
                 "an external effect adapter must expose a non-empty string device_id"
             )
         return device_id
+
+    @staticmethod
+    def _budget_denial_reason(error: Exception) -> str:
+        if isinstance(error, BudgetPolicyConflictError):
+            return BUDGET_POLICY_CONFLICT
+        if isinstance(error, BudgetDeadlineError):
+            return BUDGET_DEADLINE_EXPIRED
+        if isinstance(error, BudgetLimitError):
+            return BUDGET_LIMIT_EXHAUSTED
+        raise TypeError(f"unsupported budget denial: {type(error).__name__}")
+
+    def _complete_budget_denial(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        operation_id: UUID,
+        reason: str,
+        previous_state: ContractState,
+    ) -> None:
+        contract = envelope.payload
+        if not isinstance(contract, ExecutionContract):
+            raise ValueError("budget denial requires an execution contract envelope")
+        denial_at = self.clock.now()
+        held_event = self._transition(
+            envelope,
+            previous_state,
+            ContractState.HELD,
+            ordinal=1 if previous_state is ContractState.RECEIVED else 4,
+            occurred_at=denial_at,
+        )
+        self.store.complete_budget_scope_denial(
+            contract.contract_id,
+            contract.contract_revision,
+            operation_id=operation_id,
+            reason=reason,
+            first_envelope=envelope,
+            held_event=held_event,
+            inbox_message_id=envelope.message_id,
+            processed_at=denial_at,
+        )
 
     def _assert_external_dispatch_configuration(
         self, journal: Mapping[str, Any], expected_device_id: str | None
@@ -1721,6 +1927,11 @@ class DummyRobotService(RuntimeService):
         contract = cause.payload
         assert isinstance(contract, ExecutionContract)
         terminal = ContractState(str(journal["state"]))
+        previous_state = (
+            ContractState.ACCEPTED
+            if terminal is ContractState.HELD and journal.get("dispatch_recorded_at") is None
+            else ContractState.RUNNING
+        )
         replay_id = uuid5(NAMESPACE_URL, f"dtt-replay:{cause.message_id}:{terminal.value}")
         replay = self.factory.make(
             "execution.event",
@@ -1730,7 +1941,7 @@ class DummyRobotService(RuntimeService):
                 event_id=replay_id,
                 contract_id=contract.contract_id,
                 contract_revision=contract.contract_revision,
-                previous_state=ContractState.RUNNING,
+                previous_state=previous_state,
                 next_state=terminal,
                 occurred_at=datetime.fromisoformat(
                     str(journal["terminal_at"]).replace("Z", "+00:00")

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -8,10 +8,11 @@ make a future external physical action exactly-once.
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -25,7 +26,7 @@ from deferred_teleop.external_effect import (
 )
 from deferred_teleop.protocol import ContractState, ExecutionEvent, MessageEnvelope
 
-CURRENT_SCHEMA_VERSION = 3
+CURRENT_SCHEMA_VERSION = 4
 DEFAULT_BUSY_TIMEOUT_MS = 5_000
 TERMINAL_STATES = frozenset(
     {
@@ -55,6 +56,52 @@ class RecordConflictError(StorageError):
 
 class InvalidStateTransitionError(StorageError):
     """A requested durable state transition is illegal."""
+
+
+class BudgetError(StorageError):
+    """Base class for a durable external-action budget decision."""
+
+
+class BudgetPolicyConflictError(BudgetError, RecordConflictError):
+    """The restart policy differs from the immutable persisted snapshot."""
+
+
+class BudgetScopeConflictError(BudgetError, RecordConflictError):
+    """Another contract already owns the operation budget scope."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        operation_id: str | None = None,
+        bound_contract_id: str | None = None,
+        bound_contract_revision: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.operation_id = operation_id
+        self.bound_contract_id = bound_contract_id
+        self.bound_contract_revision = bound_contract_revision
+
+
+class BudgetDeadlineError(BudgetError):
+    """The local service-clock budget window has elapsed before dispatch."""
+
+
+class BudgetClockRollbackError(BudgetError):
+    """The trusted service clock is behind a durable budget timestamp."""
+
+
+class BudgetLimitError(BudgetError):
+    """The durable one-attempt, one-action reservation is already consumed."""
+
+
+LEGACY_OBSERVE_ONLY = "LEGACY_OBSERVE_ONLY"
+LEGACY_UNBUDGETED_HOLD = "LEGACY_UNBUDGETED_HOLD"
+BUDGET_SCOPE_CONFLICT = "BUDGET_SCOPE_CONFLICT"
+BUDGET_POLICY_CONFLICT = "BUDGET_POLICY_CONFLICT"
+BUDGET_DEADLINE_EXPIRED = "BUDGET_DEADLINE_EXPIRED"
+BUDGET_CLOCK_ROLLBACK = "BUDGET_CLOCK_ROLLBACK"
+BUDGET_LIMIT_EXHAUSTED = "BUDGET_LIMIT_EXHAUSTED"
 
 
 def _utc_text(value: datetime) -> str:
@@ -97,6 +144,29 @@ def _result_json(result: Mapping[str, Any]) -> str:
     if not isinstance(json.loads(encoded), dict):
         raise ValueError("terminal results must be JSON objects")
     return encoded
+
+
+def _validate_budget_policy(
+    *,
+    attempt_limit: int,
+    action_limit: int,
+    max_elapsed_seconds: float,
+) -> float:
+    """Validate the deliberately narrow local external-action policy."""
+
+    if type(attempt_limit) is not int or attempt_limit != 1:
+        raise ValueError("external autonomy attempt_limit must be the literal 1")
+    if type(action_limit) is not int or action_limit != 1:
+        raise ValueError("external autonomy action_limit must be the literal 1")
+    if isinstance(max_elapsed_seconds, bool):
+        raise ValueError("max_elapsed_seconds must be a finite positive float")
+    try:
+        value = float(max_elapsed_seconds)
+    except (TypeError, ValueError) as error:
+        raise ValueError("max_elapsed_seconds must be a finite positive float") from error
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError("max_elapsed_seconds must be a finite positive float")
+    return value
 
 
 def _configure(connection: sqlite3.Connection, busy_timeout_ms: int) -> None:
@@ -197,7 +267,114 @@ def _migration_3(connection: sqlite3.Connection) -> None:
     )
 
 
-MIGRATIONS = {1: _migration_1, 2: _migration_2, 3: _migration_3}
+def _migration_4(connection: sqlite3.Connection) -> None:
+    """Add the Robot-local budget and classify pre-budget journal records.
+
+    Migration deliberately records only facts already present in the v3
+    journal.  It never creates an authorization or a retrospective budget
+    reservation for an old record.
+    """
+
+    connection.execute(
+        """
+        CREATE TABLE autonomy_budget (
+            operation_id TEXT PRIMARY KEY,
+            bound_contract_id TEXT NOT NULL,
+            bound_contract_revision INTEGER NOT NULL CHECK (bound_contract_revision = 1),
+            effect_key TEXT NOT NULL,
+            attempt_limit INTEGER NOT NULL CHECK (attempt_limit = 1),
+            action_limit INTEGER NOT NULL CHECK (action_limit = 1),
+            max_elapsed_seconds REAL NOT NULL CHECK (
+                max_elapsed_seconds > 0.0
+                AND max_elapsed_seconds < 1.7976931348623157e308
+            ),
+            window_started_at TEXT NOT NULL,
+            deadline_at TEXT NOT NULL,
+            clock_high_water_at TEXT NOT NULL,
+            attempts_reserved INTEGER NOT NULL CHECK (attempts_reserved IN (0, 1)),
+            actions_reserved INTEGER NOT NULL CHECK (actions_reserved IN (0, 1)),
+            dispatch_reserved_at TEXT,
+            resolution TEXT,
+            FOREIGN KEY (bound_contract_id, bound_contract_revision)
+                REFERENCES execution_journal (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE autonomy_budget_legacy (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL,
+            operation_id TEXT NOT NULL,
+            classification TEXT NOT NULL CHECK (
+                classification IN ('LEGACY_OBSERVE_ONLY', 'LEGACY_UNBUDGETED_HOLD')
+            ),
+            marked_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision),
+            FOREIGN KEY (contract_id, contract_revision)
+                REFERENCES execution_journal (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE autonomy_budget_denial (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL,
+            operation_id TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            first_envelope_json TEXT NOT NULL,
+            held_event_json TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX autonomy_budget_operation_idx
+            ON autonomy_budget (operation_id)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX autonomy_budget_legacy_operation_idx
+            ON autonomy_budget_legacy (operation_id)
+        """
+    )
+
+    marked_at = _now_text()
+    connection.execute(
+        """
+        INSERT INTO autonomy_budget_legacy (
+            contract_id, contract_revision, operation_id, classification, marked_at
+        )
+        SELECT contract_id, contract_revision, operation_id, ?, ?
+        FROM execution_journal
+        WHERE dispatch_recorded_at IS NOT NULL
+          AND dispatch_device_id IS NOT NULL
+        """,
+        (LEGACY_OBSERVE_ONLY, marked_at),
+    )
+    connection.execute(
+        """
+        INSERT INTO autonomy_budget_legacy (
+            contract_id, contract_revision, operation_id, classification, marked_at
+        )
+        SELECT journal.contract_id, journal.contract_revision, journal.operation_id, ?, ?
+        FROM execution_journal AS journal
+        WHERE journal.state = 'ACCEPTED'
+          AND NOT EXISTS (
+              SELECT 1 FROM autonomy_budget_legacy AS legacy
+              WHERE legacy.contract_id = journal.contract_id
+                AND legacy.contract_revision = journal.contract_revision
+          )
+        """,
+        (LEGACY_UNBUDGETED_HOLD, marked_at),
+    )
+
+
+MIGRATIONS = {1: _migration_1, 2: _migration_2, 3: _migration_3, 4: _migration_4}
 
 
 def initialize_database(
@@ -500,6 +677,597 @@ class NodeStore:
             )
             return True
 
+    def find_execution_journal(
+        self, contract_id: UUID, contract_revision: int
+    ) -> dict[str, Any] | None:
+        """Return one journal row without changing durable state."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM execution_journal
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def budget_legacy_classification(
+        self, contract_id: UUID, contract_revision: int
+    ) -> str | None:
+        row = self._connection.execute(
+            """
+            SELECT classification FROM autonomy_budget_legacy
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        return str(row["classification"]) if row is not None else None
+
+    def find_autonomy_budget(
+        self, contract_id: UUID, contract_revision: int
+    ) -> dict[str, Any] | None:
+        """Return the budget bound to one contract, without changing it."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM autonomy_budget
+            WHERE bound_contract_id = ? AND bound_contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def admit_external_budget_contract(
+        self,
+        *,
+        contract_id: UUID,
+        contract_revision: int,
+        operation_id: UUID,
+        task_id: UUID,
+        effect_key: str,
+        accepted_at: datetime,
+        max_elapsed_seconds: float,
+        attempt_limit: int = 1,
+        action_limit: int = 1,
+    ) -> bool:
+        """Admit one rev-1 external contract and snapshot its local policy.
+
+        The operation scope check runs before the unique ``effect_key`` insert.
+        A repeated immutable contract returns ``False``; a different contract
+        for the operation raises :class:`BudgetScopeConflictError` without
+        creating a second journal row.
+        """
+
+        policy_seconds = _validate_budget_policy(
+            attempt_limit=attempt_limit,
+            action_limit=action_limit,
+            max_elapsed_seconds=max_elapsed_seconds,
+        )
+        if contract_revision != 1:
+            raise ValueError("external autonomy budget admits contract revision 1 only")
+        if not isinstance(effect_key, str) or not effect_key.strip():
+            raise ValueError("effect_key must be a non-empty string")
+        accepted_text = _utc_text(accepted_at)
+        try:
+            deadline_text = _utc_text(
+                accepted_at + timedelta(seconds=policy_seconds)
+            )
+        except (OverflowError, ValueError) as error:
+            raise ValueError("max_elapsed_seconds produces an invalid deadline") from error
+        operation_text = str(operation_id)
+        contract_text = str(contract_id)
+        task_text = str(task_id)
+
+        with self._transaction() as connection:
+            budget = connection.execute(
+                "SELECT * FROM autonomy_budget WHERE operation_id = ?",
+                (operation_text,),
+            ).fetchone()
+            if budget is not None:
+                if (
+                    budget["bound_contract_id"] != contract_text
+                    or int(budget["bound_contract_revision"]) != contract_revision
+                ):
+                    raise BudgetScopeConflictError(
+                        f"operation_id already bound to contract {budget['bound_contract_id']}"
+                        f":{budget['bound_contract_revision']}",
+                        operation_id=operation_text,
+                        bound_contract_id=str(budget["bound_contract_id"]),
+                        bound_contract_revision=int(budget["bound_contract_revision"]),
+                    )
+                journal = self._journal_row(connection, contract_id, contract_revision)
+                immutable = (operation_text, task_text, effect_key)
+                if (
+                    str(journal["operation_id"]),
+                    str(journal["task_id"]),
+                    str(journal["effect_key"]),
+                ) != immutable:
+                    raise RecordConflictError("contract revision collision")
+                return False
+
+            prior_denial = connection.execute(
+                """
+                SELECT operation_id FROM autonomy_budget_denial
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, contract_revision),
+            ).fetchone()
+            if prior_denial is not None:
+                if str(prior_denial["operation_id"]) != operation_text:
+                    raise RecordConflictError("budget denial contract collision")
+                raise BudgetScopeConflictError(
+                    "contract was already denied for its operation scope",
+                    operation_id=operation_text,
+                )
+
+            # The budget table is not the only possible historical owner.  A
+            # v3 journal (or a non-external journal) can already claim this
+            # operation; inspect it before touching the effect-key UNIQUE
+            # constraint so the result remains an explicit scope conflict.
+            operation_journal = connection.execute(
+                """
+                SELECT contract_id, contract_revision, operation_id, task_id, effect_key
+                FROM execution_journal WHERE operation_id = ?
+                ORDER BY contract_revision, contract_id LIMIT 1
+                """,
+                (operation_text,),
+            ).fetchone()
+            if operation_journal is not None:
+                if (
+                    operation_journal["contract_id"] != contract_text
+                    or int(operation_journal["contract_revision"]) != contract_revision
+                ):
+                    raise BudgetScopeConflictError(
+                        "operation_id is already owned by another contract",
+                        operation_id=operation_text,
+                        bound_contract_id=str(operation_journal["contract_id"]),
+                        bound_contract_revision=int(operation_journal["contract_revision"]),
+                    )
+                immutable = (operation_text, task_text, effect_key)
+                if (
+                    str(operation_journal["operation_id"]),
+                    str(operation_journal["task_id"]),
+                    str(operation_journal["effect_key"]),
+                ) != immutable:
+                    raise RecordConflictError("contract revision collision")
+                # A journal without a budget is a historical/corrupt state.
+                # Migration marks all legitimate v3 cases, so never invent a
+                # fresh authorization here.
+                raise RecordConflictError(
+                    "external contract journal has no durable autonomy budget"
+                )
+
+            # This final check handles a same contract identifier whose
+            # operation differs, while still preserving the operation-scope
+            # ordering above.
+            existing_contract = connection.execute(
+                """
+                SELECT operation_id, task_id, effect_key FROM execution_journal
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, contract_revision),
+            ).fetchone()
+            if existing_contract is not None:
+                if (
+                    str(existing_contract["operation_id"]),
+                    str(existing_contract["task_id"]),
+                    str(existing_contract["effect_key"]),
+                ) != (operation_text, task_text, effect_key):
+                    raise RecordConflictError("contract revision collision")
+                raise RecordConflictError(
+                    "external contract journal has no durable autonomy budget"
+                )
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO execution_journal (
+                        contract_id, contract_revision, operation_id, task_id, state,
+                        effect_key, accepted_at
+                    ) VALUES (?, ?, ?, ?, 'ACCEPTED', ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        contract_revision,
+                        operation_text,
+                        task_text,
+                        effect_key,
+                        accepted_text,
+                    ),
+                )
+            except sqlite3.IntegrityError as error:
+                # A concurrent/previous effect-key claim is still surfaced as
+                # a record conflict.  Operation scope was checked first.
+                raise RecordConflictError(f"effect_key already claimed: {effect_key}") from error
+            connection.execute(
+                """
+                INSERT INTO autonomy_budget (
+                    operation_id, bound_contract_id, bound_contract_revision, effect_key,
+                    attempt_limit, action_limit, max_elapsed_seconds,
+                    window_started_at, deadline_at, clock_high_water_at,
+                    attempts_reserved, actions_reserved, dispatch_reserved_at, resolution
+                ) VALUES (?, ?, ?, ?, 1, 1, ?, ?, ?, ?, 0, 0, NULL, NULL)
+                """,
+                (
+                    operation_text,
+                    contract_text,
+                    contract_revision,
+                    effect_key,
+                    policy_seconds,
+                    accepted_text,
+                    deadline_text,
+                    accepted_text,
+                ),
+            )
+        return True
+
+    def reserve_external_dispatch_with_budget(
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        recorded_at: datetime,
+        device_id: str,
+        max_elapsed_seconds: float,
+        attempt_limit: int = 1,
+        action_limit: int = 1,
+    ) -> bool:
+        """Reserve the sole external action and record dispatch atomically.
+
+        The SQLite transaction commits the reservation, device identity, and
+        ``DISPATCH_RECORDED`` boundary together.  The caller may invoke the
+        physical adapter only after this method returns ``True``.
+        """
+
+        policy_seconds = _validate_budget_policy(
+            attempt_limit=attempt_limit,
+            action_limit=action_limit,
+            max_elapsed_seconds=max_elapsed_seconds,
+        )
+        if not isinstance(device_id, str) or not device_id.strip():
+            raise ValueError("device_id must be a non-empty string")
+        recorded_text = _utc_text(recorded_at)
+
+        with self._transaction() as connection:
+            journal = self._journal_row(connection, contract_id, contract_revision)
+            if journal["dispatch_recorded_at"] is not None:
+                stored_device_id = journal["dispatch_device_id"]
+                if stored_device_id != device_id:
+                    raise RecordConflictError(
+                        "dispatch device identity is immutable and does not match"
+                    )
+                return False
+            if journal["state"] != ContractState.ACCEPTED.value:
+                if journal["state"] in TERMINAL_STATES:
+                    return False
+                raise InvalidStateTransitionError(
+                    "external budget reservation requires ACCEPTED state"
+                )
+            budget = connection.execute(
+                "SELECT * FROM autonomy_budget WHERE operation_id = ?",
+                (str(journal["operation_id"]),),
+            ).fetchone()
+            if budget is None:
+                raise RecordConflictError(
+                    "external contract has no durable autonomy budget"
+                )
+            if (
+                budget["bound_contract_id"] != str(contract_id)
+                or int(budget["bound_contract_revision"]) != contract_revision
+                or budget["effect_key"] != journal["effect_key"]
+            ):
+                raise BudgetScopeConflictError(
+                    "autonomy budget binding does not match contract",
+                    operation_id=str(journal["operation_id"]),
+                    bound_contract_id=str(budget["bound_contract_id"]),
+                    bound_contract_revision=int(budget["bound_contract_revision"]),
+                )
+            if (
+                int(budget["attempt_limit"]) != attempt_limit
+                or int(budget["action_limit"]) != action_limit
+                or float(budget["max_elapsed_seconds"]) != policy_seconds
+            ):
+                raise BudgetPolicyConflictError(
+                    BUDGET_POLICY_CONFLICT
+                    + ": configured external autonomy policy differs from durable snapshot"
+                )
+            if int(budget["attempts_reserved"]) != 0 or int(budget["actions_reserved"]) != 0:
+                raise BudgetLimitError(BUDGET_LIMIT_EXHAUSTED)
+
+            accepted_at = _parse_utc_text(journal["accepted_at"], field_name="accepted_at")
+            high_water_at = _parse_utc_text(
+                budget["clock_high_water_at"], field_name="clock_high_water_at"
+            )
+            deadline_at = _parse_utc_text(
+                budget["deadline_at"], field_name="deadline_at"
+            )
+            if recorded_at < accepted_at or recorded_at < high_water_at:
+                raise BudgetClockRollbackError(
+                    BUDGET_CLOCK_ROLLBACK
+                    + ": trusted service clock is earlier than durable budget time"
+                )
+            if recorded_at >= deadline_at:
+                raise BudgetDeadlineError(
+                    BUDGET_DEADLINE_EXPIRED
+                    + ": service-clock budget window has elapsed"
+                )
+
+            connection.execute(
+                """
+                UPDATE autonomy_budget
+                SET attempts_reserved = 1, actions_reserved = 1,
+                    dispatch_reserved_at = ?, clock_high_water_at = ?
+                WHERE operation_id = ?
+                """,
+                (recorded_text, recorded_text, str(journal["operation_id"])),
+            )
+            connection.execute(
+                """
+                UPDATE execution_journal
+                SET state = 'DISPATCH_RECORDED', dispatch_recorded_at = ?,
+                    dispatch_device_id = ?
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (
+                    recorded_text,
+                    device_id,
+                    str(contract_id),
+                    contract_revision,
+                ),
+            )
+        return True
+
+    def budget_denial_event(
+        self, contract_id: UUID, contract_revision: int
+    ) -> MessageEnvelope | None:
+        """Return the exact durable HELD event for a budget denial, if any."""
+
+        row = self._connection.execute(
+            """
+            SELECT held_event_json FROM autonomy_budget_denial
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._decode_envelope(
+            "autonomy_budget_denial", f"{contract_id}:{contract_revision}", row["held_event_json"]
+        )
+
+    def complete_budget_scope_denial(
+        self,
+        contract_id: UUID,
+        contract_revision: int,
+        *,
+        operation_id: UUID,
+        reason: str,
+        first_envelope: MessageEnvelope,
+        held_event: MessageEnvelope,
+        inbox_message_id: UUID,
+        processed_at: datetime,
+    ) -> bool:
+        """Persist a pre-dispatch denial, its stable HELD event, and inbox completion.
+
+        The method also serves the legacy ``ACCEPTED`` migration hold.  It is
+        intentionally named for the scope-denial call site because the scope
+        conflict must be handled before a second journal insert.  Existing
+        denial rows always reuse their original canonical event bytes.
+        """
+
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("budget denial reason must not be empty")
+        if not isinstance(first_envelope, MessageEnvelope):
+            raise ValueError("first_envelope must be a MessageEnvelope")
+        if first_envelope.message_id != inbox_message_id:
+            raise RecordConflictError(
+                "budget denial first envelope must be the claimed inbox message"
+            )
+        first_payload = first_envelope.payload
+        if (
+            not hasattr(first_payload, "contract_id")
+            or first_payload.contract_id != contract_id
+            or getattr(first_payload, "contract_revision", None) != contract_revision
+            or getattr(first_payload, "operation_id", None) != operation_id
+        ):
+            raise RecordConflictError(
+                "budget denial first envelope does not match contract or operation"
+            )
+        if not isinstance(held_event, MessageEnvelope):
+            raise ValueError("held_event must be a MessageEnvelope")
+        event = held_event.payload
+        if not isinstance(event, ExecutionEvent):
+            raise ValueError("held_event must contain an ExecutionEvent")
+        if (
+            event.contract_id != contract_id
+            or event.contract_revision != contract_revision
+            or event.next_state is not ContractState.HELD
+            or event.previous_state not in {ContractState.RECEIVED, ContractState.ACCEPTED}
+        ):
+            raise RecordConflictError("budget denial event does not match pre-dispatch hold")
+        operation_text = str(operation_id)
+        contract_text = str(contract_id)
+        first_encoded = _envelope_json(first_envelope)
+        candidate_encoded = _envelope_json(held_event)
+        event_occurred_text = _utc_text(event.occurred_at)
+        processed_text = _utc_text(processed_at)
+
+        with self._transaction() as connection:
+            inbox = connection.execute(
+                "SELECT processing_state FROM inbox WHERE message_id = ?",
+                (str(inbox_message_id),),
+            ).fetchone()
+            if inbox is None or inbox["processing_state"] != "PROCESSING":
+                raise InvalidStateTransitionError("only PROCESSING inbox messages can complete")
+
+            journal = connection.execute(
+                """
+                SELECT * FROM execution_journal
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, contract_revision),
+            ).fetchone()
+            if journal is not None:
+                if str(journal["operation_id"]) != operation_text:
+                    raise RecordConflictError("budget denial operation does not match journal")
+                if journal["dispatch_recorded_at"] is not None:
+                    raise InvalidStateTransitionError(
+                        "budget denial cannot follow durable dispatch"
+                    )
+                if journal["state"] not in {
+                    ContractState.ACCEPTED.value,
+                    ContractState.HELD.value,
+                }:
+                    raise InvalidStateTransitionError(
+                        "budget denial requires ACCEPTED or HELD journal state"
+                    )
+                if (
+                    journal["state"] == ContractState.ACCEPTED.value
+                    and event.previous_state is not ContractState.ACCEPTED
+                ):
+                    raise InvalidStateTransitionError(
+                        "an ACCEPTED journal requires an ACCEPTED -> HELD denial"
+                    )
+                accepted_at = _parse_utc_text(
+                    journal["accepted_at"], field_name="accepted_at"
+                )
+                if event.occurred_at < accepted_at:
+                    raise BudgetClockRollbackError(
+                        BUDGET_CLOCK_ROLLBACK
+                        + ": denial timestamp is earlier than durable acceptance"
+                    )
+            if processed_at < event.occurred_at:
+                raise BudgetClockRollbackError(
+                    BUDGET_CLOCK_ROLLBACK
+                    + ": inbox completion precedes denial timestamp"
+                )
+
+            existing = connection.execute(
+                """
+                SELECT operation_id, reason, first_envelope_json, held_event_json
+                FROM autonomy_budget_denial
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, contract_revision),
+            ).fetchone()
+            if existing is None:
+                denial_first_encoded = first_encoded
+                denial_event_encoded = candidate_encoded
+                connection.execute(
+                    """
+                    INSERT INTO autonomy_budget_denial (
+                        contract_id, contract_revision, operation_id, reason,
+                        first_envelope_json, held_event_json, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        contract_revision,
+                        operation_text,
+                        reason,
+                        denial_first_encoded,
+                        denial_event_encoded,
+                        processed_text,
+                    ),
+                )
+            else:
+                if str(existing["operation_id"]) != operation_text:
+                    raise RecordConflictError("budget denial operation collision")
+                if str(existing["reason"]) != reason:
+                    raise RecordConflictError("budget denial reason is immutable")
+                denial_first_encoded = str(existing["first_envelope_json"])
+                denial_event_encoded = str(existing["held_event_json"])
+                # Decode immutable evidence before writing any consequence.
+                durable_first = self._decode_envelope(
+                    "autonomy_budget_denial",
+                    f"{contract_text}:{contract_revision}:first",
+                    denial_first_encoded,
+                )
+                if (
+                    durable_first.message_type != first_envelope.message_type
+                    or durable_first.payload.model_dump(mode="json")
+                    != first_envelope.payload.model_dump(mode="json")
+                ):
+                    raise RecordConflictError(
+                        "budget denial first envelope payload is immutable"
+                    )
+                durable_event = self._decode_envelope(
+                    "autonomy_budget_denial",
+                    f"{contract_text}:{contract_revision}:held",
+                    denial_event_encoded,
+                )
+                durable_payload = durable_event.payload
+                if not isinstance(durable_payload, ExecutionEvent):
+                    raise CorruptRecordError(
+                        f"invalid autonomy budget denial event {contract_text}:{contract_revision}"
+                    )
+
+            if journal is not None and journal["state"] == ContractState.ACCEPTED.value:
+                connection.execute(
+                    """
+                    UPDATE execution_journal
+                    SET state = 'HELD', terminal_at = ?, terminal_result_json = ?
+                    WHERE contract_id = ? AND contract_revision = ?
+                    """,
+                    (
+                        event_occurred_text,
+                        _result_json({"budget_denial": reason}),
+                        contract_text,
+                        contract_revision,
+                    ),
+                )
+            budget = connection.execute(
+                """
+                SELECT operation_id, clock_high_water_at FROM autonomy_budget
+                WHERE operation_id = ? AND bound_contract_id = ?
+                  AND bound_contract_revision = ?
+                """,
+                (operation_text, contract_text, contract_revision),
+            ).fetchone()
+            if budget is not None:
+                current_high_water = _parse_utc_text(
+                    budget["clock_high_water_at"], field_name="clock_high_water_at"
+                )
+                high_water_text = (
+                    event_occurred_text
+                    if event.occurred_at >= current_high_water
+                    else _utc_text(current_high_water)
+                )
+                connection.execute(
+                    """
+                    UPDATE autonomy_budget SET resolution = ?, clock_high_water_at = ?
+                    WHERE operation_id = ? AND bound_contract_id = ?
+                      AND bound_contract_revision = ?
+                    """,
+                    (
+                        reason,
+                        high_water_text,
+                        operation_text,
+                        contract_text,
+                        contract_revision,
+                    ),
+                )
+
+            durable_event = self._decode_envelope(
+                "autonomy_budget_denial",
+                f"{contract_text}:{contract_revision}:held",
+                denial_event_encoded,
+            )
+            self._insert_outbox(connection, durable_event)
+            connection.execute(
+                """
+                UPDATE inbox SET processing_state = 'PROCESSED', processed_at = ?,
+                    handler_result_reference = ?, error_json = NULL
+                WHERE message_id = ?
+                """,
+                (
+                    processed_text,
+                    f"held:{reason}:{contract_text}",
+                    str(inbox_message_id),
+                ),
+            )
+        return existing is None
+
     def accept_contract(
         self,
         *,
@@ -787,6 +1555,37 @@ class NodeStore:
                     contract_revision,
                 ),
             )
+            budget = connection.execute(
+                """
+                SELECT clock_high_water_at FROM autonomy_budget
+                WHERE operation_id = ? AND bound_contract_id = ?
+                  AND bound_contract_revision = ?
+                """,
+                (str(journal["operation_id"]), str(contract_id), contract_revision),
+            ).fetchone()
+            if budget is not None:
+                current_high_water = _parse_utc_text(
+                    budget["clock_high_water_at"], field_name="clock_high_water_at"
+                )
+                high_water_text = (
+                    occurred_text
+                    if occurred_at >= current_high_water
+                    else _utc_text(current_high_water)
+                )
+                connection.execute(
+                    """
+                    UPDATE autonomy_budget SET resolution = ?, clock_high_water_at = ?
+                    WHERE operation_id = ? AND bound_contract_id = ?
+                      AND bound_contract_revision = ?
+                    """,
+                    (
+                        resolution,
+                        high_water_text,
+                        str(journal["operation_id"]),
+                        str(contract_id),
+                        contract_revision,
+                    ),
+                )
         return True
 
     def append_execution_audit(
@@ -826,6 +1625,25 @@ class NodeStore:
     def inspect_execution_journal(self) -> list[dict[str, Any]]:
         return self._rows(
             "SELECT * FROM execution_journal ORDER BY contract_id, contract_revision"
+        )
+
+    def inspect_autonomy_budget(self) -> list[dict[str, Any]]:
+        return self._rows("SELECT * FROM autonomy_budget ORDER BY operation_id")
+
+    def inspect_autonomy_budget_legacy(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM autonomy_budget_legacy
+            ORDER BY operation_id, contract_id, contract_revision
+            """
+        )
+
+    def inspect_autonomy_budget_denials(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM autonomy_budget_denial
+            ORDER BY recorded_at, contract_id, contract_revision
+            """
         )
 
     def inbox_messages(self) -> list[MessageEnvelope]:

--- a/tests/test_autonomy_budget.py
+++ b/tests/test_autonomy_budget.py
@@ -1,0 +1,646 @@
+import asyncio
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from deferred_teleop.external_effect import (
+    ExternalEffectObservation,
+    ExternalOutcome,
+    PersistentDummyExternalEffect,
+)
+from deferred_teleop.protocol import (
+    ContractState,
+    ExecutionEvent,
+    MessageEnvelope,
+)
+from deferred_teleop.runtime import (
+    DummyRobotService,
+    EnvelopeFactory,
+    FieldService,
+    MissionService,
+)
+from deferred_teleop.storage import (
+    BUDGET_CLOCK_ROLLBACK,
+    BUDGET_DEADLINE_EXPIRED,
+    BUDGET_POLICY_CONFLICT,
+    BudgetClockRollbackError,
+    BudgetDeadlineError,
+    NodeStore,
+    RecordConflictError,
+    initialize_database,
+)
+
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+
+
+class VirtualClock:
+    def __init__(self, current: datetime = NOW) -> None:
+        self.current = current
+
+    def now(self) -> datetime:
+        return self.current
+
+    async def sleep(self, seconds: float) -> None:
+        del seconds
+
+
+class CrashAfterPress(PersistentDummyExternalEffect):
+    def __init__(self, path: str | Path, **kwargs: object) -> None:
+        super().__init__(path, **kwargs)
+        self._crash = True
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        result = super().press(effect_key)
+        if self._crash:
+            self._crash = False
+            raise RuntimeError("injected crash after external press")
+        return result
+
+
+class CrashBeforePress(PersistentDummyExternalEffect):
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        del effect_key
+        raise RuntimeError("injected crash before external press")
+
+
+async def _deliver(service, envelope: MessageEnvelope) -> None:
+    if service.store.receive(envelope, received_at=service.clock.now()):
+        await service.handle(envelope)
+
+
+async def _make_chain(tmp_path: Path, clock: VirtualClock):
+    mission_store = NodeStore(tmp_path / "mission.sqlite3")
+    field_store = NodeStore(tmp_path / "field.sqlite3")
+    mission = MissionService(
+        mission_store,
+        EnvelopeFactory("mission-1", clock),
+        configured_one_way_delay=0.0,
+    )
+    field = FieldService(
+        field_store,
+        EnvelopeFactory("field-1", clock),
+        dummy_fixture_compatibility=False,
+    )
+    intent = mission.submit_press_button()
+    await _deliver(field, intent)
+    assignment = next(
+        message
+        for message in field_store.outbox_messages()
+        if message.message_type == "task.assignment"
+    )
+    contract = next(
+        message
+        for message in field_store.outbox_messages()
+        if message.message_type == "execution.contract"
+    )
+    return mission_store, field_store, field, assignment, contract
+
+
+def test_dtt_accepts_only_the_new_pre_dispatch_hold_transition() -> None:
+    event = ExecutionEvent(
+        event_id=uuid4(),
+        contract_id=uuid4(),
+        contract_revision=1,
+        previous_state=ContractState.ACCEPTED,
+        next_state=ContractState.HELD,
+        occurred_at=NOW,
+    )
+    assert event.next_state is ContractState.HELD
+    with pytest.raises(ValueError, match="illegal contract transition"):
+        ExecutionEvent(
+            event_id=uuid4(),
+            contract_id=event.contract_id,
+            contract_revision=1,
+            previous_state=ContractState.ACCEPTED,
+            next_state=ContractState.SUCCEEDED,
+            occurred_at=NOW,
+        )
+
+
+def test_external_budget_is_one_reservation_and_replay_ignores_changed_policy(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                    max_elapsed_seconds=60.0,
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                assert adapter.press_count == 1
+                budget = robot_store.inspect_autonomy_budget()[0]
+                assert budget["attempts_reserved"] == 1
+                assert budget["actions_reserved"] == 1
+                assert budget["attempt_limit"] == 1
+                assert budget["action_limit"] == 1
+                assert budget["resolution"] == "APPLIED"
+
+            with NodeStore(robot_path) as restarted_store:
+                restarted = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                    max_elapsed_seconds=1.0,
+                )
+                duplicate = contract.model_copy(
+                    update={"message_id": uuid4(), "source_sequence": contract.source_sequence + 1}
+                )
+                await _deliver(restarted, duplicate)
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+                assert restarted_store.inspect_autonomy_budget()[0]["actions_reserved"] == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("crash_type", "outcome", "expected_presses", "expected_state"),
+    [
+        (CrashBeforePress, ExternalOutcome.NOT_APPLIED, 0, ContractState.HELD),
+        (CrashAfterPress, ExternalOutcome.UNKNOWN, 1, ContractState.HELD),
+    ],
+    ids=["crash-before-press-after-deadline", "crash-after-press-unknown"],
+)
+def test_reserved_budget_recovers_by_observation_after_restart_and_deadline(
+    tmp_path: Path, crash_type, outcome: ExternalOutcome, expected_presses: int, expected_state
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                crashing = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=crash_type(external_path, clock=clock),
+                    max_elapsed_seconds=1.0,
+                )
+                await _deliver(crashing, assignment)
+                with pytest.raises(RuntimeError):
+                    await _deliver(crashing, contract)
+                assert robot_store.inspect_autonomy_budget()[0]["actions_reserved"] == 1
+
+            clock.current += timedelta(seconds=2)
+            with NodeStore(robot_path) as restarted_store:
+                adapter = PersistentDummyExternalEffect(
+                    external_path,
+                    observation_outcome=outcome,
+                    clock=clock,
+                )
+                restarted = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                    max_elapsed_seconds=60.0,
+                )
+                await restarted.recover()
+                assert adapter.press_count == expected_presses
+                assert restarted_store.inspect_execution_journal()[0]["state"] == (
+                    expected_state.value
+                )
+                assert restarted_store.inspect_autonomy_budget()[0]["actions_reserved"] == 1
+
+    asyncio.run(scenario())
+
+
+def test_deadline_and_clock_rollback_never_reserve_a_new_dispatch(tmp_path: Path) -> None:
+    contract_id = UUID("70000000-0000-4000-8000-000000000001")
+    operation_id = UUID("30000000-0000-4000-8000-000000000001")
+    task_id = UUID("50000000-0000-4000-8000-000000000001")
+    effect_key = f"press:{operation_id}:1"
+    for attempted_at, error_type, code in (
+        (NOW + timedelta(seconds=1), BudgetDeadlineError, BUDGET_DEADLINE_EXPIRED),
+        (NOW - timedelta(seconds=1), BudgetClockRollbackError, BUDGET_CLOCK_ROLLBACK),
+    ):
+        path = tmp_path / f"{error_type.__name__}.sqlite3"
+        with NodeStore(path) as store:
+            assert store.admit_external_budget_contract(
+                contract_id=contract_id,
+                contract_revision=1,
+                operation_id=operation_id,
+                task_id=task_id,
+                effect_key=effect_key,
+                accepted_at=NOW,
+                max_elapsed_seconds=1.0,
+            )
+            with pytest.raises(error_type, match=code):
+                store.reserve_external_dispatch_with_budget(
+                    contract_id,
+                    1,
+                    recorded_at=attempted_at,
+                    device_id="dummy-external-button-1",
+                    max_elapsed_seconds=1.0,
+                )
+            journal = store.inspect_execution_journal()[0]
+            assert journal["state"] == ContractState.ACCEPTED.value
+            assert store.inspect_autonomy_budget()[0]["actions_reserved"] == 0
+
+
+def test_clock_rollback_waits_before_accepted_then_resumes_one_reservation(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                )
+                await _deliver(robot, assignment)
+                assert robot_store.admit_external_budget_contract(
+                    contract_id=contract.payload.contract_id,
+                    contract_revision=1,
+                    operation_id=contract.payload.operation_id,
+                    task_id=assignment.payload.task_id,
+                    effect_key=f"press:{contract.payload.operation_id}:1",
+                    accepted_at=NOW,
+                    max_elapsed_seconds=60.0,
+                )
+
+                clock.current = NOW - timedelta(seconds=10)
+                with pytest.raises(BudgetClockRollbackError):
+                    await _deliver(robot, contract)
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.ACCEPTED.value
+                assert journal["dispatch_recorded_at"] is None
+                assert journal["terminal_at"] is None
+                budget = robot_store.inspect_autonomy_budget()[0]
+                assert budget["attempts_reserved"] == 0
+                assert budget["actions_reserved"] == 0
+                assert adapter.press_count == 0
+
+                clock.current = NOW + timedelta(seconds=1)
+                await robot.recover()
+                assert adapter.press_count == 1
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.SUCCEEDED.value
+                budget = robot_store.inspect_autonomy_budget()[0]
+                assert budget["attempts_reserved"] == 1
+                assert budget["actions_reserved"] == 1
+
+    asyncio.run(scenario())
+
+
+def test_deadline_denial_is_held_without_reservation_or_external_proof(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                    max_elapsed_seconds=60.0,
+                )
+                await _deliver(robot, assignment)
+                assert robot_store.admit_external_budget_contract(
+                    contract_id=contract.payload.contract_id,
+                    contract_revision=1,
+                    operation_id=contract.payload.operation_id,
+                    task_id=assignment.payload.task_id,
+                    effect_key=f"press:{contract.payload.operation_id}:1",
+                    accepted_at=NOW,
+                    max_elapsed_seconds=60.0,
+                )
+                clock.current = NOW + timedelta(seconds=60)
+                await _deliver(robot, contract)
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.HELD.value
+                assert journal["effect_count"] == 0
+                assert journal["dispatch_recorded_at"] is None
+                assert adapter.press_count == 0
+                budget = robot_store.inspect_autonomy_budget()[0]
+                assert budget["attempts_reserved"] == 0
+                assert budget["actions_reserved"] == 0
+                assert budget["resolution"] == BUDGET_DEADLINE_EXPIRED
+                events = [
+                    message.payload
+                    for message in robot_store.outbox_messages()
+                    if isinstance(message.payload, ExecutionEvent)
+                ]
+                assert len(events) == 1
+                assert events[0].previous_state is ContractState.ACCEPTED
+                assert events[0].next_state is ContractState.HELD
+                assert "proof" not in journal["terminal_result_json"]
+
+    asyncio.run(scenario())
+
+
+def test_policy_change_before_dispatch_holds_without_rewriting_snapshot(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                    max_elapsed_seconds=1.0,
+                )
+                await _deliver(robot, assignment)
+                assert robot_store.admit_external_budget_contract(
+                    contract_id=contract.payload.contract_id,
+                    contract_revision=1,
+                    operation_id=contract.payload.operation_id,
+                    task_id=assignment.payload.task_id,
+                    effect_key=f"press:{contract.payload.operation_id}:1",
+                    accepted_at=NOW,
+                    max_elapsed_seconds=60.0,
+                )
+                clock.current = NOW + timedelta(seconds=1)
+                await _deliver(robot, contract)
+                journal = robot_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.HELD.value
+                assert journal["dispatch_recorded_at"] is None
+                assert journal["effect_count"] == 0
+                assert adapter.press_count == 0
+                budget = robot_store.inspect_autonomy_budget()[0]
+                assert budget["max_elapsed_seconds"] == 60.0
+                assert budget["attempts_reserved"] == 0
+                assert budget["actions_reserved"] == 0
+                assert budget["resolution"] == BUDGET_POLICY_CONFLICT
+
+    asyncio.run(scenario())
+
+
+def test_external_budget_never_falls_back_to_dummy_without_adapter(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                await _deliver(
+                    DummyRobotService(
+                        robot_store,
+                        EnvelopeFactory("dummy-robot-1", clock),
+                        external_effect_adapter=PersistentDummyExternalEffect(
+                            tmp_path / "external.jsonl", clock=clock
+                        ),
+                    ),
+                    assignment,
+                )
+                assert robot_store.admit_external_budget_contract(
+                    contract_id=contract.payload.contract_id,
+                    contract_revision=1,
+                    operation_id=contract.payload.operation_id,
+                    task_id=assignment.payload.task_id,
+                    effect_key=f"press:{contract.payload.operation_id}:1",
+                    accepted_at=NOW,
+                    max_elapsed_seconds=60.0,
+                )
+
+            with NodeStore(robot_path) as restarted_store:
+                restarted = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                )
+                with pytest.raises(RecordConflictError, match="requires its original adapter"):
+                    await _deliver(restarted, contract)
+                journal = restarted_store.inspect_execution_journal()[0]
+                assert journal["state"] == ContractState.ACCEPTED.value
+                assert journal["dispatch_recorded_at"] is None
+                assert journal["effect_count"] == 0
+                budget = restarted_store.inspect_autonomy_budget()[0]
+                assert budget["attempts_reserved"] == 0
+                assert budget["actions_reserved"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_scope_conflict_is_durable_and_reuses_exact_held_event_bytes(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        external_path = tmp_path / "external.jsonl"
+        robot_path = tmp_path / "robot.sqlite3"
+        with mission_store, field_store:
+            with NodeStore(robot_path) as robot_store:
+                adapter = PersistentDummyExternalEffect(external_path, clock=clock)
+                robot = DummyRobotService(
+                    robot_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=adapter,
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                conflicting = contract.model_copy(
+                    update={
+                        "message_id": uuid4(),
+                        "source_sequence": contract.source_sequence + 1,
+                        "payload": contract.payload.model_copy(update={"contract_id": uuid4()}),
+                    }
+                )
+                await _deliver(robot, conflicting)
+                first_denial = robot_store.inspect_autonomy_budget_denials()[0]
+                first_event_json = first_denial["held_event_json"]
+                held = robot_store.budget_denial_event(
+                    conflicting.payload.contract_id, conflicting.payload.contract_revision
+                )
+                assert held is not None
+                assert held.payload.previous_state is ContractState.RECEIVED
+                repeat = conflicting.model_copy(
+                    update={
+                        "message_id": uuid4(),
+                        "source_sequence": conflicting.source_sequence + 1,
+                    }
+                )
+                await _deliver(robot, repeat)
+                assert robot_store.inspect_autonomy_budget_denials()[0]["held_event_json"] == (
+                    first_event_json
+                )
+                assert len(robot_store.inspect_execution_journal()) == 1
+                assert adapter.press_count == 1
+
+            with NodeStore(robot_path) as restarted_store:
+                restarted = DummyRobotService(
+                    restarted_store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        external_path, clock=clock
+                    ),
+                )
+                repeat_after_restart = repeat.model_copy(
+                    update={"message_id": uuid4(), "source_sequence": repeat.source_sequence + 1}
+                )
+                await _deliver(restarted, repeat_after_restart)
+                assert restarted_store.inspect_autonomy_budget_denials()[0]["held_event_json"] == (
+                    first_event_json
+                )
+                assert PersistentDummyExternalEffect(external_path, clock=clock).press_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_v3_migration_marks_dispatch_observe_only_and_acceptance_unbudgeted_hold(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        clock = VirtualClock()
+        mission_store, field_store, _field, assignment, contract = await _make_chain(
+            tmp_path, clock
+        )
+        legacy_paths = (
+            (tmp_path / "legacy-dispatch.sqlite3", "DISPATCH_RECORDED", "dummy-external-button-1"),
+            (tmp_path / "legacy-succeeded.sqlite3", "SUCCEEDED", "dummy-external-button-1"),
+            (tmp_path / "legacy-held.sqlite3", "HELD", "dummy-external-button-1"),
+            (tmp_path / "legacy-accepted.sqlite3", "ACCEPTED", None),
+        )
+        effect_key = f"press:{contract.payload.operation_id}:1"
+        for path, state, device_id in legacy_paths:
+            initialize_database(path, target_version=3)
+            with sqlite3.connect(path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO execution_journal (
+                        contract_id, contract_revision, operation_id, task_id, state,
+                        effect_key, effect_count, accepted_at, dispatch_recorded_at,
+                        dispatch_device_id, terminal_at, terminal_result_json
+                    ) VALUES (?, 1, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(contract.payload.contract_id),
+                        str(contract.payload.operation_id),
+                        str(assignment.payload.task_id),
+                        state,
+                        effect_key,
+                        NOW.isoformat().replace("+00:00", "Z"),
+                        (NOW if device_id is not None else None),
+                        device_id,
+                        (
+                            NOW.isoformat().replace("+00:00", "Z")
+                            if state in {"SUCCEEDED", "HELD"}
+                            else None
+                        ),
+                        ("{}" if state in {"SUCCEEDED", "HELD"} else None),
+                    ),
+                )
+        with mission_store, field_store:
+            with NodeStore(legacy_paths[0][0]) as store:
+                assert store.budget_legacy_classification(
+                    contract.payload.contract_id, 1
+                ) == "LEGACY_OBSERVE_ONLY"
+                assert store.inspect_autonomy_budget() == []
+                robot = DummyRobotService(
+                    store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                    external_effect_adapter=PersistentDummyExternalEffect(
+                        tmp_path / "legacy-dispatch.jsonl",
+                        observation_outcome=ExternalOutcome.NOT_APPLIED,
+                        clock=clock,
+                    ),
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                assert store.inspect_execution_journal()[0]["state"] == ContractState.HELD.value
+                assert store.inspect_autonomy_budget() == []
+
+            for path, expected_state in (
+                (legacy_paths[1][0], ContractState.SUCCEEDED),
+                (legacy_paths[2][0], ContractState.HELD),
+            ):
+                with NodeStore(path) as store:
+                    assert store.budget_legacy_classification(
+                        contract.payload.contract_id, 1
+                    ) == "LEGACY_OBSERVE_ONLY"
+                    adapter = PersistentDummyExternalEffect(
+                        tmp_path / f"{expected_state.value.lower()}-legacy.jsonl", clock=clock
+                    )
+                    robot = DummyRobotService(
+                        store,
+                        EnvelopeFactory("dummy-robot-1", clock),
+                        external_effect_adapter=adapter,
+                        max_elapsed_seconds=0.001,
+                    )
+                    await _deliver(robot, assignment)
+                    await _deliver(robot, contract)
+                    assert store.inspect_execution_journal()[0]["state"] == expected_state.value
+                    assert store.inspect_autonomy_budget() == []
+                    assert adapter.press_count == 0
+                    assert adapter.records == ()
+                    replay_events = [
+                        message.payload
+                        for message in store.outbox_messages()
+                        if isinstance(message.payload, ExecutionEvent)
+                    ]
+                    assert len(replay_events) == 1
+                    assert replay_events[0].previous_state is ContractState.RUNNING
+                    assert replay_events[0].next_state is expected_state
+
+            with NodeStore(legacy_paths[3][0]) as store:
+                assert store.budget_legacy_classification(
+                    contract.payload.contract_id, 1
+                ) == "LEGACY_UNBUDGETED_HOLD"
+                robot = DummyRobotService(
+                    store,
+                    EnvelopeFactory("dummy-robot-1", clock),
+                )
+                await _deliver(robot, assignment)
+                await _deliver(robot, contract)
+                row = store.inspect_execution_journal()[0]
+                assert row["state"] == ContractState.HELD.value
+                assert row["effect_count"] == 0
+                assert json.loads(row["terminal_result_json"]) == {
+                    "budget_denial": "LEGACY_UNBUDGETED_HOLD"
+                }
+                assert store.inspect_autonomy_budget() == []
+                events = [
+                    message.payload
+                    for message in store.outbox_messages()
+                    if isinstance(message.payload, ExecutionEvent)
+                ]
+                assert len(events) == 1
+                assert events[0].previous_state is ContractState.ACCEPTED
+                assert events[0].next_state is ContractState.HELD
+                assert "proof" not in row["terminal_result_json"]
+
+    asyncio.run(scenario())

--- a/tests/test_external_effect.py
+++ b/tests/test_external_effect.py
@@ -21,7 +21,12 @@ from deferred_teleop.runtime import (
     dummy_pose,
     evidence,
 )
-from deferred_teleop.storage import NodeStore, RecordConflictError, initialize_database
+from deferred_teleop.storage import (
+    CURRENT_SCHEMA_VERSION,
+    NodeStore,
+    RecordConflictError,
+    initialize_database,
+)
 
 NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
 
@@ -597,7 +602,7 @@ def test_v2_dispatch_without_device_refuses_adapter_and_keeps_legacy_dummy_path(
 
         with mission_store, field_store:
             with NodeStore(robot_path) as robot_store:
-                assert robot_store.schema_version == 3
+                assert robot_store.schema_version == CURRENT_SCHEMA_VERSION
                 adapter = CountingObservationAdapter(
                     device_id="legacy-replacement-device", clock=clock
                 )

--- a/tests/test_external_outcome_storage.py
+++ b/tests/test_external_outcome_storage.py
@@ -13,6 +13,7 @@ from deferred_teleop.external_effect import (
 from deferred_teleop.protocol import ContractState, ExecutionEvent
 from deferred_teleop.runtime import EnvelopeFactory
 from deferred_teleop.storage import (
+    CURRENT_SCHEMA_VERSION,
     InvalidStateTransitionError,
     NodeStore,
     RecordConflictError,
@@ -329,7 +330,7 @@ def test_v2_dispatch_without_device_migrates_and_preserves_legacy_dummy_recovery
     connection.close()
 
     with NodeStore(path) as store:
-        assert store.schema_version == 3
+        assert store.schema_version == CURRENT_SCHEMA_VERSION
         journal = store.inspect_execution_journal()[0]
         assert journal["state"] == ContractState.DISPATCH_RECORDED.value
         assert journal["dispatch_device_id"] is None


### PR DESCRIPTION
An external adapter now receives one durable, revision-1 reservation per operation, with an immutable local policy and a finite dispatch window (60 seconds by default). Admission and dispatch reservation are atomic; restart observes or replays a recorded dispatch without authorizing another press. Pre-dispatch scope, policy and deadline refusals are durable, and clock rollback waits without inventing an early terminal event. Schema v4 conservatively classifies legacy v3 work.

Validation: 152 Python tests pass, including 11 budget cases; Ruff, schema/model/oracle drift checks and the M1 release gate pass. All six historical M1 golden files remain byte-identical. The source and integration documentation received an independent critical review.

This slice requires one active Robot instance per database and external adapter. SQLite does not fence external I/O between competing processes; that inherited limitation is documented and tracked in #45. M1.8 remains open for cross-revision effect identity and broader execution guarantees. No physical hardware validation is claimed.