### PR TITLE
M3a.1: prove bounded spatial intent under delayed observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ### Added
 
+- bounded M3a.1 two-button simulation using the Mission/Field/Robot service classes, 1200 seconds
+  of virtual intent transit, Field-local observation, one durable Robot reservation and an
+  independent spatial device journal. Same-identity re-anchoring, ambiguity/over-tolerance holds,
+  already-latched recognition and recovery are checked against actual simulated contacts.
+  Attributed post-action evidence reaches the separate programmatic Mission view; missing or
+  inconsistent command evidence remains explicit UNKNOWN. See the [guide and limits](docs/m3/M3A_TWO_BUTTON.md)
+  and [service proof](docs/m3/evidence/two-button-service-proof.json). Full M3a/M3b, physical and
+  VR gates remain open.
 - experimental external-effect recovery with a separate persistent simulated button, durable
   device binding, observe-only recovery after uncertain dispatch, and immutable outcome evidence;
 - explicit historical dummy-fixture compatibility; normal Field reconciliation requires compatible
@@ -78,7 +86,7 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 - M2.4 is complete, including the cross-version reference check and native Linux/Win64 Kinematics
   validation.
 - M2.2 is complete. Its raw articulated feed does not validate model geometry; an FK consumer must
-  call the explicit description-backed validator. The integrated Python suite passes 152 tests;
+  call the explicit description-backed validator. The integrated Python suite passes 175 tests;
   the historical M2.2 135/20 snapshot remains identified in its platform record.
 - M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK and the M2.8a
   preview math core are complete with Linux/Win64 evidence. The bounded M2.9a articulated-scene

--- a/README.md
+++ b/README.md
@@ -2,23 +2,13 @@
 
 **A research prototype for delay-tolerant, VR-mediated shared autonomy with remote robots.**
 
-> **Status:** M0, the M1 delay-tolerant dummy, and the bounded M2.2–M2.5 protocol, math, oracle, and actor
-> slices are complete. The bounded M2.7 constrained-IK implementation is complete with Linux and
-> Win64 Unreal Engine 5.8.2 evidence: each run records 35 contextual successes, including all 13
-> IK tests, with build/editor exit code 0.
-> The bounded M2.8a local KinematicPreview math core is implemented; Linux and Win64 Unreal
-> validation each record 43/43 contextual successes, including all eight preview tests, with
-> build/editor exit code 0.
-> The bounded M1.8c local external-action budget supports one revision-1 reservation/window;
-> the integrated Python suite passes 152 tests, while cross-revision effect identity and
-> multiprocess fencing remain open.
-> The bounded M2.9a opt-in articulated-scene tranche is complete: Linux and Win64 each record
-> build/editor exit code 0 and 50 tests (48 `Success` plus two expected `SuccessWithWarnings` for
-> missing-model and duplicate-sequence negative cases). Its desktop capture is synthetic fixture
-> replay; full M2.9 and #20/#21 remain open.
-> The `v0.1.0` release gate is satisfied with portable Python CI;
-> M2.2–M2.5 have separate Unreal Engine 5.8.2 evidence on Linux and Win64. No physical robot path
-> is enabled.
+> **Status:** M0 and the historical M1 dummy gate are complete. Bounded delay/recovery,
+> autonomy-budget and M2 kinematics/presentation slices are implemented. M3a.1 adds a delayed
+> two-button simulation with bounded re-anchoring and independently recorded effects.
+> The integrated Python suite passes 175 tests. For M2.9a, Linux and Win64 UE 5.8.2 each pass 50
+> contextual tests (48 successes plus two expected negative-case warnings), with build/editor exit code 0.
+> Full M1.7/M1.8, M2 authoring/integration and M3a/M3b remain open. The desktop image is synthetic;
+> no physical robot or VR authoring result is claimed.
 
 Deferred Teleoperation explores how an operator can express a spatial and linguistic intent from a delayed representation of a remote environment, while an autonomous field site grounds, assigns, executes, adapts, or holds that intent without depending on a real-time round trip.
 
@@ -46,7 +36,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
 | M1.8 external effect | M1.8b delayed proof and bounded M1.8c one-reservation local budget implemented; cross-revision identity and multiprocess fencing remain open |
 | SO-101 twin | M2.2 articulated-state protocol (#14), M2.3 canonical transforms/generic FK code (#15), M2.4 cross-language numerical oracle (#16), and the bounded M2.5 rigid-link actor are complete with Python 3.11/3.12 and Linux/Win64 UE 5.8.2 evidence; the M2.7 constrained-IK implementation and M2.8a local preview math core are complete with Linux/Win64 UE 5.8.2 evidence; the bounded M2.9a opt-in articulated-scene tranche is complete with Linux/Win64 native evidence and a synthetic desktop capture; full M2.9, desktop/VR authoring, and #20/#21 integration remain open |
-| Autonomous delayed button press | Planned for M3 |
+| Autonomous delayed button press | [M3a.1 two-button simulation](docs/m3/M3A_TWO_BUTTON.md) implemented; full M3a S0–S10 and physical M3b remain open |
 | Hardware control | Disabled by default; not implemented publicly |
 
 See [project status](docs/STATUS.md), [canonical terminology](docs/concepts/TERMINOLOGY.md), [time, frames and provenance](docs/concepts/TIME_FRAMES_AND_PROVENANCE.md), the initial [threat model](docs/security/THREAT_MODEL.md), and the [roadmap](ROADMAP.md).
@@ -134,7 +124,7 @@ tests. Version 2 fixes the reference operation order so Python 3.11 and 3.12 gen
 bytes; the final native validation passes the eight-test `DeferredTeleop.M2.Kinematics` selector
 on Linux and Win64, as recorded in the [M2.4 platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 alongside the earlier full 14-test context. The post-rebase integrated Python validation passes
-152 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
+175 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. The raw articulated feed does not validate SO-101
 geometry: an FK consumer must call the description-backed validator and retain its diagnostics.
 M2.4 supplies the numerical FK oracle. The bounded M2.7 constrained-IK implementation (#19)
@@ -193,6 +183,21 @@ Run the full matrix and release decision with `dtt-release-gate verify --scope r
 required automated and reference-platform item must pass.
 
 The Unreal host project and plugin live under `unreal/DeferredTeleopDemo`. See [the Unreal notes](unreal/README.md). GitHub CI does not compile Unreal; M0 and the M1 visualization were therefore verified locally with Unreal Engine 5.8.2 on Windows, the reference Unreal platform for this release. Unreal on Linux is not claimed as supported by `v0.1.0`.
+
+## Delayed two-button simulation
+
+[M3a.1](docs/m3/M3A_TWO_BUTTON.md) executes the Mission, Field and Robot service classes in one
+process with separate persistent stores and an independent simulated device journal. Mission
+sends a reference-based intent; after 1200 seconds of virtual transit, Field acquires its local
+current observation. Robot executes, re-anchors the same identity within the allowed bound,
+or holds. The programmatic Mission snapshot receives the attributed post-action evidence.
+
+The [service proof](docs/m3/evidence/two-button-service-proof.json) records normal contact,
+bounded displacement, over-tolerance and ambiguous-swap holds, recognition of an already-latched
+button without a new action, and close/reopen recovery after an injected post-press failure.
+The fixed-reference ablations record no contact (`NONE`) or contact with the other button in the simulation.
+These are deterministic simulation oracles, not a distributed-network, perception, VR or
+physical-hardware validation. Full M3a still requires S0–S10; M3b is a separate physical gate.
 
 ## Design constraints
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ validity so that admission, execution and expiry are evaluated at the receiving 
 inferred from a link profile name.
 
 The M1.8b bounded combined slice is implemented and covered by six focused tests. M1.8c adds
-eleven persistent budget cases; the current Python suite passes 152 tests. These slices do not
+eleven persistent budget cases; the current Python suite passes 175 tests. These slices do not
 validate physical hardware, a real network, or a whole-OS restart.
 Positive and ambiguous observation recovery are covered under long delay; absent external
 evidence remains covered by the separate M1.8a recovery proof. It covers contract revision 1;
@@ -199,7 +199,7 @@ Python 3.11 and 3.12 produce identical bytes, and its final native validation pa
 `DeferredTeleop.M2.Kinematics` selector on both targets. The [M2.4 fixture contract](docs/m2/KINEMATICS_FIXTURES.md)
 defines nine SO-101 cases, six independent Python reference tests, and three Unreal Automation
 tests; the integrated oracle snapshot reports 121 Python tests. The post-rebase integrated Python
-validation passes 152 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
+validation passes 175 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 retains the earlier full 14-test run as context. The raw articulated feed preserves a model
 reference but does not validate geometry; an FK consumer must call the explicit description-backed
 validator. The recorded M2.5 Linux and Win64 runs pass their full Automation reports with build and
@@ -250,11 +250,33 @@ The tranche does not close full M2.9, #20 or #21.
 
 ## M3 — Autonomous delayed button press with bounded re-anchoring
 
-Status: **planned; complete only after M3a and M3b**
+Status: **in progress; bounded M3a.1 implemented; complete only after full M3a and M3b**
 
 M3 is the next behavioral boundary. It brings a deliberately bounded slice of the later M4/M5
 ideas into the first button experiment so that delay changes the knowledge available to the local
 decision. It does not attempt robot-agnostic generalization or open-ended autonomy.
+
+### M3a.1 — Delayed two-button service slice
+
+Status: **implemented for the bounded simulation scope**
+
+The [guide](docs/m3/M3A_TWO_BUTTON.md) and [service proof](docs/m3/evidence/two-button-service-proof.json)
+cover one immutable revision-1 `EnsureButtonLatched` intent through Mission, 1200 seconds of
+virtual transit, Field-local observation after the delay, Robot admission/reservation, an
+independent device journal, and the final Mission snapshot. The service classes run in one
+process with separate stores; failures are injected and stores/devices are reopened.
+
+S0 establishes actual A/B contacts. S1 permits same-identity re-anchoring at the declared bound
+and holds beyond it; S2 holds on ambiguous identity while the fixed-reference ablation contacts
+the other button. S4 recognizes an already-latched target without a new impulse or budget
+admission. Recovery preserves one reservation and one impulse, and replay preserves the accepted
+proof. Missing or inconsistent command evidence resolves to explicit UNKNOWN rather than an
+attributed contact. This slice does not close the full S0–S10 matrix or physical M3b.
+
+Next, extend the same independent oracles to the remaining matrix rows before broadening the
+policy. Cross-revision effect identity and causal lineage, multiprocess fencing (#45), and the
+separate M2 parser/authoring/integration issues (#47, #20 and #21) remain open. Future 2D/VR
+comparisons retain the same controller and local autonomy.
 
 ### M3a — Deterministic simulation gate
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,7 +13,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
 | M1.8 | **In progress; M1.8b proof and bounded M1.8c budget implemented** | One revision-1 local reservation/window is durable; cross-revision identity and multiprocess fencing remain open |
 | M2 | **In progress; target `v0.2.0`** | M2.1 structural model, M2.2 articulated-state protocol, M2.3 FK math core, M2.4 oracle, M2.5 actor, and M2.8a local preview math core are complete with Linux/Win64 UE evidence; M2.7 constrained IK is complete with Linux/Win64 UE evidence; bounded M2.9a articulated-scene tranche is complete with Linux/Win64 native evidence and a synthetic desktop capture; full M2.9, desktop/VR authoring and #20/#21 remain |
-| M3 | **Planned; M3a + M3b required** | Simulation oracle gate plus calibrated physical-fixture gate |
+| M3 | **In progress; bounded M3a.1 implemented** | [Two-button service proof](m3/evidence/two-button-service-proof.json); full M3a S0–S10 and physical M3b remain open |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
 
 M1.7a, M1.7, M1.8 and the enriched M3a/M3b slices are specified in the [delayed-intent
@@ -123,7 +123,7 @@ records the machine-readable eight-test native results and retains the earlier f
 context. The generated SO-101 structural check and the M2.4 fixture contract have distinct roles:
 the latter supplies the numerical FK oracle. Wire parsing and the live Mission view preserve the
 articulated model reference without validating SO-101 geometry; an FK consumer must call the
-explicit description-backed validator. The post-rebase integrated Python validation passes 152
+explicit description-backed validator. The post-rebase integrated Python validation passes 175
 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. Remaining M2 work is described in the [M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md).
 
@@ -213,7 +213,22 @@ All 72 Python tests, Ruff and the unchanged M1 CI release gate passed in
 - existing `dtt/0` golden and Unreal Mission-view evidence preserved;
 - no claim of complete lineage or multi-operation coherence.
 
-## Planned, not implemented
+## Implemented in M3a.1
+
+The [two-button guide](m3/M3A_TWO_BUTTON.md) and [machine-readable proof](m3/evidence/two-button-service-proof.json)
+record the bounded in-process Mission/Field/Robot simulation with separate persistent stores.
+Field acquires the current observation locally after 1200 seconds of virtual Mission-to-Field
+transit. Robot acts only within the declared same-identity displacement and one-action budget;
+the independent device records the actual contact and counters, which return to Mission.
+
+The focused suite covers S0, S1, S2 and S4 behaviors, target B, reference/context/proof mutations,
+reservation failures and close/reopen recovery. A separate recorded run exercises six scenario
+setups, including a failure after the real simulated impulse and an already-latched replay.
+The latter produces no new impulse, execution journal or budget. An unverified command digest
+produces durable HELD/UNKNOWN with no attributed contact or counters. These are simulation
+receipts; no separate-process crash, power-loss, network-deployment, physical or VR claim follows.
+
+## Remaining work
 
 ### M1.7 full lineage gate
 
@@ -233,7 +248,7 @@ durably; recovery observes without blind replay and rejects a missing or substit
 unknown outcome remains held, and a terminal event alone does not manufacture measured completion
 telemetry in the normal Field.
 
-The integrated Python suite passes 152 tests, including six M1.8b scenarios and eleven persistent
+The integrated Python suite passes 175 tests, including six M1.8b scenarios and eleven persistent
 M1.8c budget cases. The historical golden session and its six committed files remain unchanged,
 and the release gate remains unchanged. Its explicit dummy fixture compatibility is documented;
 it is not an external observation guarantee. M1.8c assumes one active Robot instance per SQLite
@@ -274,7 +289,7 @@ The remaining full M1.8 gate requires:
 - M3a oracles transposed to the physical fixture, with Robot and independent fixture evidence
   recorded separately for every result.
 
-M3 remains incomplete until both M3a and M3b pass. Neither gate is currently implemented.
+M3 remains incomplete until both full M3a and M3b pass. M3a.1 implements the bounded subset above; the remaining simulation rows and physical gate are still open.
 
 ### Later M4/M5 work
 
@@ -296,8 +311,7 @@ integration gates remain open. A milestone is complete
 only after its deterministic replay, machine-readable artifacts and visible result satisfy the gate
 in the [roadmap](../ROADMAP.md).
 
-This documentation change does not close M1.7 or M3. M3a remains a future simulation gate, and
-M3b's physical-fixture evidence is not present.
+The bounded M3a.1 implementation does not close M1.7 or M3. Full M3a still requires its remaining scenario rows, and M3b's physical-fixture evidence is not present.
 
 `v0.1.0` remains the historical M1 tag; later planned increments do not add capabilities to it.
 `v0.2.0` remains the M2 target and makes no physical SO-101 or hardware-control claim.

--- a/docs/m3/M3A_TWO_BUTTON.md
+++ b/docs/m3/M3A_TWO_BUTTON.md
@@ -1,0 +1,105 @@
+# M3a two-button spatial slice (simulation-only)
+
+This simulation-only slice provides the independent simulated-device fixture
+and the pure Robot policy
+used by the M3a observed-spatial-intent integration. It covers one immutable
+revision-1 `EnsureButtonLatched(desired_latched=true)` operation. The existing
+M1/M2 payloads and golden bytes remain unchanged.
+
+`deferred_teleop.m3a_types` contains frozen local value types for the persisted
+observation, exact intent reference, execution context, command, level proof,
+and local decision. The wire `TwoButtonEffectEvidence` carries the independent
+post-dispatch contact, counters, latches, outcome, and command digest.
+`canonical_bytes()` uses sorted compact UTF-8 JSON and
+`canonical_digest()` returns `sha256:<64 lowercase hex digits>`. Observation and
+command values compute their digest over the payload without the digest field;
+when a caller supplies a digest, construction verifies it.
+
+The policy entry point is:
+
+```python
+decision = decide_two_button(
+    intent,
+    reference_observation,
+    current_observation,
+    level_evidence,
+    expected_source_id=observer_id,
+    expected_device_id=device_id,
+)
+```
+
+It validates the reference observation ID, recomputed digest, target detection,
+pose, frame, calibration, world revision, and observed timestamp before making
+a decision. It accepts a unique same-identity detection at zero displacement
+(`EXECUTE`) or within the inclusive tolerance (`REANCHOR_EXECUTE`). Missing,
+non-unique, candidate-set, and over-tolerance detections produce
+`HOLD_AMBIGUOUS`. Frame/calibration differences produce
+`HOLD_CONTEXT_MISMATCH`; changed reference payloads produce
+`HOLD_REFERENCE_MISMATCH`. A trusted level proof that the named target is
+already latched produces `RECOGNIZE_EFFECT`, which is the preacceptance path
+and does not derive a command.
+
+`derive_spatial_press_command()` turns an execute decision into an immutable
+`SpatialPressCommand`. It copies the selected observation pose and source IDs;
+it never reads a fixture or chooses a nearest target.
+
+`TwoButtonFixture` owns hidden simulated button positions, collision radius,
+scenario setup, level state, and the append-only device journal. The only
+simulated contact entry point is `press_at(SpatialPressCommand)`. Each press row records the exact
+canonical command bytes and digest, effect key, commanded position/frame/
+calibration, simulated contact (`A`, `B`, or `NONE`), both counters, and both
+latches. Every append flushes and `fsync`s the file before returning; the parent
+ directory is synced when the platform exposes directory descriptors. Closing
+ and reopening the fixture demonstrates visibility after reopening the objects
+ in the test process; it does not prove an OS process restart, power-loss, or
+ filesystem durability.
+
+`SpatialExternalEffectAdapter.bind(effect_key, command)` persists an immutable
+effect-key-to-command binding and returns a receipt containing device ID,
+effect key, and command digest. Equal rebinds return the same receipt. A
+different command for an existing key raises `SpatialBindingConflictError`.
+`press(effect_key)` can dispatch only the command loaded from that binding and
+calls the fixture's `press_at`; it accepts no target name or mutable position.
+
+In the service harness, Mission persists the authoring reference and authors
+the intent. It does not send a current observation that was known before the
+delay. After the virtual 1200-second transit, `M3aFieldService` records the
+current observation directly from its local observer, then builds the Field
+bundle. The bundle preserves the reference observation's source, provenance,
+`observed_at`, `produced_at`, and world revision instead of re-dating it.
+The older Mission helper `publish_m3a_current_observation` remains reserved for
+compatibility/test replays and is not this local proof.
+Robot's post-dispatch `TwoButtonEffectEvidence` is durably committed with the
+external outcome, relayed Field-to-Mission, and used by `m3a.view`; counters,
+latches, contact, and terminal result remain `null` until that post-action
+proof exists. An already-latched preacceptance therefore cannot attribute its
+unrelated seed impulse to the new operation.
+
+Field and Mission persist the first command-digest-verified effect proof for a
+contract and compare later copies by canonical payload plus source,
+destination, and correlation semantics. Identical transport retries retain the
+first proof; divergent copies are recorded as conflicts and cannot rewrite the
+read model. A digest-unverified `UNKNOWN` is retained as one durable diagnostic
+until an attributable proof exists, and never supplies physical facts. These
+checks preserve consistency and replay behavior between the configured
+services. They are not cryptographic authentication and do not establish that
+a first message from a trusted service was genuine.
+
+The focused proofs run in the public checkout with:
+
+```text
+PYTHONPATH=python/src python -m pytest -q tests/test_m3a_two_button.py
+```
+
+The service integration tests cover the five oracle groups: S0 nominal A
+contact, S1 inclusive re-anchor and epsilon hold, intent/reference integrity
+with exact duplicate bytes and durable conflict, S2 ambiguous A/B swap, and S4
+already-latched preacceptance plus Robot/device reopen. They exercise the
+Mission-to-Field 1200-second virtual transit followed by Field-local current
+observation, Field's persisted reference and plan/context/assignment/contract
+bundle, Robot's retryable dependency ordering, the single M1.8c reservation,
+the relayed post-effect proof, and the independent device journal.
+
+The fixture and contact proof are simulation-only. The slice does not claim
+M3a closure, cancellation, new-impulse semantics, revisions, physical
+validity, or hardware behavior.

--- a/docs/m3/evidence/two-button-service-proof.json
+++ b/docs/m3/evidence/two-button-service-proof.json
@@ -1,0 +1,571 @@
+{
+  "evidence_date_utc": "2026-09-05T03:08:40Z",
+  "integration_base_commit": "1dfc085cef048acf104bc73882b6faa979799111",
+  "limits": [
+    "All services run in one process with separate persistent stores; close/reopen is exercised inside that test process and does not prove an OS process restart, power-loss recovery, or distributed deployment.",
+    "The 1200-second transit is virtual time; no wall-clock or network-latency performance claim follows.",
+    "S4 uses one explicitly recorded seed pulse (seed=1) and zero new pulses; the recognized level is not attributed as a new operation effect.",
+    "The injected post-press failure is a service recovery frontier; this proof does not claim an OS kill, VR, physical hardware, or distributed-network result.",
+    "One active Robot instance per SQLite store/adapter is assumed (#45 remains open); multiprocess fencing and cross-revision identity are outside this slice.",
+    "Services are trusted and the records are integrity evidence, not cryptographic authentication or a network security proof.",
+    "This bounded M3a.1 record covers six scenarios only. Full M3a and M3b remain open; no milestone-completion claim is made.",
+    "The private runner raw JSON, databases, JSONL device journal and logs remain outside the public projection. Public pytest reproduces the checked-in oracles without promising identical UUIDs or capture bytes."
+  ],
+  "reproduction": {
+    "private_runner": "supplementary private service receipt; invoke only from the private run recipe",
+    "public_focused_command": "PYTHONPATH=python/src python -m pytest -q tests/test_m3a_two_button.py",
+    "public_full_command": "PYTHONPATH=python/src python -m pytest -q",
+    "python_path_placeholder": "REPO_ROOT/python/src",
+    "source_root_placeholder": "REPO_ROOT",
+    "uuid_and_capture_reproducibility": false
+  },
+  "scenarios": [
+    {
+      "budget": {
+        "actions_reserved": 1,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 1,
+        "execution_journal_entries": 1,
+        "journal_states": [
+          "SUCCEEDED"
+        ]
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "EXECUTE",
+        "contact": "A",
+        "new_pulses": 1,
+        "reason": "REFERENCE_STILL_VALID"
+      },
+      "id": "S0_NOMINAL_A_CRASH_AFTER_PRESS",
+      "mission": {
+        "a_counter": 1,
+        "a_latched": true,
+        "b_counter": 0,
+        "b_latched": false,
+        "business_result": "APPLIED",
+        "canonical_effect_bindings": 1,
+        "contract_state": "SUCCEEDED",
+        "physical_contact": "A",
+        "terminal_result": {
+          "a_counter": 1,
+          "a_latched": true,
+          "b_counter": 0,
+          "b_latched": false,
+          "command_digest": "sha256:e526a0d24c597d6bd78f661660f2fefc19ccc9160d9ed0aeb6899892fcc1f5cf",
+          "command_digest_diagnostic": null,
+          "command_digest_verified": true,
+          "command_executed": true,
+          "contract_id": "ae3dbc02-1afd-5341-aa39-faf2448f09dd",
+          "contract_revision": 1,
+          "device_id": "two-button-device-1",
+          "effect_key": "press:d335d685-969e-4d6d-8fbf-1966593558fb:1",
+          "intent_revision": 1,
+          "observation_id": "spatial:6e6ffeb8-d09b-40c6-b4e9-a68898b8d780",
+          "observed_at": "2026-09-05T00:20:00Z",
+          "operation_id": "d335d685-969e-4d6d-8fbf-1966593558fb",
+          "outcome": "APPLIED",
+          "physical_contact": "A",
+          "semantic_effect_id": "ensure-latched:A",
+          "semantic_goal_attained": true,
+          "target_entity_id": "A"
+        }
+      },
+      "observed": {
+        "a_counter": 1,
+        "a_latched": true,
+        "action": "EXECUTE",
+        "b_counter": 0,
+        "b_latched": false,
+        "contact": "A",
+        "new_operation_pulses": 1,
+        "reason": "REFERENCE_STILL_VALID",
+        "seed_pulses": 0,
+        "total_device_pulses": 1
+      },
+      "raw_scenario_id": "S0_NOMINAL_A_CRASH_AFTER_PRESS",
+      "recovery": {
+        "interrupted_rows_recovered": 1,
+        "post_press_failure_injected": true,
+        "reopened_before_recovery": true,
+        "second_pulse": false
+      },
+      "target": "A"
+    },
+    {
+      "budget": {
+        "actions_reserved": 1,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 1,
+        "execution_journal_entries": 1,
+        "journal_states": [
+          "SUCCEEDED"
+        ]
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "REANCHOR_EXECUTE",
+        "contact": "A",
+        "new_pulses": 1,
+        "reason": "SAME_ID_REANCHORED"
+      },
+      "id": "S1_BOUNDARY",
+      "mission": {
+        "a_counter": 1,
+        "a_latched": true,
+        "b_counter": 0,
+        "b_latched": false,
+        "business_result": "APPLIED",
+        "canonical_effect_bindings": 1,
+        "contract_state": "SUCCEEDED",
+        "physical_contact": "A",
+        "terminal_result": {
+          "a_counter": 1,
+          "a_latched": true,
+          "b_counter": 0,
+          "b_latched": false,
+          "command_digest": "sha256:0d7d83ba28c2851e0d90930ea6770f41e096a595d4ae758e6d5bf20c7c3bc30c",
+          "command_digest_diagnostic": null,
+          "command_digest_verified": true,
+          "command_executed": true,
+          "contract_id": "fa62f8b5-4f3f-53cb-bdbe-69330bc540d9",
+          "contract_revision": 1,
+          "device_id": "two-button-device-1",
+          "effect_key": "press:92a4b903-d046-438a-b084-138600d1297e:1",
+          "intent_revision": 1,
+          "observation_id": "spatial:6dfbc36e-3666-46a0-8044-0bee1a68b87b",
+          "observed_at": "2026-09-05T00:20:00Z",
+          "operation_id": "92a4b903-d046-438a-b084-138600d1297e",
+          "outcome": "APPLIED",
+          "physical_contact": "A",
+          "semantic_effect_id": "ensure-latched:A",
+          "semantic_goal_attained": true,
+          "target_entity_id": "A"
+        }
+      },
+      "observed": {
+        "a_counter": 1,
+        "a_latched": true,
+        "action": "REANCHOR_EXECUTE",
+        "b_counter": 0,
+        "b_latched": false,
+        "contact": "A",
+        "new_operation_pulses": 1,
+        "reason": "SAME_ID_REANCHORED",
+        "seed_pulses": 0,
+        "total_device_pulses": 1
+      },
+      "raw_scenario_id": "S1_BOUNDARY",
+      "target": "A"
+    },
+    {
+      "budget": {
+        "actions_reserved": 0,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 0,
+        "execution_journal_entries": 0,
+        "journal_states": []
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "HOLD_AMBIGUOUS",
+        "contact": null,
+        "new_pulses": 0,
+        "reason": "DISPLACEMENT_EXCEEDS_TOLERANCE"
+      },
+      "id": "S1_EPSILON",
+      "mission": {
+        "a_counter": null,
+        "a_latched": null,
+        "b_counter": null,
+        "b_latched": null,
+        "business_result": null,
+        "canonical_effect_bindings": 0,
+        "contract_state": "HELD",
+        "physical_contact": null,
+        "terminal_result": null
+      },
+      "observed": {
+        "a_counter": 0,
+        "a_latched": false,
+        "action": "HOLD_AMBIGUOUS",
+        "b_counter": 0,
+        "b_latched": false,
+        "contact": null,
+        "new_operation_pulses": 0,
+        "reason": "DISPLACEMENT_EXCEEDS_TOLERANCE",
+        "seed_pulses": 0,
+        "total_device_pulses": 0
+      },
+      "raw_scenario_id": "S1_EPSILON",
+      "target": "A"
+    },
+    {
+      "budget": {
+        "actions_reserved": 0,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 0,
+        "execution_journal_entries": 0,
+        "journal_states": []
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "HOLD_AMBIGUOUS",
+        "contact": null,
+        "new_pulses": 0,
+        "reason": "TARGET_CANDIDATE_SET_AMBIGUOUS"
+      },
+      "id": "S2_SWAP",
+      "mission": {
+        "a_counter": null,
+        "a_latched": null,
+        "b_counter": null,
+        "b_latched": null,
+        "business_result": null,
+        "canonical_effect_bindings": 0,
+        "contract_state": "HELD",
+        "physical_contact": null,
+        "terminal_result": null
+      },
+      "observed": {
+        "a_counter": 0,
+        "a_latched": false,
+        "action": "HOLD_AMBIGUOUS",
+        "b_counter": 0,
+        "b_latched": false,
+        "contact": null,
+        "new_operation_pulses": 0,
+        "reason": "TARGET_CANDIDATE_SET_AMBIGUOUS",
+        "seed_pulses": 0,
+        "total_device_pulses": 0
+      },
+      "raw_scenario_id": "S2_SWAP",
+      "target": "A"
+    },
+    {
+      "budget": {
+        "actions_reserved": 0,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 0,
+        "execution_journal_entries": 0,
+        "journal_states": []
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "RECOGNIZE_EFFECT",
+        "contact": null,
+        "new_pulses": 0,
+        "reason": "ALREADY_LATCHED",
+        "seed_pulses": 1
+      },
+      "id": "S4_ALREADY_LATCHED_REOPEN_DUPLICATE",
+      "mission": {
+        "a_counter": null,
+        "a_latched": null,
+        "b_counter": null,
+        "b_latched": null,
+        "business_result": "RECOGNIZED_ALREADY_EFFECTIVE",
+        "canonical_effect_bindings": 0,
+        "contract_state": "HELD",
+        "physical_contact": null,
+        "terminal_result": null
+      },
+      "observed": {
+        "a_counter": 1,
+        "a_latched": true,
+        "action": "RECOGNIZE_EFFECT",
+        "b_counter": 0,
+        "b_latched": false,
+        "contact": null,
+        "new_operation_pulses": 0,
+        "reason": "ALREADY_LATCHED",
+        "seed_pulses": 1,
+        "total_device_pulses": 1
+      },
+      "raw_scenario_id": "S4_ALREADY_LATCHED_REOPEN_DUPLICATE",
+      "replay": {
+        "decision_bytes_identical": true,
+        "device_unchanged": true,
+        "held_event_bytes_identical": true,
+        "new_pulses": 0,
+        "reopened": true
+      },
+      "target": "A"
+    },
+    {
+      "budget": {
+        "actions_reserved": 1,
+        "autonomy_budget_denials": 0,
+        "autonomy_budget_entries": 1,
+        "execution_journal_entries": 1,
+        "journal_states": [
+          "SUCCEEDED"
+        ]
+      },
+      "clocks": {
+        "clock_now": "2026-09-05T00:20:00Z",
+        "current_observed_at": "2026-09-05T00:20:00Z",
+        "elapsed_seconds": 1200,
+        "reference_observed_at": "2026-09-05T00:00:00Z",
+        "t0": "2026-09-05T00:00:00Z"
+      },
+      "delay_seconds": 1200,
+      "expected": {
+        "action": "EXECUTE",
+        "contact": "B",
+        "new_pulses": 1,
+        "reason": "REFERENCE_STILL_VALID"
+      },
+      "id": "S0_NOMINAL_B",
+      "mission": {
+        "a_counter": 0,
+        "a_latched": false,
+        "b_counter": 1,
+        "b_latched": true,
+        "business_result": "APPLIED",
+        "canonical_effect_bindings": 1,
+        "contract_state": "SUCCEEDED",
+        "physical_contact": "B",
+        "terminal_result": {
+          "a_counter": 0,
+          "a_latched": false,
+          "b_counter": 1,
+          "b_latched": true,
+          "command_digest": "sha256:b80ff21d4d7c18cb4b2630546ea6ec4a4e7ec22168db03ebe387e2abdc34a6bf",
+          "command_digest_diagnostic": null,
+          "command_digest_verified": true,
+          "command_executed": true,
+          "contract_id": "686f558a-5817-5cce-9f10-9a69b68fd4ce",
+          "contract_revision": 1,
+          "device_id": "two-button-device-1",
+          "effect_key": "press:fde856e9-a326-482f-9a19-af1da7c1c60e:1",
+          "intent_revision": 1,
+          "observation_id": "spatial:f17a8ab8-a728-4976-84ed-b8ecc41f0a57",
+          "observed_at": "2026-09-05T00:20:00Z",
+          "operation_id": "fde856e9-a326-482f-9a19-af1da7c1c60e",
+          "outcome": "APPLIED",
+          "physical_contact": "B",
+          "semantic_effect_id": "ensure-latched:B",
+          "semantic_goal_attained": true,
+          "target_entity_id": "B"
+        }
+      },
+      "observed": {
+        "a_counter": 0,
+        "a_latched": false,
+        "action": "EXECUTE",
+        "b_counter": 1,
+        "b_latched": true,
+        "contact": "B",
+        "new_operation_pulses": 1,
+        "reason": "REFERENCE_STILL_VALID",
+        "seed_pulses": 0,
+        "total_device_pulses": 1
+      },
+      "raw_scenario_id": "S0_NOMINAL",
+      "target": "B"
+    }
+  ],
+  "schema": "deferred-teleoperation/m3a.1-two-button-service-proof.v1",
+  "scope": {
+    "active_robot_instances_per_store": 1,
+    "milestone": "M3a.1",
+    "operation": "EnsureButtonLatched(desired_latched=true)",
+    "revision": 1,
+    "service_authentication": "trusted services; this evidence is not cryptographic authentication",
+    "service_path": "Mission -> virtual transit -> local Field observation -> Robot -> independent simulated device -> Mission",
+    "virtual_delay_seconds": 1200
+  },
+  "sources": {
+    "count": 10,
+    "files": [
+      {
+        "bytes": 194801,
+        "path": "python/src/deferred_teleop/runtime.py",
+        "sha256": "7f91ba0d067fa1e4f88e2e3398eb2642ade6686b380c4821df428381cd47ffe2"
+      },
+      {
+        "bytes": 22084,
+        "path": "python/src/deferred_teleop/protocol.py",
+        "sha256": "ff487045f7cbe6520911d74301a1e76586abd3d9ce335a46b634b16d37fe7ecd"
+      },
+      {
+        "bytes": 111015,
+        "path": "python/src/deferred_teleop/storage.py",
+        "sha256": "1d5f966d930c00f4cc25f7080be963a840fd000653dfc26dd17b26ee12a2cd89"
+      },
+      {
+        "bytes": 7809,
+        "path": "python/src/deferred_teleop/mission_view.py",
+        "sha256": "4a79a9778873285db208c584ef56ce1f04ffe41aa22652a11880feb48bada263"
+      },
+      {
+        "bytes": 33576,
+        "path": "python/src/deferred_teleop/m3a_types.py",
+        "sha256": "6e20f43073011b82e4117152ed283f35b5d51c63605bf15e1deb89dbd865e45e"
+      },
+      {
+        "bytes": 35645,
+        "path": "python/src/deferred_teleop/two_button_fixture.py",
+        "sha256": "c4f1658e2cb109f20e6d68f47ff7ef9f10a813ca8218c315613872ca56ef99a8"
+      },
+      {
+        "bytes": 16200,
+        "path": "python/src/deferred_teleop/two_button_policy.py",
+        "sha256": "fee3932357e1e6717dc823da4ac2f3a7c32c64f4a841996885af5e8e557d680e"
+      },
+      {
+        "bytes": 14006,
+        "path": "python/src/deferred_teleop/external_effect.py",
+        "sha256": "fc195bc45955afa652156228e3c8caca968eea88c5321a0be2efd42c1f3a544d"
+      },
+      {
+        "bytes": 56567,
+        "path": "tests/test_m3a_two_button.py",
+        "sha256": "5309b91558f744d945b6b5e0811e6a4a1c5fd117465179fc0fbd2ce09c0be2f3"
+      },
+      {
+        "bytes": 47197,
+        "path": "protocol/v0/schemas/message-envelope.schema.json",
+        "sha256": "a6687bc5353e742ee2e8ee1a917cc73928b618b8b18c9ddb208e611fe47110f0"
+      }
+    ],
+    "manifest_sha256": "07a6aa4c140b3bc92c75f0761c28b7ab6a3669e9bc4bc0dea8b61b8cb1271329",
+    "unchanged_during_validation": true
+  },
+  "status": "verified_bounded_slice",
+  "validation": {
+    "checks": [
+      {
+        "exit_code": 0,
+        "log_sha256": "f4c4f0e7ecd0de0c5bb6693a99e60309855d2913de70fb0a875ed9b1ce32847a",
+        "name": "pytest"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "82b3e6a6c090a57601d22943bd23fca9218d1031dbe5a7b754092f9a156b4f18",
+        "name": "ruff"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "name": "schema"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "name": "model"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "466790a1ca97b7e1b196645ca253867e3b7f9ea94c456c53524c2787eb4f2a16",
+        "name": "oracle"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "ff6e7d4a394b843139bb0bfae313ce9c85333c838df17a389d186ea8f7a7b648",
+        "name": "gate"
+      },
+      {
+        "exit_code": 0,
+        "log_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "name": "diff"
+      }
+    ],
+    "golden_artifacts": {
+      "base_commit": "1dfc085cef048acf104bc73882b6faa979799111",
+      "byte_identical": true,
+      "files": [
+        {
+          "bytes": 1487,
+          "path": "fixtures/m1/golden-session/README.md",
+          "sha256": "2de71be2ee218d9b7c0f4ee63f5f3a20f67f27cdd69e844824550b3ba685c6d7"
+        },
+        {
+          "bytes": 3292,
+          "path": "fixtures/m1/golden-session/expected-domain-state.json",
+          "sha256": "59f5b1927fc18e6f00ba6e654b91f8137eaca002497f2701acdeb39f7c41eed2"
+        },
+        {
+          "bytes": 359,
+          "path": "fixtures/m1/golden-session/expected-effect-counter.json",
+          "sha256": "f952470e7b4f214803a9039711f93b4099507c9b506257054a71ab6dd5ab138b"
+        },
+        {
+          "bytes": 5221,
+          "path": "fixtures/m1/golden-session/expected-mission-view.json",
+          "sha256": "5412ade4288360091807e7be4040d319873d2089822564683a99eeb4f5033512"
+        },
+        {
+          "bytes": 1424,
+          "path": "fixtures/m1/golden-session/manifest.json",
+          "sha256": "ac8efb8cc002cce65dfb36cab282e8770c8c888126383d40154b9da7676a4b8d"
+        },
+        {
+          "bytes": 23364,
+          "path": "fixtures/m1/golden-session/messages.jsonl",
+          "sha256": "6c1ac3bd0c46fdcee1bc664e70816802f6373711ef63b3ff687177771af37829"
+        }
+      ]
+    },
+    "python_version": "Python 3.11.15",
+    "runner": {
+      "exit_code": 0,
+      "public_source_fingerprints_checked_before_and_after": 9,
+      "report_sha256": "62d318216a0f5ab88a3769850662204cd64e5de9ee437c2c13a2ab702a58e135",
+      "runner_sha256": "4b1e52f4a3afb60549d15eb1146d60506d70765e20f78c03f8bc761e5d7cba8f",
+      "runner_visibility": "private supplementary receipt; public reproduction uses the test suite",
+      "scenario_count": 6
+    },
+    "sqlite_schema_version": 9,
+    "tests": {
+      "focused_m3a": {
+        "failed": 0,
+        "passed": 23,
+        "skipped": 0
+      },
+      "full_python": {
+        "failed": 0,
+        "passed": 175,
+        "skipped": 0
+      },
+      "junit_sha256": "19a79661965086c0226f14eff5061681a0ed2abbfaee1d4014b41f1c0dc19a99",
+      "log_sha256": "f4c4f0e7ecd0de0c5bb6693a99e60309855d2913de70fb0a875ed9b1ce32847a"
+    }
+  }
+}

--- a/protocol/v0/schemas/message-envelope.schema.json
+++ b/protocol/v0/schemas/message-envelope.schema.json
@@ -51,6 +51,46 @@
       "title": "ContractState",
       "type": "string"
     },
+    "EntityDetection": {
+      "additionalProperties": false,
+      "description": "One M3a observed candidate set and measured spatial pose.",
+      "properties": {
+        "candidate_entity_ids": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Candidate Entity Ids",
+          "type": "array"
+        },
+        "detection_id": {
+          "minLength": 1,
+          "title": "Detection Id",
+          "type": "string"
+        },
+        "pose": {
+          "$ref": "#/$defs/Pose"
+        },
+        "source_evidence_id": {
+          "minLength": 1,
+          "title": "Source Evidence Id",
+          "type": "string"
+        },
+        "visibility": {
+          "title": "Visibility",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "detection_id",
+        "candidate_entity_ids",
+        "pose",
+        "visibility",
+        "source_evidence_id"
+      ],
+      "title": "EntityDetection",
+      "type": "object"
+    },
     "EntitySelector": {
       "additionalProperties": false,
       "properties": {
@@ -267,6 +307,400 @@
         "position_radians"
       ],
       "title": "JointPosition",
+      "type": "object"
+    },
+    "LocalTwoButtonDecision": {
+      "additionalProperties": false,
+      "description": "Pure Robot decision with explicit action/reason and budget state.",
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/M3aAction"
+        },
+        "budget_state": {
+          "minLength": 1,
+          "title": "Budget State",
+          "type": "string"
+        },
+        "command_digest": {
+          "anyOf": [
+            {
+              "maxLength": 71,
+              "minLength": 71,
+              "pattern": "sha256:[0-9a-f]{64}",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Command Digest"
+        },
+        "current_observation_id": {
+          "minLength": 1,
+          "title": "Current Observation Id",
+          "type": "string"
+        },
+        "displacement_m": {
+          "anyOf": [
+            {
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Displacement M"
+        },
+        "intent_revision": {
+          "const": 1,
+          "title": "Intent Revision",
+          "type": "integer"
+        },
+        "level_evidence_observation_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Level Evidence Observation Id"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "reason": {
+          "minLength": 1,
+          "title": "Reason",
+          "type": "string"
+        },
+        "reference_observation_id": {
+          "minLength": 1,
+          "title": "Reference Observation Id",
+          "type": "string"
+        },
+        "selected_detection_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Selected Detection Id"
+        },
+        "semantic_effect_id": {
+          "minLength": 1,
+          "title": "Semantic Effect Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id",
+        "intent_revision",
+        "semantic_effect_id",
+        "reference_observation_id",
+        "current_observation_id",
+        "action",
+        "reason",
+        "budget_state"
+      ],
+      "title": "LocalTwoButtonDecision",
+      "type": "object"
+    },
+    "M3aAction": {
+      "enum": [
+        "EXECUTE",
+        "REANCHOR_EXECUTE",
+        "HOLD_AMBIGUOUS",
+        "HOLD_REFERENCE_MISMATCH",
+        "HOLD_CONTEXT_MISMATCH",
+        "RECOGNIZE_EFFECT"
+      ],
+      "title": "M3aAction",
+      "type": "string"
+    },
+    "M3aEnsureLatchedIntent": {
+      "additionalProperties": false,
+      "description": "Revision-1 M3a root intent; only the true level effect is in scope.",
+      "properties": {
+        "desired_latched": {
+          "const": true,
+          "title": "Desired Latched",
+          "type": "boolean"
+        },
+        "expires_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expires At"
+        },
+        "intent_revision": {
+          "const": 1,
+          "title": "Intent Revision",
+          "type": "integer"
+        },
+        "max_displacement_m": {
+          "minimum": 0.0,
+          "title": "Max Displacement M",
+          "type": "number"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "reference_calibration_version": {
+          "minLength": 1,
+          "title": "Reference Calibration Version",
+          "type": "string"
+        },
+        "reference_detection_id": {
+          "minLength": 1,
+          "title": "Reference Detection Id",
+          "type": "string"
+        },
+        "reference_digest": {
+          "maxLength": 71,
+          "minLength": 71,
+          "pattern": "sha256:[0-9a-f]{64}",
+          "title": "Reference Digest",
+          "type": "string"
+        },
+        "reference_frame_id": {
+          "minLength": 1,
+          "title": "Reference Frame Id",
+          "type": "string"
+        },
+        "reference_observation_id": {
+          "minLength": 1,
+          "title": "Reference Observation Id",
+          "type": "string"
+        },
+        "reference_observed_at": {
+          "format": "date-time",
+          "title": "Reference Observed At",
+          "type": "string"
+        },
+        "reference_pose": {
+          "$ref": "#/$defs/Pose"
+        },
+        "reference_world_revision": {
+          "minimum": 1,
+          "title": "Reference World Revision",
+          "type": "integer"
+        },
+        "same_identity_only": {
+          "const": true,
+          "default": true,
+          "title": "Same Identity Only",
+          "type": "boolean"
+        },
+        "semantic_effect_id": {
+          "minLength": 1,
+          "title": "Semantic Effect Id",
+          "type": "string"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id",
+        "intent_revision",
+        "semantic_effect_id",
+        "target_entity_id",
+        "desired_latched",
+        "reference_observation_id",
+        "reference_detection_id",
+        "reference_digest",
+        "reference_pose",
+        "reference_frame_id",
+        "reference_calibration_version",
+        "reference_world_revision",
+        "reference_observed_at",
+        "max_displacement_m"
+      ],
+      "title": "M3aEnsureLatchedIntent",
+      "type": "object"
+    },
+    "M3aSpatialExecutionContext": {
+      "additionalProperties": false,
+      "description": "Field's verified contract/context and full current observation.",
+      "properties": {
+        "contract_id": {
+          "format": "uuid",
+          "title": "Contract Id",
+          "type": "string"
+        },
+        "contract_revision": {
+          "const": 1,
+          "title": "Contract Revision",
+          "type": "integer"
+        },
+        "current_observation": {
+          "$ref": "#/$defs/TwoButtonObservation"
+        },
+        "current_observation_envelope_id": {
+          "minLength": 1,
+          "title": "Current Observation Envelope Id",
+          "type": "string"
+        },
+        "expected_device_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expected Device Id"
+        },
+        "expires_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expires At"
+        },
+        "intent_revision": {
+          "const": 1,
+          "title": "Intent Revision",
+          "type": "integer"
+        },
+        "max_displacement_m": {
+          "minimum": 0.0,
+          "title": "Max Displacement M",
+          "type": "number"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "reference_calibration_version": {
+          "minLength": 1,
+          "title": "Reference Calibration Version",
+          "type": "string"
+        },
+        "reference_detection_id": {
+          "minLength": 1,
+          "title": "Reference Detection Id",
+          "type": "string"
+        },
+        "reference_digest": {
+          "maxLength": 71,
+          "minLength": 71,
+          "pattern": "sha256:[0-9a-f]{64}",
+          "title": "Reference Digest",
+          "type": "string"
+        },
+        "reference_frame_id": {
+          "minLength": 1,
+          "title": "Reference Frame Id",
+          "type": "string"
+        },
+        "reference_observation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TwoButtonObservation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reference_observation_id": {
+          "minLength": 1,
+          "title": "Reference Observation Id",
+          "type": "string"
+        },
+        "reference_observed_at": {
+          "format": "date-time",
+          "title": "Reference Observed At",
+          "type": "string"
+        },
+        "reference_pose": {
+          "$ref": "#/$defs/Pose"
+        },
+        "reference_world_revision": {
+          "minimum": 1,
+          "title": "Reference World Revision",
+          "type": "integer"
+        },
+        "same_identity_only": {
+          "const": true,
+          "default": true,
+          "title": "Same Identity Only",
+          "type": "boolean"
+        },
+        "semantic_effect_id": {
+          "minLength": 1,
+          "title": "Semantic Effect Id",
+          "type": "string"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        },
+        "task_id": {
+          "format": "uuid",
+          "title": "Task Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id",
+        "intent_revision",
+        "contract_id",
+        "contract_revision",
+        "task_id",
+        "semantic_effect_id",
+        "target_entity_id",
+        "reference_observation_id",
+        "reference_detection_id",
+        "reference_digest",
+        "reference_pose",
+        "reference_frame_id",
+        "reference_calibration_version",
+        "reference_world_revision",
+        "reference_observed_at",
+        "current_observation_envelope_id",
+        "current_observation",
+        "max_displacement_m"
+      ],
+      "title": "M3aSpatialExecutionContext",
       "type": "object"
     },
     "OperationIntent": {
@@ -604,6 +1038,64 @@
       "title": "SpatialFrame",
       "type": "object"
     },
+    "SpatialPressCommand": {
+      "additionalProperties": false,
+      "description": "Immutable command addressed to the independent spatial adapter.",
+      "properties": {
+        "calibration_version": {
+          "minLength": 1,
+          "title": "Calibration Version",
+          "type": "string"
+        },
+        "command_digest": {
+          "maxLength": 71,
+          "minLength": 71,
+          "pattern": "sha256:[0-9a-f]{64}",
+          "title": "Command Digest",
+          "type": "string"
+        },
+        "command_id": {
+          "minLength": 1,
+          "title": "Command Id",
+          "type": "string"
+        },
+        "effect_key": {
+          "minLength": 1,
+          "title": "Effect Key",
+          "type": "string"
+        },
+        "frame_id": {
+          "minLength": 1,
+          "title": "Frame Id",
+          "type": "string"
+        },
+        "position_m": {
+          "$ref": "#/$defs/Vector3"
+        },
+        "source_detection_id": {
+          "minLength": 1,
+          "title": "Source Detection Id",
+          "type": "string"
+        },
+        "source_observation_id": {
+          "minLength": 1,
+          "title": "Source Observation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "command_id",
+        "effect_key",
+        "position_m",
+        "frame_id",
+        "calibration_version",
+        "source_observation_id",
+        "source_detection_id",
+        "command_digest"
+      ],
+      "title": "SpatialPressCommand",
+      "type": "object"
+    },
     "TaskAssignment": {
       "additionalProperties": false,
       "properties": {
@@ -662,6 +1154,322 @@
         "target_entity_id"
       ],
       "title": "TaskNode",
+      "type": "object"
+    },
+    "TwoButtonEffectEvidence": {
+      "additionalProperties": false,
+      "description": "Post-dispatch device proof for one M3a spatial effect.",
+      "properties": {
+        "a_counter": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "A Counter"
+        },
+        "a_latched": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "A Latched"
+        },
+        "b_counter": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "B Counter"
+        },
+        "b_latched": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "B Latched"
+        },
+        "command_digest": {
+          "maxLength": 71,
+          "minLength": 71,
+          "pattern": "sha256:[0-9a-f]{64}",
+          "title": "Command Digest",
+          "type": "string"
+        },
+        "command_digest_diagnostic": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Command Digest Diagnostic"
+        },
+        "command_digest_verified": {
+          "default": true,
+          "title": "Command Digest Verified",
+          "type": "boolean"
+        },
+        "command_executed": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Command Executed"
+        },
+        "contract_id": {
+          "format": "uuid",
+          "title": "Contract Id",
+          "type": "string"
+        },
+        "contract_revision": {
+          "const": 1,
+          "title": "Contract Revision",
+          "type": "integer"
+        },
+        "device_id": {
+          "minLength": 1,
+          "title": "Device Id",
+          "type": "string"
+        },
+        "effect_key": {
+          "minLength": 1,
+          "title": "Effect Key",
+          "type": "string"
+        },
+        "intent_revision": {
+          "const": 1,
+          "title": "Intent Revision",
+          "type": "integer"
+        },
+        "observation_id": {
+          "minLength": 1,
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "operation_id": {
+          "format": "uuid",
+          "title": "Operation Id",
+          "type": "string"
+        },
+        "outcome": {
+          "enum": [
+            "APPLIED",
+            "NOT_APPLIED",
+            "UNKNOWN"
+          ],
+          "title": "Outcome",
+          "type": "string"
+        },
+        "physical_contact": {
+          "anyOf": [
+            {
+              "enum": [
+                "A",
+                "B",
+                "NONE"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Physical Contact"
+        },
+        "semantic_effect_id": {
+          "minLength": 1,
+          "title": "Semantic Effect Id",
+          "type": "string"
+        },
+        "semantic_goal_attained": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Semantic Goal Attained"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "operation_id",
+        "intent_revision",
+        "contract_id",
+        "contract_revision",
+        "semantic_effect_id",
+        "target_entity_id",
+        "effect_key",
+        "command_digest",
+        "device_id",
+        "observation_id",
+        "observed_at",
+        "outcome"
+      ],
+      "title": "TwoButtonEffectEvidence",
+      "type": "object"
+    },
+    "TwoButtonLevelEvidence": {
+      "additionalProperties": false,
+      "description": "Independent level sensor proof for one named button.",
+      "properties": {
+        "actual_latched": {
+          "title": "Actual Latched",
+          "type": "boolean"
+        },
+        "counter": {
+          "minimum": 0,
+          "title": "Counter",
+          "type": "integer"
+        },
+        "desired_latched": {
+          "const": true,
+          "title": "Desired Latched",
+          "type": "boolean"
+        },
+        "device_id": {
+          "minLength": 1,
+          "title": "Device Id",
+          "type": "string"
+        },
+        "evidence_observation_id": {
+          "minLength": 1,
+          "title": "Evidence Observation Id",
+          "type": "string"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "target_entity_id": {
+          "minLength": 1,
+          "title": "Target Entity Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_entity_id",
+        "desired_latched",
+        "actual_latched",
+        "device_id",
+        "counter",
+        "observed_at",
+        "evidence_observation_id"
+      ],
+      "title": "TwoButtonLevelEvidence",
+      "type": "object"
+    },
+    "TwoButtonObservation": {
+      "additionalProperties": false,
+      "description": "Persisted reference/current observation envelope for M3a.",
+      "properties": {
+        "calibration_version": {
+          "minLength": 1,
+          "title": "Calibration Version",
+          "type": "string"
+        },
+        "canonical_payload_digest": {
+          "maxLength": 71,
+          "minLength": 71,
+          "pattern": "sha256:[0-9a-f]{64}",
+          "title": "Canonical Payload Digest",
+          "type": "string"
+        },
+        "detections": {
+          "items": {
+            "$ref": "#/$defs/EntityDetection"
+          },
+          "title": "Detections",
+          "type": "array"
+        },
+        "frame_id": {
+          "minLength": 1,
+          "title": "Frame Id",
+          "type": "string"
+        },
+        "observation_id": {
+          "minLength": 1,
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "produced_at": {
+          "format": "date-time",
+          "title": "Produced At",
+          "type": "string"
+        },
+        "source_id": {
+          "minLength": 1,
+          "title": "Source Id",
+          "type": "string"
+        },
+        "world_revision": {
+          "minimum": 1,
+          "title": "World Revision",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "observation_id",
+        "source_id",
+        "world_revision",
+        "observed_at",
+        "produced_at",
+        "frame_id",
+        "calibration_version",
+        "canonical_payload_digest",
+        "detections"
+      ],
+      "title": "TwoButtonObservation",
       "type": "object"
     },
     "Vector3": {
@@ -901,6 +1709,139 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.two_button.observation"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/TwoButtonObservation"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.ensure_latched.intent"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/M3aEnsureLatchedIntent"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.spatial.context"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/M3aSpatialExecutionContext"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.spatial.command"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/SpatialPressCommand"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.spatial.level"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/TwoButtonLevelEvidence"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.spatial.effect"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/TwoButtonEffectEvidence"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "const": "m3a.spatial.decision"
+          }
+        },
+        "required": [
+          "message_type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/LocalTwoButtonDecision"
+          }
+        }
+      }
     }
   ],
   "properties": {
@@ -962,7 +1903,14 @@
         "robot.articulated_state",
         "robot.forecast",
         "site.snapshot",
-        "prediction.manifest"
+        "prediction.manifest",
+        "m3a.two_button.observation",
+        "m3a.ensure_latched.intent",
+        "m3a.spatial.context",
+        "m3a.spatial.command",
+        "m3a.spatial.level",
+        "m3a.spatial.effect",
+        "m3a.spatial.decision"
       ],
       "title": "Message Type",
       "type": "string"
@@ -1014,6 +1962,30 @@
         },
         {
           "$ref": "#/$defs/PredictionManifest"
+        },
+        {
+          "$ref": "#/$defs/EntityDetection"
+        },
+        {
+          "$ref": "#/$defs/TwoButtonObservation"
+        },
+        {
+          "$ref": "#/$defs/M3aEnsureLatchedIntent"
+        },
+        {
+          "$ref": "#/$defs/M3aSpatialExecutionContext"
+        },
+        {
+          "$ref": "#/$defs/SpatialPressCommand"
+        },
+        {
+          "$ref": "#/$defs/TwoButtonLevelEvidence"
+        },
+        {
+          "$ref": "#/$defs/TwoButtonEffectEvidence"
+        },
+        {
+          "$ref": "#/$defs/LocalTwoButtonDecision"
         }
       ],
       "title": "Payload"

--- a/python/src/deferred_teleop/m3a_types.py
+++ b/python/src/deferred_teleop/m3a_types.py
@@ -1,0 +1,841 @@
+"""Small immutable value types used by the M3a two-button slice.
+
+The M3a messages deliberately live beside the historical ``dtt/0`` protocol
+models while the service integration is being reviewed.  They are plain local
+types: no existing wire payload or golden fixture is changed by this module.
+
+The canonical encoders in this file are also used by the spatial fixture.  A
+digest is always computed over the payload without its digest field; this
+avoids a self-referential value and makes the bytes persisted by the device
+journal independently reproducible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from deferred_teleop.protocol import Pose
+
+
+class M3aTypeError(ValueError):
+    """Raised when an M3a value cannot satisfy its immutable contract."""
+
+
+def _utc_text(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise M3aTypeError("timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _require_text(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise M3aTypeError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _require_datetime(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise M3aTypeError(f"{field_name} must be timezone-aware")
+    return value
+
+
+def _require_uuid(value: object, *, field_name: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        try:
+            return UUID(value)
+        except ValueError as error:
+            raise M3aTypeError(f"{field_name} must be a UUID") from error
+    raise M3aTypeError(f"{field_name} must be a UUID")
+
+
+def _require_int(value: object, *, field_name: str, minimum: int = 0) -> int:
+    # bool is an int subclass but has no place in a revision or counter.
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise M3aTypeError(f"{field_name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_finite(value: object, *, field_name: str, minimum: float = 0.0) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise M3aTypeError(f"{field_name} must be a finite number >= {minimum}")
+    converted = float(value)
+    if not math.isfinite(converted) or converted < minimum:
+        raise M3aTypeError(f"{field_name} must be a finite number >= {minimum}")
+    return converted
+
+
+def _require_pose(value: object, *, field_name: str) -> Pose:
+    if not isinstance(value, Pose):
+        raise M3aTypeError(f"{field_name} must be a protocol Pose")
+    return value
+
+
+def _require_bool(value: object, *, field_name: str) -> bool:
+    if type(value) is not bool:
+        raise M3aTypeError(f"{field_name} must be a boolean")
+    return value
+
+
+def _canonicalize(value: object) -> object:
+    """Convert supported values to a JSON-safe, deterministic tree."""
+
+    if isinstance(value, datetime):
+        return _utc_text(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, StrEnum):
+        return value.value
+    if dataclasses.is_dataclass(value):
+        return _canonicalize(
+            {field.name: getattr(value, field.name) for field in dataclasses.fields(value)}
+        )
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _canonicalize(model_dump(mode="python"))
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonicalize(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (tuple, list)):
+        return [_canonicalize(item) for item in value]
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise M3aTypeError("canonical payload cannot contain a non-finite number")
+        return value
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    raise M3aTypeError(f"unsupported canonical payload value: {type(value).__name__}")
+
+
+def canonical_bytes(value: object) -> bytes:
+    """Return canonical UTF-8 JSON bytes for an M3a value or payload tree."""
+
+    return json.dumps(
+        _canonicalize(value),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_digest(value: object) -> str:
+    """Return the repository's ``sha256:<hex>`` digest spelling."""
+
+    return "sha256:" + hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def _validate_digest(value: object, *, expected: str, field_name: str) -> str:
+    digest = _require_text(value, field_name=field_name)
+    if digest != expected:
+        raise M3aTypeError(f"{field_name} does not match canonical payload")
+    if len(digest) != 71 or not digest.startswith("sha256:"):
+        raise M3aTypeError(f"{field_name} must be sha256:<64 lowercase hexadecimal digits>")
+    if any(character not in "0123456789abcdef" for character in digest[7:]):
+        raise M3aTypeError(f"{field_name} must be sha256:<64 lowercase hexadecimal digits>")
+    return digest
+
+
+def _pose_dump(pose: Pose, *, mode: str = "python") -> dict[str, Any]:
+    return pose.model_dump(mode=mode)  # type: ignore[return-value]
+
+
+def _normalise_candidate_ids(value: object) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, (tuple, list)):
+        raise M3aTypeError("candidate_entity_ids must be a sequence of IDs")
+    candidates = tuple(_require_text(item, field_name="candidate_entity_id") for item in value)
+    if not candidates:
+        raise M3aTypeError("candidate_entity_ids must not be empty")
+    if len(set(candidates)) != len(candidates):
+        raise M3aTypeError("candidate_entity_ids must not contain duplicates")
+    return candidates
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class EntityDetection:
+    """One observed candidate set and its measured pose."""
+
+    detection_id: str
+    candidate_entity_ids: tuple[str, ...]
+    pose: Pose
+    visibility: bool
+    source_evidence_id: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "detection_id", _require_text(self.detection_id, field_name="detection_id")
+        )
+        object.__setattr__(
+            self,
+            "candidate_entity_ids",
+            _normalise_candidate_ids(self.candidate_entity_ids),
+        )
+        object.__setattr__(self, "pose", _require_pose(self.pose, field_name="pose"))
+        object.__setattr__(
+            self, "visibility", _require_bool(self.visibility, field_name="visibility")
+        )
+        object.__setattr__(
+            self,
+            "source_evidence_id",
+            _require_text(self.source_evidence_id, field_name="source_evidence_id"),
+        )
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        return {
+            "detection_id": self.detection_id,
+            "candidate_entity_ids": list(self.candidate_entity_ids),
+            "pose": _pose_dump(self.pose, mode=mode),
+            "visibility": self.visibility,
+            "source_evidence_id": self.source_evidence_id,
+        }
+
+    @property
+    def is_unique(self) -> bool:
+        return len(self.candidate_entity_ids) == 1
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TwoButtonObservation:
+    """Persisted observer output used for both authoring and execution."""
+
+    observation_id: str
+    source_id: str
+    world_revision: int
+    observed_at: datetime
+    produced_at: datetime
+    frame_id: str
+    calibration_version: str
+    detections: tuple[EntityDetection, ...]
+    canonical_payload_digest: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "observation_id", _require_text(self.observation_id, field_name="observation_id")
+        )
+        object.__setattr__(self, "source_id", _require_text(self.source_id, field_name="source_id"))
+        object.__setattr__(
+            self,
+            "world_revision",
+            _require_int(self.world_revision, field_name="world_revision", minimum=1),
+        )
+        observed_at = _require_datetime(self.observed_at, field_name="observed_at")
+        produced_at = _require_datetime(self.produced_at, field_name="produced_at")
+        if produced_at < observed_at:
+            raise M3aTypeError("produced_at cannot precede observed_at")
+        object.__setattr__(self, "observed_at", observed_at)
+        object.__setattr__(self, "produced_at", produced_at)
+        object.__setattr__(self, "frame_id", _require_text(self.frame_id, field_name="frame_id"))
+        object.__setattr__(
+            self,
+            "calibration_version",
+            _require_text(self.calibration_version, field_name="calibration_version"),
+        )
+        if isinstance(self.detections, (str, bytes)) or not isinstance(
+            self.detections, (tuple, list)
+        ):
+            raise M3aTypeError("detections must be a sequence")
+        detections = tuple(self.detections)
+        if any(not isinstance(detection, EntityDetection) for detection in detections):
+            raise M3aTypeError("detections must contain EntityDetection values")
+        for detection in detections:
+            if detection.pose.frame.frame_id != self.frame_id:
+                raise M3aTypeError("detection pose frame does not match observation frame_id")
+            if detection.pose.frame.calibration_version != self.calibration_version:
+                raise M3aTypeError(
+                    "detection pose calibration does not match observation calibration_version"
+                )
+        if len({detection.detection_id for detection in detections}) != len(detections):
+            raise M3aTypeError("detections must not contain duplicate detection_id values")
+        object.__setattr__(self, "detections", detections)
+        expected = canonical_digest(self._payload_without_digest())
+        supplied = self.canonical_payload_digest
+        if supplied:
+            object.__setattr__(
+                self,
+                "canonical_payload_digest",
+                _validate_digest(
+                    supplied,
+                    expected=expected,
+                    field_name="canonical_payload_digest",
+                ),
+            )
+        else:
+            object.__setattr__(self, "canonical_payload_digest", expected)
+
+    def _payload_without_digest(self) -> dict[str, Any]:
+        return {
+            "observation_id": self.observation_id,
+            "source_id": self.source_id,
+            "world_revision": self.world_revision,
+            "observed_at": self.observed_at,
+            "produced_at": self.produced_at,
+            "frame_id": self.frame_id,
+            "calibration_version": self.calibration_version,
+            "detections": self.detections,
+        }
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        return {
+            **self._payload_without_digest(),
+            "observed_at": _utc_text(self.observed_at) if mode == "json" else self.observed_at,
+            "produced_at": _utc_text(self.produced_at) if mode == "json" else self.produced_at,
+            "detections": [detection.model_dump(mode=mode) for detection in self.detections],
+            "canonical_payload_digest": self.canonical_payload_digest,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_bytes(self._payload_without_digest())
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class M3aEnsureLatchedIntent:
+    """The one immutable revision-1 spatial intent admitted by M3a."""
+
+    operation_id: UUID
+    intent_revision: int
+    semantic_effect_id: str
+    target_entity_id: str
+    desired_latched: bool
+    reference_observation_id: str
+    reference_detection_id: str
+    reference_digest: str
+    reference_pose: Pose
+    reference_frame_id: str
+    reference_calibration_version: str
+    reference_world_revision: int
+    reference_observed_at: datetime
+    same_identity_only: bool = True
+    max_displacement_m: float = 0.0
+    expires_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "operation_id", _require_uuid(self.operation_id, field_name="operation_id")
+        )
+        if self.intent_revision != 1:
+            raise M3aTypeError("M3aEnsureLatchedIntent supports intent_revision 1 only")
+        object.__setattr__(
+            self,
+            "semantic_effect_id",
+            _require_text(self.semantic_effect_id, field_name="semantic_effect_id"),
+        )
+        object.__setattr__(
+            self,
+            "target_entity_id",
+            _require_text(self.target_entity_id, field_name="target_entity_id"),
+        )
+        if self.desired_latched is not True:
+            raise M3aTypeError("M3aEnsureLatchedIntent desired_latched must be true")
+        object.__setattr__(self, "desired_latched", True)
+        for field_name in (
+            "reference_observation_id",
+            "reference_detection_id",
+            "reference_digest",
+            "reference_frame_id",
+            "reference_calibration_version",
+        ):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name=field_name)
+            )
+        object.__setattr__(
+            self, "reference_pose", _require_pose(self.reference_pose, field_name="reference_pose")
+        )
+        if self.reference_pose.frame.frame_id != self.reference_frame_id:
+            raise M3aTypeError("reference_pose frame does not match reference_frame_id")
+        if self.reference_pose.frame.calibration_version != self.reference_calibration_version:
+            raise M3aTypeError(
+                "reference_pose calibration does not match reference_calibration_version"
+            )
+        object.__setattr__(
+            self,
+            "reference_world_revision",
+            _require_int(
+                self.reference_world_revision, field_name="reference_world_revision", minimum=1
+            ),
+        )
+        object.__setattr__(
+            self,
+            "reference_observed_at",
+            _require_datetime(self.reference_observed_at, field_name="reference_observed_at"),
+        )
+        object.__setattr__(
+            self,
+            "same_identity_only",
+            _require_bool(self.same_identity_only, field_name="same_identity_only"),
+        )
+        if not self.same_identity_only:
+            raise M3aTypeError("M3aEnsureLatchedIntent requires same_identity_only=true")
+        object.__setattr__(
+            self,
+            "max_displacement_m",
+            _require_finite(self.max_displacement_m, field_name="max_displacement_m"),
+        )
+        if self.expires_at is not None:
+            object.__setattr__(
+                self, "expires_at", _require_datetime(self.expires_at, field_name="expires_at")
+            )
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "operation_id": self.operation_id,
+            "intent_revision": self.intent_revision,
+            "semantic_effect_id": self.semantic_effect_id,
+            "target_entity_id": self.target_entity_id,
+            "desired_latched": self.desired_latched,
+            "reference_observation_id": self.reference_observation_id,
+            "reference_detection_id": self.reference_detection_id,
+            "reference_digest": self.reference_digest,
+            "reference_pose": _pose_dump(self.reference_pose, mode=mode),
+            "reference_frame_id": self.reference_frame_id,
+            "reference_calibration_version": self.reference_calibration_version,
+            "reference_world_revision": self.reference_world_revision,
+            "reference_observed_at": self.reference_observed_at,
+            "same_identity_only": self.same_identity_only,
+            "max_displacement_m": self.max_displacement_m,
+            "expires_at": self.expires_at,
+        }
+        if mode == "json":
+            result["operation_id"] = str(self.operation_id)
+            result["reference_observed_at"] = _utc_text(self.reference_observed_at)
+            result["expires_at"] = _utc_text(self.expires_at) if self.expires_at else None
+        return result
+
+    @property
+    def canonical_intent_digest(self) -> str:
+        return canonical_digest(self.model_dump(mode="python"))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class M3aSpatialExecutionContext:
+    """Field's verified contract/context binding delivered to Robot."""
+
+    operation_id: UUID
+    intent_revision: int
+    contract_id: UUID
+    contract_revision: int
+    task_id: UUID
+    semantic_effect_id: str
+    target_entity_id: str
+    reference_observation_id: str
+    reference_detection_id: str
+    reference_digest: str
+    reference_pose: Pose
+    reference_frame_id: str
+    reference_calibration_version: str
+    reference_world_revision: int
+    reference_observed_at: datetime
+    current_observation_envelope_id: str
+    current_observation: TwoButtonObservation
+    reference_observation: TwoButtonObservation | None = None
+    same_identity_only: bool = True
+    max_displacement_m: float = 0.0
+    expires_at: datetime | None = None
+    expected_device_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "operation_id", _require_uuid(self.operation_id, field_name="operation_id")
+        )
+        object.__setattr__(
+            self, "contract_id", _require_uuid(self.contract_id, field_name="contract_id")
+        )
+        object.__setattr__(self, "task_id", _require_uuid(self.task_id, field_name="task_id"))
+        if self.intent_revision != 1 or self.contract_revision != 1:
+            raise M3aTypeError("M3a spatial context supports revision 1 only")
+        object.__setattr__(
+            self,
+            "semantic_effect_id",
+            _require_text(self.semantic_effect_id, field_name="semantic_effect_id"),
+        )
+        object.__setattr__(
+            self,
+            "target_entity_id",
+            _require_text(self.target_entity_id, field_name="target_entity_id"),
+        )
+        for field_name in (
+            "reference_observation_id",
+            "reference_detection_id",
+            "reference_digest",
+            "reference_frame_id",
+            "reference_calibration_version",
+            "current_observation_envelope_id",
+        ):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name=field_name)
+            )
+        object.__setattr__(
+            self, "reference_pose", _require_pose(self.reference_pose, field_name="reference_pose")
+        )
+        if self.reference_pose.frame.frame_id != self.reference_frame_id:
+            raise M3aTypeError("reference_pose frame does not match reference_frame_id")
+        if self.reference_pose.frame.calibration_version != self.reference_calibration_version:
+            raise M3aTypeError(
+                "reference_pose calibration does not match reference_calibration_version"
+            )
+        object.__setattr__(
+            self,
+            "reference_world_revision",
+            _require_int(
+                self.reference_world_revision, field_name="reference_world_revision", minimum=1
+            ),
+        )
+        object.__setattr__(
+            self,
+            "reference_observed_at",
+            _require_datetime(self.reference_observed_at, field_name="reference_observed_at"),
+        )
+        object.__setattr__(self, "current_observation", self.current_observation)
+        if not isinstance(self.current_observation, TwoButtonObservation):
+            raise M3aTypeError("current_observation must be TwoButtonObservation")
+        if self.reference_observation is not None:
+            if not isinstance(self.reference_observation, TwoButtonObservation):
+                raise M3aTypeError("reference_observation must be TwoButtonObservation")
+            if self.reference_observation.observation_id != self.reference_observation_id:
+                raise M3aTypeError("reference_observation ID differs from context binding")
+            if self.reference_observation.canonical_payload_digest != self.reference_digest:
+                raise M3aTypeError("reference_observation digest differs from context binding")
+        object.__setattr__(
+            self,
+            "same_identity_only",
+            _require_bool(self.same_identity_only, field_name="same_identity_only"),
+        )
+        if not self.same_identity_only:
+            raise M3aTypeError("M3a spatial context requires same_identity_only=true")
+        object.__setattr__(
+            self,
+            "max_displacement_m",
+            _require_finite(self.max_displacement_m, field_name="max_displacement_m"),
+        )
+        if self.expires_at is not None:
+            object.__setattr__(
+                self, "expires_at", _require_datetime(self.expires_at, field_name="expires_at")
+            )
+        if self.expected_device_id is not None:
+            object.__setattr__(
+                self,
+                "expected_device_id",
+                _require_text(self.expected_device_id, field_name="expected_device_id"),
+            )
+
+    @property
+    def current_observation_canonical_payload_digest(self) -> str:
+        return self.current_observation.canonical_payload_digest
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "operation_id": self.operation_id,
+            "intent_revision": self.intent_revision,
+            "contract_id": self.contract_id,
+            "contract_revision": self.contract_revision,
+            "task_id": self.task_id,
+            "semantic_effect_id": self.semantic_effect_id,
+            "target_entity_id": self.target_entity_id,
+            "reference_observation_id": self.reference_observation_id,
+            "reference_detection_id": self.reference_detection_id,
+            "reference_digest": self.reference_digest,
+            "reference_pose": _pose_dump(self.reference_pose, mode=mode),
+            "reference_frame_id": self.reference_frame_id,
+            "reference_calibration_version": self.reference_calibration_version,
+            "reference_world_revision": self.reference_world_revision,
+            "reference_observed_at": self.reference_observed_at,
+            "current_observation_envelope_id": self.current_observation_envelope_id,
+            "current_observation": self.current_observation.model_dump(mode=mode),
+            "reference_observation": (
+                self.reference_observation.model_dump(mode=mode)
+                if self.reference_observation is not None
+                else None
+            ),
+            "same_identity_only": self.same_identity_only,
+            "max_displacement_m": self.max_displacement_m,
+            "expires_at": self.expires_at,
+            "expected_device_id": self.expected_device_id,
+        }
+        if mode == "json":
+            result["operation_id"] = str(self.operation_id)
+            result["contract_id"] = str(self.contract_id)
+            result["task_id"] = str(self.task_id)
+            result["reference_observed_at"] = _utc_text(self.reference_observed_at)
+            result["expires_at"] = _utc_text(self.expires_at) if self.expires_at else None
+        return result
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SpatialPressCommand:
+    """The only physical command accepted by the spatial fixture."""
+
+    command_id: str
+    effect_key: str
+    position_m: tuple[float, float, float]
+    frame_id: str
+    calibration_version: str
+    source_observation_id: str
+    source_detection_id: str
+    command_digest: str = ""
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "command_id",
+            "effect_key",
+            "frame_id",
+            "calibration_version",
+            "source_observation_id",
+            "source_detection_id",
+        ):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name=field_name)
+            )
+        if isinstance(self.position_m, (str, bytes)) or not isinstance(
+            self.position_m, (tuple, list)
+        ):
+            raise M3aTypeError("position_m must contain exactly three numbers")
+        if len(self.position_m) != 3:
+            raise M3aTypeError("position_m must contain exactly three numbers")
+        position = tuple(
+            _require_finite(component, field_name="position_m component", minimum=-math.inf)
+            for component in self.position_m
+        )
+        object.__setattr__(self, "position_m", position)
+        expected = canonical_digest(self._payload_without_digest())
+        if self.command_digest:
+            object.__setattr__(
+                self,
+                "command_digest",
+                _validate_digest(
+                    self.command_digest, expected=expected, field_name="command_digest"
+                ),
+            )
+        else:
+            object.__setattr__(self, "command_digest", expected)
+
+    def _payload_without_digest(self) -> dict[str, Any]:
+        return {
+            "command_id": self.command_id,
+            "effect_key": self.effect_key,
+            "position_m": self.position_m,
+            "frame_id": self.frame_id,
+            "calibration_version": self.calibration_version,
+            "source_observation_id": self.source_observation_id,
+            "source_detection_id": self.source_detection_id,
+        }
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        return {**self._payload_without_digest(), "command_digest": self.command_digest}
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_bytes(self._payload_without_digest())
+
+    @classmethod
+    def from_pose(
+        cls,
+        *,
+        command_id: str,
+        effect_key: str,
+        pose: Pose,
+        source_observation_id: str,
+        source_detection_id: str,
+    ) -> SpatialPressCommand:
+        return cls(
+            command_id=command_id,
+            effect_key=effect_key,
+            position_m=(pose.position.x, pose.position.y, pose.position.z),
+            frame_id=pose.frame.frame_id,
+            calibration_version=pose.frame.calibration_version,
+            source_observation_id=source_observation_id,
+            source_detection_id=source_detection_id,
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SpatialBindingReceipt:
+    """Durable device receipt returned by ``bind``."""
+
+    device_id: str
+    effect_key: str
+    command_digest: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "device_id", _require_text(self.device_id, field_name="device_id"))
+        object.__setattr__(
+            self, "effect_key", _require_text(self.effect_key, field_name="effect_key")
+        )
+        object.__setattr__(
+            self, "command_digest", _require_text(self.command_digest, field_name="command_digest")
+        )
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, str]:
+        return {
+            "device_id": self.device_id,
+            "effect_key": self.effect_key,
+            "command_digest": self.command_digest,
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TwoButtonLevelEvidence:
+    """Independent level sensor evidence for one named button."""
+
+    target_entity_id: str
+    desired_latched: bool
+    actual_latched: bool
+    device_id: str
+    counter: int
+    observed_at: datetime
+    evidence_observation_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("target_entity_id", "device_id", "evidence_observation_id"):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name=field_name)
+            )
+        object.__setattr__(
+            self,
+            "desired_latched",
+            _require_bool(self.desired_latched, field_name="desired_latched"),
+        )
+        object.__setattr__(
+            self, "actual_latched", _require_bool(self.actual_latched, field_name="actual_latched")
+        )
+        object.__setattr__(
+            self, "counter", _require_int(self.counter, field_name="counter", minimum=0)
+        )
+        object.__setattr__(
+            self, "observed_at", _require_datetime(self.observed_at, field_name="observed_at")
+        )
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        return {
+            "target_entity_id": self.target_entity_id,
+            "desired_latched": self.desired_latched,
+            "actual_latched": self.actual_latched,
+            "device_id": self.device_id,
+            "counter": self.counter,
+            "observed_at": _utc_text(self.observed_at) if mode == "json" else self.observed_at,
+            "evidence_observation_id": self.evidence_observation_id,
+        }
+
+
+class TwoButtonAction(StrEnum):
+    EXECUTE = "EXECUTE"
+    REANCHOR_EXECUTE = "REANCHOR_EXECUTE"
+    HOLD_AMBIGUOUS = "HOLD_AMBIGUOUS"
+    HOLD_REFERENCE_MISMATCH = "HOLD_REFERENCE_MISMATCH"
+    HOLD_CONTEXT_MISMATCH = "HOLD_CONTEXT_MISMATCH"
+    RECOGNIZE_EFFECT = "RECOGNIZE_EFFECT"
+
+
+# Names used in early design notes are kept as aliases so callers do not need
+# to duplicate enum conversion logic while the service layer is integrated.
+LocalTwoButtonAction = TwoButtonAction
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LocalTwoButtonDecision:
+    """Pure Robot decision, including the reason for every hold."""
+
+    operation_id: UUID
+    intent_revision: int
+    semantic_effect_id: str
+    reference_observation_id: str
+    current_observation_id: str
+    action: TwoButtonAction
+    reason: str
+    selected_detection_id: str | None = None
+    displacement_m: float | None = None
+    budget_state: str = "NOT_ADMITTED"
+    command_digest: str | None = None
+    level_evidence_observation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "operation_id", _require_uuid(self.operation_id, field_name="operation_id")
+        )
+        if self.intent_revision != 1:
+            raise M3aTypeError("LocalTwoButtonDecision supports intent_revision 1 only")
+        for field_name in (
+            "semantic_effect_id",
+            "reference_observation_id",
+            "current_observation_id",
+            "reason",
+            "budget_state",
+        ):
+            object.__setattr__(
+                self, field_name, _require_text(getattr(self, field_name), field_name=field_name)
+            )
+        if not isinstance(self.action, TwoButtonAction):
+            try:
+                object.__setattr__(self, "action", TwoButtonAction(self.action))
+            except (TypeError, ValueError) as error:
+                raise M3aTypeError("action is not a supported M3a two-button action") from error
+        if self.selected_detection_id is not None:
+            object.__setattr__(
+                self,
+                "selected_detection_id",
+                _require_text(self.selected_detection_id, field_name="selected_detection_id"),
+            )
+        if self.displacement_m is not None:
+            object.__setattr__(
+                self,
+                "displacement_m",
+                _require_finite(self.displacement_m, field_name="displacement_m"),
+            )
+        if self.command_digest is not None:
+            object.__setattr__(
+                self,
+                "command_digest",
+                _require_text(self.command_digest, field_name="command_digest"),
+            )
+        if self.level_evidence_observation_id is not None:
+            object.__setattr__(
+                self,
+                "level_evidence_observation_id",
+                _require_text(
+                    self.level_evidence_observation_id, field_name="level_evidence_observation_id"
+                ),
+            )
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "operation_id": self.operation_id,
+            "intent_revision": self.intent_revision,
+            "semantic_effect_id": self.semantic_effect_id,
+            "reference_observation_id": self.reference_observation_id,
+            "current_observation_id": self.current_observation_id,
+            "action": self.action.value,
+            "reason": self.reason,
+            "selected_detection_id": self.selected_detection_id,
+            "displacement_m": self.displacement_m,
+            "budget_state": self.budget_state,
+            "command_digest": self.command_digest,
+            "level_evidence_observation_id": self.level_evidence_observation_id,
+        }
+        if mode == "json":
+            result["operation_id"] = str(self.operation_id)
+        return result
+
+
+__all__ = [
+    "EntityDetection",
+    "LocalTwoButtonAction",
+    "LocalTwoButtonDecision",
+    "M3aEnsureLatchedIntent",
+    "M3aSpatialExecutionContext",
+    "M3aTypeError",
+    "SpatialBindingReceipt",
+    "SpatialPressCommand",
+    "TwoButtonAction",
+    "TwoButtonLevelEvidence",
+    "TwoButtonObservation",
+    "canonical_bytes",
+    "canonical_digest",
+]

--- a/python/src/deferred_teleop/mission_view.py
+++ b/python/src/deferred_teleop/mission_view.py
@@ -14,9 +14,14 @@ from deferred_teleop.protocol import (
     ArticulatedRobotState,
     ContractState,
     EvidenceMetadata,
+    LocalTwoButtonDecision,
     Pose,
     PredictionManifest,
     ProvenanceKind,
+    SpatialPressCommand,
+    TwoButtonEffectEvidence,
+    TwoButtonLevelEvidence,
+    TwoButtonObservation,
     WireModel,
 )
 
@@ -107,6 +112,53 @@ class MissionViewState(WireModel):
     trajectory_forecasts: tuple[TimedTrajectorySample, ...]
     prediction_manifests: tuple[PredictionManifest, ...]
     status: MissionViewStatus
+
+
+class M3aMissionViewState(WireModel):
+    """Dedicated read model for the observed spatial two-button slice.
+
+    The historical ``mission.view_state`` remains unchanged.  This model keeps
+    the M3a evidence and physical proof together so a client can distinguish a
+    semantic decision, a dispatched command, and the device's contact result.
+    """
+
+    protocol_version: Literal["dtt/0"] = "dtt/0"
+    message_type: Literal["m3a.view"] = "m3a.view"
+    source_id: Annotated[str, Field(min_length=1)]
+    source_sequence: Annotated[int, Field(ge=1)]
+    produced_at: datetime
+    operation_id: UUID | None
+    correlation_id: UUID | None
+    configured_one_way_delay_seconds: Annotated[float, Field(ge=0.0)]
+    reference_observation: TwoButtonObservation | None
+    current_observation: TwoButtonObservation | None
+    level_evidence: TwoButtonLevelEvidence | None
+    decision: LocalTwoButtonDecision | None
+    command: SpatialPressCommand | None
+    effect_evidence: TwoButtonEffectEvidence | None
+    contract_id: UUID | None
+    contract_state: ContractState | None
+    terminal_result: dict[str, object] | None
+    business_result: str | None
+    physical_contact: Literal["A", "B", "NONE"] | None
+    a_counter: Annotated[int | None, Field(ge=0)]
+    b_counter: Annotated[int | None, Field(ge=0)]
+    a_latched: bool | None
+    b_latched: bool | None
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> M3aMissionViewState:
+        if not self.source_id.strip():
+            raise ValueError("source_id must not be blank")
+        if self.business_result is not None and not self.business_result.strip():
+            raise ValueError("business_result must not be blank")
+        return self
+
+
+# A short alias keeps call sites readable while retaining the explicit model
+# name for schema and documentation consumers.
+M3aViewState = M3aMissionViewState
+M3ATwoButtonViewState = M3aMissionViewState
 
 
 class ArticulatedArrivalRobotState(WireModel):

--- a/python/src/deferred_teleop/protocol.py
+++ b/python/src/deferred_teleop/protocol.py
@@ -307,6 +307,242 @@ class PredictionManifest(WireModel):
         return self
 
 
+class EntityDetection(WireModel):
+    """One M3a observed candidate set and measured spatial pose."""
+
+    detection_id: OpaqueId
+    candidate_entity_ids: tuple[OpaqueId, ...]
+    pose: Pose
+    visibility: bool
+    source_evidence_id: OpaqueId
+
+    @model_validator(mode="after")
+    def validate_candidates(self) -> EntityDetection:
+        if not self.candidate_entity_ids:
+            raise ValueError("candidate_entity_ids must not be empty")
+        if len(set(self.candidate_entity_ids)) != len(self.candidate_entity_ids):
+            raise ValueError("candidate_entity_ids must not contain duplicates")
+        return self
+
+
+class TwoButtonObservation(WireModel):
+    """Persisted reference/current observation envelope for M3a."""
+
+    observation_id: OpaqueId
+    source_id: OpaqueId
+    world_revision: Revision
+    observed_at: datetime
+    produced_at: datetime
+    frame_id: OpaqueId
+    calibration_version: OpaqueId
+    canonical_payload_digest: Annotated[
+        str,
+        Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+    ]
+    detections: tuple[EntityDetection, ...]
+
+    @model_validator(mode="after")
+    def validate_observation(self) -> TwoButtonObservation:
+        if self.produced_at < self.observed_at:
+            raise ValueError("produced_at cannot precede observed_at")
+        if any(
+            detection.pose.frame.frame_id != self.frame_id
+            or detection.pose.frame.calibration_version != self.calibration_version
+            for detection in self.detections
+        ):
+            raise ValueError("detection pose context differs from observation context")
+        if len({detection.detection_id for detection in self.detections}) != len(self.detections):
+            raise ValueError("detections must not contain duplicate detection_id values")
+        return self
+
+
+class M3aEnsureLatchedIntent(WireModel):
+    """Revision-1 M3a root intent; only the true level effect is in scope."""
+
+    operation_id: UUID
+    intent_revision: Literal[1]
+    semantic_effect_id: OpaqueId
+    target_entity_id: OpaqueId
+    desired_latched: Literal[True]
+    reference_observation_id: OpaqueId
+    reference_detection_id: OpaqueId
+    reference_digest: Annotated[
+        str,
+        Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+    ]
+    reference_pose: Pose
+    reference_frame_id: OpaqueId
+    reference_calibration_version: OpaqueId
+    reference_world_revision: Revision
+    reference_observed_at: datetime
+    same_identity_only: Literal[True] = True
+    max_displacement_m: float = Field(ge=0.0)
+    expires_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def validate_reference_context(self) -> M3aEnsureLatchedIntent:
+        if self.reference_pose.frame.frame_id != self.reference_frame_id:
+            raise ValueError("reference_pose frame differs from reference_frame_id")
+        if self.reference_pose.frame.calibration_version != self.reference_calibration_version:
+            raise ValueError(
+                "reference_pose calibration differs from reference_calibration_version"
+            )
+        if self.expires_at is not None and self.expires_at < self.reference_observed_at:
+            raise ValueError("expires_at cannot precede reference_observed_at")
+        if not math.isfinite(self.max_displacement_m):
+            raise ValueError("max_displacement_m must be finite")
+        return self
+
+
+class M3aSpatialExecutionContext(WireModel):
+    """Field's verified contract/context and full current observation."""
+
+    operation_id: UUID
+    intent_revision: Literal[1]
+    contract_id: UUID
+    contract_revision: Literal[1]
+    task_id: UUID
+    semantic_effect_id: OpaqueId
+    target_entity_id: OpaqueId
+    reference_observation_id: OpaqueId
+    reference_detection_id: OpaqueId
+    reference_digest: Annotated[
+        str,
+        Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+    ]
+    reference_pose: Pose
+    reference_frame_id: OpaqueId
+    reference_calibration_version: OpaqueId
+    reference_world_revision: Revision
+    reference_observed_at: datetime
+    current_observation_envelope_id: OpaqueId
+    current_observation: TwoButtonObservation
+    reference_observation: TwoButtonObservation | None = None
+    same_identity_only: Literal[True] = True
+    max_displacement_m: float = Field(ge=0.0)
+    expires_at: datetime | None = None
+    expected_device_id: OpaqueId | None = None
+
+    @model_validator(mode="after")
+    def validate_context(self) -> M3aSpatialExecutionContext:
+        if self.reference_pose.frame.frame_id != self.reference_frame_id:
+            raise ValueError("reference_pose frame differs from reference_frame_id")
+        if self.reference_pose.frame.calibration_version != self.reference_calibration_version:
+            raise ValueError(
+                "reference_pose calibration differs from reference_calibration_version"
+            )
+        if self.current_observation.frame_id != self.reference_frame_id:
+            raise ValueError("current observation frame differs from reference frame")
+        if self.current_observation.calibration_version != self.reference_calibration_version:
+            raise ValueError("current observation calibration differs from reference calibration")
+        if self.reference_observation is not None:
+            if self.reference_observation.observation_id != self.reference_observation_id:
+                raise ValueError("reference observation ID differs from context binding")
+            if self.reference_observation.canonical_payload_digest != self.reference_digest:
+                raise ValueError("reference observation digest differs from context binding")
+        if not math.isfinite(self.max_displacement_m):
+            raise ValueError("max_displacement_m must be finite")
+        return self
+
+
+class SpatialPressCommand(WireModel):
+    """Immutable command addressed to the independent spatial adapter."""
+
+    command_id: OpaqueId
+    effect_key: OpaqueId
+    position_m: Vector3
+    frame_id: OpaqueId
+    calibration_version: OpaqueId
+    source_observation_id: OpaqueId
+    source_detection_id: OpaqueId
+    command_digest: Annotated[
+        str,
+        Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+    ]
+
+
+class TwoButtonLevelEvidence(WireModel):
+    """Independent level sensor proof for one named button."""
+
+    target_entity_id: OpaqueId
+    desired_latched: Literal[True]
+    actual_latched: bool
+    device_id: OpaqueId
+    counter: Annotated[int, Field(ge=0)]
+    observed_at: datetime
+    evidence_observation_id: OpaqueId
+
+
+class TwoButtonEffectEvidence(WireModel):
+    """Post-dispatch device proof for one M3a spatial effect."""
+
+    operation_id: UUID
+    intent_revision: Literal[1]
+    contract_id: UUID
+    contract_revision: Literal[1]
+    semantic_effect_id: OpaqueId
+    target_entity_id: OpaqueId
+    effect_key: OpaqueId
+    command_digest: Annotated[
+        str,
+        Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+    ]
+    device_id: OpaqueId
+    observation_id: OpaqueId
+    observed_at: datetime
+    outcome: Literal["APPLIED", "NOT_APPLIED", "UNKNOWN"]
+    # ``False`` means the digest below is the durable command expectation,
+    # because the adapter did not report a matching digest.  Such an effect is
+    # an explicit UNKNOWN diagnostic and cannot attribute contact or counters.
+    command_digest_verified: bool = True
+    command_digest_diagnostic: OpaqueId | None = None
+    physical_contact: Literal["A", "B", "NONE"] | None = None
+    command_executed: bool | None = None
+    semantic_goal_attained: bool | None = None
+    a_counter: Annotated[int, Field(ge=0)] | None = None
+    b_counter: Annotated[int, Field(ge=0)] | None = None
+    a_latched: bool | None = None
+    b_latched: bool | None = None
+
+
+class M3aAction(StrEnum):
+    EXECUTE = "EXECUTE"
+    REANCHOR_EXECUTE = "REANCHOR_EXECUTE"
+    HOLD_AMBIGUOUS = "HOLD_AMBIGUOUS"
+    HOLD_REFERENCE_MISMATCH = "HOLD_REFERENCE_MISMATCH"
+    HOLD_CONTEXT_MISMATCH = "HOLD_CONTEXT_MISMATCH"
+    RECOGNIZE_EFFECT = "RECOGNIZE_EFFECT"
+
+
+class LocalTwoButtonDecision(WireModel):
+    """Pure Robot decision with explicit action/reason and budget state."""
+
+    operation_id: UUID
+    intent_revision: Literal[1]
+    semantic_effect_id: OpaqueId
+    reference_observation_id: OpaqueId
+    current_observation_id: OpaqueId
+    action: M3aAction
+    reason: OpaqueId
+    selected_detection_id: OpaqueId | None = None
+    displacement_m: float | None = Field(default=None, ge=0.0)
+    budget_state: OpaqueId
+    command_digest: (
+        Annotated[
+            str,
+            Field(pattern=r"sha256:[0-9a-f]{64}", min_length=71, max_length=71),
+        ]
+        | None
+    ) = None
+    level_evidence_observation_id: OpaqueId | None = None
+
+    @model_validator(mode="after")
+    def validate_displacement(self) -> LocalTwoButtonDecision:
+        if self.displacement_m is not None and not math.isfinite(self.displacement_m):
+            raise ValueError("displacement_m must be finite")
+        return self
+
+
 Payload = Annotated[
     OperationIntent
     | GroundedOperation
@@ -318,13 +554,28 @@ Payload = Annotated[
     | ArticulatedRobotState
     | RobotForecast
     | SiteSnapshot
-    | PredictionManifest,
+    | PredictionManifest
+    | EntityDetection
+    | TwoButtonObservation
+    | M3aEnsureLatchedIntent
+    | M3aSpatialExecutionContext
+    | SpatialPressCommand
+    | TwoButtonLevelEvidence
+    | TwoButtonEffectEvidence
+    | LocalTwoButtonDecision,
     Field(union_mode="left_to_right"),
 ]
 
 
 ROOT_MESSAGE_TYPES = frozenset(
-    {"operation.intent", "robot.state", "robot.articulated_state", "site.snapshot"}
+    {
+        "operation.intent",
+        "robot.state",
+        "robot.articulated_state",
+        "site.snapshot",
+        "m3a.two_button.observation",
+        "m3a.ensure_latched.intent",
+    }
 )
 PAYLOAD_TYPES: dict[str, type[WireModel]] = {
     "operation.intent": OperationIntent,
@@ -338,6 +589,13 @@ PAYLOAD_TYPES: dict[str, type[WireModel]] = {
     "robot.forecast": RobotForecast,
     "site.snapshot": SiteSnapshot,
     "prediction.manifest": PredictionManifest,
+    "m3a.two_button.observation": TwoButtonObservation,
+    "m3a.ensure_latched.intent": M3aEnsureLatchedIntent,
+    "m3a.spatial.context": M3aSpatialExecutionContext,
+    "m3a.spatial.command": SpatialPressCommand,
+    "m3a.spatial.level": TwoButtonLevelEvidence,
+    "m3a.spatial.effect": TwoButtonEffectEvidence,
+    "m3a.spatial.decision": LocalTwoButtonDecision,
 }
 
 
@@ -356,6 +614,13 @@ class MessageEnvelope(WireModel):
         "robot.forecast",
         "site.snapshot",
         "prediction.manifest",
+        "m3a.two_button.observation",
+        "m3a.ensure_latched.intent",
+        "m3a.spatial.context",
+        "m3a.spatial.command",
+        "m3a.spatial.level",
+        "m3a.spatial.effect",
+        "m3a.spatial.decision",
     ]
     source_id: OpaqueId
     source_boot_id: UUID

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
@@ -14,10 +14,38 @@ from deferred_teleop.external_effect import (
     ExternalOutcome,
     coerce_observation,
 )
+from deferred_teleop.m3a_types import (
+    EntityDetection as LocalEntityDetection,
+)
+from deferred_teleop.m3a_types import (
+    LocalTwoButtonDecision as LocalM3aDecision,
+)
+from deferred_teleop.m3a_types import (
+    M3aEnsureLatchedIntent as LocalM3aIntent,
+)
+from deferred_teleop.m3a_types import (
+    M3aSpatialExecutionContext as LocalM3aContext,
+)
+from deferred_teleop.m3a_types import (
+    SpatialPressCommand as LocalM3aCommand,
+)
+from deferred_teleop.m3a_types import (
+    TwoButtonAction,
+)
+from deferred_teleop.m3a_types import (
+    TwoButtonLevelEvidence as LocalM3aLevelEvidence,
+)
+from deferred_teleop.m3a_types import (
+    TwoButtonObservation as LocalM3aObservation,
+)
+from deferred_teleop.m3a_types import (
+    canonical_digest as m3a_canonical_digest,
+)
 from deferred_teleop.mission_view import (
     ArrivalBeliefView,
     ArticulatedMissionViewState,
     ConfirmedStateView,
+    M3aMissionViewState,
     MissionConnectionState,
     MissionConnectionStatus,
     MissionViewState,
@@ -30,11 +58,16 @@ from deferred_teleop.protocol import (
     ApprovalPolicy,
     ArticulatedRobotState,
     ContractState,
+    EntityDetection,
     EntitySelector,
     EvidenceMetadata,
     ExecutionContract,
     ExecutionEvent,
     GroundedOperation,
+    LocalTwoButtonDecision,
+    M3aAction,
+    M3aEnsureLatchedIntent,
+    M3aSpatialExecutionContext,
     MessageEnvelope,
     OperationIntent,
     OperationPlan,
@@ -48,8 +81,12 @@ from deferred_teleop.protocol import (
     RobotState,
     SiteSnapshot,
     SpatialFrame,
+    SpatialPressCommand,
     TaskAssignment,
     TaskNode,
+    TwoButtonEffectEvidence,
+    TwoButtonLevelEvidence,
+    TwoButtonObservation,
     Vector3,
     WireModel,
 )
@@ -66,6 +103,11 @@ from deferred_teleop.storage import (
     BudgetScopeConflictError,
     NodeStore,
     RecordConflictError,
+)
+from deferred_teleop.two_button_policy import (
+    decide_two_button,
+    derive_spatial_press_command,
+    verify_reference,
 )
 
 TERMINAL_STATES = frozenset(
@@ -230,22 +272,26 @@ class EnvelopeFactory:
         payload: WireModel,
         *,
         causation_id: UUID | None = None,
+        not_before: datetime | None = None,
         expires_at: datetime | None = None,
         message_id: UUID | None = None,
         created_at: datetime | None = None,
+        source_id: str | None = None,
+        source_boot_id: UUID | None = None,
     ) -> MessageEnvelope:
         self._sequence += 1
         timestamp = created_at or self.clock.now() + timedelta(microseconds=self._sequence)
         return MessageEnvelope(
             message_id=message_id or self.uuid_factory(),
             message_type=message_type,
-            source_id=self.node_id,
-            source_boot_id=self.boot_id,
+            source_id=source_id or self.node_id,
+            source_boot_id=source_boot_id or self.boot_id,
             source_sequence=self._sequence,
             destination_id=destination_id,
             correlation_id=correlation_id,
             causation_id=causation_id,
             created_at=timestamp,
+            not_before=not_before,
             expires_at=expires_at,
             payload=payload,
         )
@@ -266,18 +312,186 @@ def evidence(
     *,
     world_revision: int,
     fresh_for_seconds: float = 30.0,
+    produced_at: datetime | None = None,
 ) -> EvidenceMetadata:
+    produced = produced_at or now
     return EvidenceMetadata(
         source_ids=(source_id,),
         observed_at=now,
-        produced_at=now,
+        produced_at=produced,
         provenance=provenance,
         world_revision=world_revision,
-        fresh_until=now + timedelta(seconds=fresh_for_seconds),
+        fresh_until=produced + timedelta(seconds=fresh_for_seconds),
         model_version="dummy-constant-velocity-v1"
         if provenance in {ProvenanceKind.PREDICTED, ProvenanceKind.SIMULATED}
         else None,
     )
+
+
+def _m3a_local_observation(payload: TwoButtonObservation) -> LocalM3aObservation:
+    """Convert a strict wire observation to the pure-policy value type."""
+
+    return LocalM3aObservation(
+        observation_id=payload.observation_id,
+        source_id=payload.source_id,
+        world_revision=payload.world_revision,
+        observed_at=payload.observed_at,
+        produced_at=payload.produced_at,
+        frame_id=payload.frame_id,
+        calibration_version=payload.calibration_version,
+        detections=tuple(
+            LocalEntityDetection(
+                detection_id=detection.detection_id,
+                candidate_entity_ids=tuple(detection.candidate_entity_ids),
+                pose=detection.pose,
+                visibility=detection.visibility,
+                source_evidence_id=detection.source_evidence_id,
+            )
+            for detection in payload.detections
+        ),
+        canonical_payload_digest=payload.canonical_payload_digest,
+    )
+
+
+def _m3a_wire_observation(payload: LocalM3aObservation) -> TwoButtonObservation:
+    """Convert an immutable local observation into its wire envelope payload."""
+
+    return TwoButtonObservation(
+        observation_id=payload.observation_id,
+        source_id=payload.source_id,
+        world_revision=payload.world_revision,
+        observed_at=payload.observed_at,
+        produced_at=payload.produced_at,
+        frame_id=payload.frame_id,
+        calibration_version=payload.calibration_version,
+        canonical_payload_digest=payload.canonical_payload_digest,
+        detections=tuple(
+            EntityDetection(
+                detection_id=detection.detection_id,
+                candidate_entity_ids=tuple(detection.candidate_entity_ids),
+                pose=detection.pose,
+                visibility=detection.visibility,
+                source_evidence_id=detection.source_evidence_id,
+            )
+            for detection in payload.detections
+        ),
+    )
+
+
+def _m3a_local_intent(payload: M3aEnsureLatchedIntent) -> LocalM3aIntent:
+    return LocalM3aIntent(
+        operation_id=payload.operation_id,
+        intent_revision=payload.intent_revision,
+        semantic_effect_id=payload.semantic_effect_id,
+        target_entity_id=payload.target_entity_id,
+        desired_latched=payload.desired_latched,
+        reference_observation_id=payload.reference_observation_id,
+        reference_detection_id=payload.reference_detection_id,
+        reference_digest=payload.reference_digest,
+        reference_pose=payload.reference_pose,
+        reference_frame_id=payload.reference_frame_id,
+        reference_calibration_version=payload.reference_calibration_version,
+        reference_world_revision=payload.reference_world_revision,
+        reference_observed_at=payload.reference_observed_at,
+        same_identity_only=payload.same_identity_only,
+        max_displacement_m=payload.max_displacement_m,
+        expires_at=payload.expires_at,
+    )
+
+
+def _m3a_wire_level(payload: LocalM3aLevelEvidence) -> TwoButtonLevelEvidence:
+    return TwoButtonLevelEvidence(
+        target_entity_id=payload.target_entity_id,
+        desired_latched=payload.desired_latched,
+        actual_latched=payload.actual_latched,
+        device_id=payload.device_id,
+        counter=payload.counter,
+        observed_at=payload.observed_at,
+        evidence_observation_id=payload.evidence_observation_id,
+    )
+
+
+def _m3a_local_level(payload: TwoButtonLevelEvidence) -> LocalM3aLevelEvidence:
+    """Convert independent level proof to the local policy value type."""
+
+    return LocalM3aLevelEvidence(
+        target_entity_id=payload.target_entity_id,
+        desired_latched=payload.desired_latched,
+        actual_latched=payload.actual_latched,
+        device_id=payload.device_id,
+        counter=payload.counter,
+        observed_at=payload.observed_at,
+        evidence_observation_id=payload.evidence_observation_id,
+    )
+
+
+def _m3a_wire_decision(payload: LocalM3aDecision) -> LocalTwoButtonDecision:
+    return LocalTwoButtonDecision(
+        operation_id=payload.operation_id,
+        intent_revision=payload.intent_revision,
+        semantic_effect_id=payload.semantic_effect_id,
+        reference_observation_id=payload.reference_observation_id,
+        current_observation_id=payload.current_observation_id,
+        action=M3aAction(payload.action.value),
+        reason=payload.reason,
+        selected_detection_id=payload.selected_detection_id,
+        displacement_m=payload.displacement_m,
+        budget_state=payload.budget_state,
+        command_digest=payload.command_digest,
+        level_evidence_observation_id=payload.level_evidence_observation_id,
+    )
+
+
+def _m3a_wire_command(payload: LocalM3aCommand) -> SpatialPressCommand:
+    return SpatialPressCommand(
+        command_id=payload.command_id,
+        effect_key=payload.effect_key,
+        position_m=Vector3(
+            x=payload.position_m[0], y=payload.position_m[1], z=payload.position_m[2]
+        ),
+        frame_id=payload.frame_id,
+        calibration_version=payload.calibration_version,
+        source_observation_id=payload.source_observation_id,
+        source_detection_id=payload.source_detection_id,
+        command_digest=payload.command_digest,
+    )
+
+
+def _m3a_local_context(payload: M3aSpatialExecutionContext) -> LocalM3aContext:
+    """Convert the wire context into the policy's immutable local context."""
+
+    return LocalM3aContext(
+        operation_id=payload.operation_id,
+        intent_revision=payload.intent_revision,
+        contract_id=payload.contract_id,
+        contract_revision=payload.contract_revision,
+        task_id=payload.task_id,
+        semantic_effect_id=payload.semantic_effect_id,
+        target_entity_id=payload.target_entity_id,
+        reference_observation_id=payload.reference_observation_id,
+        reference_detection_id=payload.reference_detection_id,
+        reference_digest=payload.reference_digest,
+        reference_pose=payload.reference_pose,
+        reference_frame_id=payload.reference_frame_id,
+        reference_calibration_version=payload.reference_calibration_version,
+        reference_world_revision=payload.reference_world_revision,
+        reference_observed_at=payload.reference_observed_at,
+        current_observation_envelope_id=payload.current_observation_envelope_id,
+        current_observation=_m3a_local_observation(payload.current_observation),
+        reference_observation=(
+            _m3a_local_observation(payload.reference_observation)
+            if payload.reference_observation is not None
+            else None
+        ),
+        same_identity_only=payload.same_identity_only,
+        max_displacement_m=payload.max_displacement_m,
+        expires_at=payload.expires_at,
+        expected_device_id=payload.expected_device_id,
+    )
+
+
+def _m3a_intent_digest(payload: M3aEnsureLatchedIntent) -> str:
+    return m3a_canonical_digest(payload.model_dump(mode="python"))
 
 
 def _message_id_key(message: MessageEnvelope) -> str:
@@ -1666,6 +1880,9 @@ class DummyRobotService(RuntimeService):
         effect_key: str,
         dispatch_recorded_now: bool,
         expected_device_id: str,
+        expected_contact: str | None = None,
+        m3a_context: LocalM3aContext | None = None,
+        command_digest: str | None = None,
     ) -> None:
         """Issue or recover one external effect without a hidden retry.
 
@@ -1747,6 +1964,52 @@ class DummyRobotService(RuntimeService):
             expected_effect_key=effect_key,
             expected_device_id=expected_device_id,
         )
+        unverified_digest_diagnostic: str | None = None
+        if m3a_context is not None:
+            reported_digest = observation.details.get("command_digest")
+            if command_digest is None:
+                unverified_digest_diagnostic = "M3A_COMMAND_DIGEST_EXPECTATION_UNAVAILABLE"
+            elif reported_digest is None:
+                unverified_digest_diagnostic = "M3A_COMMAND_DIGEST_MISSING"
+            elif reported_digest != command_digest:
+                unverified_digest_diagnostic = "M3A_COMMAND_DIGEST_MISMATCH"
+            if unverified_digest_diagnostic is not None:
+                observation = ExternalEffectObservation(
+                    effect_key=observation.effect_key,
+                    device_id=observation.device_id,
+                    outcome=ExternalOutcome.UNKNOWN,
+                    observed_at=observation.observed_at,
+                    observation_id=observation.observation_id,
+                    details={
+                        **dict(observation.details),
+                        "command_digest_verified": False,
+                        "command_digest_diagnostic": unverified_digest_diagnostic,
+                        "expected_command_digest": command_digest,
+                        "reported_command_digest": reported_digest,
+                    },
+                )
+        # An external adapter's APPLIED proof establishes that a command made
+        # contact with *something*.  M3a's semantic goal is narrower: the
+        # intended button must be the contact.  Preserve the low-level proof
+        # in ``details`` while resolving a B/NONE contact as a held semantic
+        # goal, so a fixed-reference ablation cannot forge A success.
+        if unverified_digest_diagnostic is None and expected_contact is not None and (
+            observation.outcome is not ExternalOutcome.APPLIED
+            or observation.details.get("contact") != expected_contact
+        ):
+            observation = ExternalEffectObservation(
+                effect_key=observation.effect_key,
+                device_id=observation.device_id,
+                outcome=ExternalOutcome.NOT_APPLIED,
+                observed_at=observation.observed_at,
+                observation_id=observation.observation_id,
+                details={
+                    **dict(observation.details),
+                    "command_executed": observation.outcome is ExternalOutcome.APPLIED,
+                    "semantic_goal_attained": False,
+                    "expected_contact": expected_contact,
+                },
+            )
         terminal_state = (
             ContractState.SUCCEEDED
             if observation.outcome is ExternalOutcome.APPLIED
@@ -1761,6 +2024,28 @@ class DummyRobotService(RuntimeService):
             occurred_at=terminal_at,
             causation_id=running_event.message_id,
         )
+        m3a_outgoing: tuple[MessageEnvelope, ...] = ()
+        if m3a_context is not None:
+            if command_digest is not None:
+                effect_envelope = (
+                    self._m3a_unverified_effect_envelope(
+                        envelope,
+                        context=m3a_context,
+                        command_digest=command_digest,
+                        observation=observation,
+                        terminal_event=terminal_event,
+                        diagnostic=unverified_digest_diagnostic,
+                    )
+                    if unverified_digest_diagnostic is not None
+                    else self._m3a_effect_envelope(
+                        envelope,
+                        context=m3a_context,
+                        command_digest=command_digest,
+                        observation=observation,
+                        terminal_event=terminal_event,
+                    )
+                )
+                m3a_outgoing = (effect_envelope,)
         resolution = {
             ExternalOutcome.APPLIED: "APPLIED",
             ExternalOutcome.UNKNOWN: "OUTCOME_UNKNOWN",
@@ -1780,6 +2065,7 @@ class DummyRobotService(RuntimeService):
             },
             occurred_at=terminal_at,
             terminal_event=terminal_event,
+            outgoing=m3a_outgoing,
         )
         self.store.append_execution_audit(
             contract.contract_id,
@@ -1955,3 +2241,2640 @@ class DummyRobotService(RuntimeService):
             "robot.terminal_replayed",
             {"contract_id": str(contract.contract_id), "state": terminal.value},
         )
+
+
+def _m3a_as_wire_observation(
+    value: TwoButtonObservation | LocalM3aObservation,
+) -> TwoButtonObservation:
+    if isinstance(value, TwoButtonObservation):
+        return value
+    if isinstance(value, LocalM3aObservation):
+        return _m3a_wire_observation(value)
+    raise TypeError("M3a observation must be a wire or local TwoButtonObservation")
+
+
+def _m3a_uuid(operation_id: UUID, label: str) -> UUID:
+    """Return a stable identifier for one M3a bundle member."""
+
+    return uuid5(NAMESPACE_URL, f"dtt-m3a:{operation_id}:1:{label}")
+
+
+class _M3aMissionMixin:
+    """Mission authoring and read-model support for the isolated M3a slice."""
+
+    def submit_ensure_button_latched(
+        self,
+        reference_observation: TwoButtonObservation | LocalM3aObservation,
+        *,
+        current_observation: TwoButtonObservation | LocalM3aObservation | None = None,
+        target_entity_id: str = "A",
+        semantic_effect_id: str = "ensure-latched:A",
+        max_displacement_m: float = 0.05,
+        operation_id: UUID | None = None,
+        correlation_id: UUID | None = None,
+        observer_id: str | None = None,
+        transit_seconds: float | None = None,
+        expires_in_seconds: float | None = None,
+    ) -> MessageEnvelope:
+        """Persist one reference and author its delayed revision-1 intent.
+
+        The caller supplies observer output; Mission never asks the device for
+        a hidden position.  It persists and forwards the authoring reference,
+        then authors the delayed intent.  Current observations are acquired
+        locally by Field after the delayed transit.  The optional current value
+        is retained only as a Mission-side compatibility/view record and is
+        never forwarded to Field by this method.
+        """
+
+        reference = _m3a_as_wire_observation(reference_observation)
+        current = (
+            _m3a_as_wire_observation(current_observation)
+            if current_observation is not None
+            else None
+        )
+        operation = operation_id or self.factory.uuid_factory()
+        correlation = correlation_id or operation
+        observer = observer_id or reference.source_id
+        delay = (
+            self.configured_one_way_delay
+            if transit_seconds is None
+            else float(transit_seconds)
+        )
+        if delay < 0.0:
+            raise ValueError("transit_seconds must be >= 0")
+        now = self.clock.now()
+        reference_envelope = self.factory.make(
+            "m3a.two_button.observation",
+            self.factory.node_id,
+            correlation,
+            reference,
+            source_id=observer,
+            created_at=now,
+        )
+        # Observer output is durably present at Mission before authoring.  A
+        # duplicate submission keeps the first immutable payload.
+        self.store.receive(reference_envelope, received_at=now)
+        field_reference = self.factory.make(
+            "m3a.two_button.observation",
+            "field-1",
+            correlation,
+            reference,
+            source_id=observer,
+            source_boot_id=reference_envelope.source_boot_id,
+            created_at=reference_envelope.created_at,
+            message_id=_m3a_uuid(operation, "reference-field-envelope"),
+        )
+        self.store.enqueue(field_reference)
+
+        not_before = reference_envelope.created_at + timedelta(seconds=delay)
+        if current is not None:
+            # TEST-ONLY compatibility: retain a Mission copy for the dedicated
+            # view.  This value is never sent to Field; production callers use
+            # record_m3a_current_observation after the delayed transit.
+            mission_current = self.factory.make(
+                "m3a.two_button.observation",
+                self.factory.node_id,
+                correlation,
+                current,
+                source_id=observer,
+                source_boot_id=reference_envelope.source_boot_id,
+                created_at=now,
+                not_before=not_before,
+                message_id=_m3a_uuid(operation, "current-mission-envelope"),
+            )
+            self.store.enqueue(mission_current)
+
+        persisted_reference = next(
+            (
+                message.payload
+                for message in self.store.inbox_messages()
+                if isinstance(message.payload, TwoButtonObservation)
+                and message.payload.observation_id == reference.observation_id
+            ),
+            None,
+        )
+        if persisted_reference is None:
+            raise RecordConflictError("M3a reference observation was not persisted at Mission")
+        detections = tuple(
+            detection
+            for detection in persisted_reference.detections
+            if detection.detection_id
+            and detection.candidate_entity_ids == (target_entity_id,)
+        )
+        if len(detections) != 1:
+            raise ValueError("M3a authoring requires one unique target detection")
+        expires_at = (
+            now + timedelta(seconds=float(expires_in_seconds))
+            if expires_in_seconds is not None
+            else None
+        )
+        intent_payload = M3aEnsureLatchedIntent(
+            operation_id=operation,
+            intent_revision=1,
+            semantic_effect_id=semantic_effect_id,
+            target_entity_id=target_entity_id,
+            desired_latched=True,
+            reference_observation_id=persisted_reference.observation_id,
+            reference_detection_id=detections[0].detection_id,
+            reference_digest=persisted_reference.canonical_payload_digest,
+            reference_pose=detections[0].pose,
+            reference_frame_id=persisted_reference.frame_id,
+            reference_calibration_version=persisted_reference.calibration_version,
+            reference_world_revision=persisted_reference.world_revision,
+            reference_observed_at=persisted_reference.observed_at,
+            same_identity_only=True,
+            max_displacement_m=float(max_displacement_m),
+            expires_at=expires_at,
+        )
+        intent_envelope = self.factory.make(
+            "m3a.ensure_latched.intent",
+            "field-1",
+            correlation,
+            intent_payload,
+            not_before=not_before,
+            expires_at=expires_at,
+            source_id=self.factory.node_id,
+            created_at=now,
+            message_id=_m3a_uuid(operation, "intent-envelope"),
+        )
+        self.store.enqueue(intent_envelope)
+        self.emit(
+            "mission.m3a_intent_submitted",
+            {
+                "operation_id": str(operation),
+                "message_id": str(intent_envelope.message_id),
+                "not_before": not_before.isoformat(),
+            },
+        )
+        return intent_envelope
+
+    # Common spellings used by small integration harnesses.
+    submit_m3a_ensure_latched = submit_ensure_button_latched
+    submit_m3a_intent = submit_ensure_button_latched
+
+    def publish_m3a_current_observation(
+        self,
+        observation: TwoButtonObservation | LocalM3aObservation,
+        *,
+        operation_id: UUID,
+        correlation_id: UUID | None = None,
+        observer_id: str | None = None,
+        transit_seconds: float | None = None,
+    ) -> MessageEnvelope:
+        """Schedule a pre-produced current observation (compatibility/test-only).
+
+        The central M3a service path acquires current truth through Field's
+        local ``record_m3a_current_observation`` after the virtual transit.
+        This method remains only for older harnesses that explicitly model a
+        separately transported current payload.
+        """
+
+        payload = _m3a_as_wire_observation(observation)
+        correlation = correlation_id or operation_id
+        delay = (
+            self.configured_one_way_delay
+            if transit_seconds is None
+            else float(transit_seconds)
+        )
+        created_at = self.clock.now()
+        envelope = self.factory.make(
+            "m3a.two_button.observation",
+            "field-1",
+            correlation,
+            payload,
+            source_id=observer_id or payload.source_id,
+            not_before=created_at + timedelta(seconds=delay),
+            created_at=created_at,
+            message_id=_m3a_uuid(operation_id, f"current-field-envelope:{payload.observation_id}"),
+        )
+        self.store.enqueue(envelope)
+        return envelope
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        if isinstance(envelope.payload, M3aSpatialExecutionContext):
+            if (
+                envelope.source_id != "field-1"
+                or envelope.destination_id != self.factory.node_id
+            ):
+                self.store.complete_inbox(
+                    envelope.message_id,
+                    processed_at=self.clock.now(),
+                    handler_result_reference="mission-m3a-context-rejected:transport",
+                )
+                return
+            try:
+                self.store.bind_m3a_context(
+                    envelope,
+                    bound_at=self.clock.now(),
+                )
+            except RecordConflictError as error:
+                self.store.complete_inbox(
+                    envelope.message_id,
+                    processed_at=self.clock.now(),
+                    handler_result_reference=f"mission-m3a-context-conflict:{error}",
+                )
+                return
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference="mission-m3a-context-bound",
+            )
+            return
+        if isinstance(envelope.payload, TwoButtonEffectEvidence):
+            self._process_m3a_effect_at_mission(envelope)
+            return
+        if isinstance(
+            envelope.payload,
+            (
+                TwoButtonObservation,
+                M3aEnsureLatchedIntent,
+                M3aSpatialExecutionContext,
+                SpatialPressCommand,
+                TwoButtonLevelEvidence,
+                TwoButtonEffectEvidence,
+                LocalTwoButtonDecision,
+            ),
+        ):
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"mission-m3a:{envelope.message_type}",
+            )
+            self.emit(
+                "mission.m3a_message",
+                {
+                    "message_id": str(envelope.message_id),
+                    "message_type": envelope.message_type,
+                },
+            )
+            return
+        await super().process_claimed(envelope)
+
+    def _m3a_effect_is_attributable(
+        self,
+        message: MessageEnvelope,
+        *,
+        intent_message: MessageEnvelope,
+        messages: tuple[MessageEnvelope, ...],
+    ) -> bool:
+        """Keep only effect proofs bound to the canonical M3a evidence chain."""
+
+        effect = message.payload
+        intent = intent_message.payload
+        if not isinstance(effect, TwoButtonEffectEvidence) or not isinstance(
+            intent, M3aEnsureLatchedIntent
+        ):
+            return False
+        if (
+            message.source_id != "field-1"
+            or message.destination_id != "mission-1"
+            or message.correlation_id != intent_message.correlation_id
+            or effect.operation_id != intent.operation_id
+            or effect.intent_revision != intent.intent_revision
+            or effect.semantic_effect_id != intent.semantic_effect_id
+            or effect.target_entity_id != intent.target_entity_id
+        ):
+            return False
+        context_binding = self.store.find_m3a_context_binding(
+            effect.contract_id,
+            effect.contract_revision,
+        )
+        if context_binding is None or (
+            context_binding.get("operation_id") != str(intent.operation_id)
+            or context_binding.get("intent_revision") != intent.intent_revision
+            or context_binding.get("source_id") != "field-1"
+            or context_binding.get("correlation_id") != str(intent_message.correlation_id)
+        ):
+            return False
+        expected_contexts = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, M3aSpatialExecutionContext)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == "mission-1"
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.operation_id == intent.operation_id
+            and candidate.payload.intent_revision == intent.intent_revision
+            and candidate.payload.contract_id == effect.contract_id
+            and candidate.payload.contract_revision == effect.contract_revision
+            and candidate.payload.semantic_effect_id == intent.semantic_effect_id
+            and candidate.payload.target_entity_id == intent.target_entity_id
+            and m3a_canonical_digest(candidate.payload.model_dump(mode="json"))
+            == context_binding.get("context_digest")
+        )
+        if not expected_contexts:
+            return False
+        context = expected_contexts[0]
+        expected_device_id = context.expected_device_id
+        if not expected_device_id or effect.device_id != expected_device_id:
+            return False
+        terminal_contract_ids = {
+            candidate.payload.contract_id
+            for candidate in messages
+            if isinstance(candidate.payload, ExecutionEvent)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == "mission-1"
+            and candidate.payload.next_state in TERMINAL_STATES
+            and candidate.correlation_id == intent_message.correlation_id
+        }
+        if effect.contract_id not in terminal_contract_ids:
+            return False
+        expected_effect_key = f"press:{effect.operation_id}:{effect.contract_revision}"
+        if effect.effect_key != expected_effect_key:
+            return False
+        matching_commands = {
+            candidate.payload.command_digest
+            for candidate in messages
+            if isinstance(candidate.payload, SpatialPressCommand)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == "mission-1"
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.effect_key == expected_effect_key
+        }
+        if effect.command_digest not in matching_commands:
+            return False
+        matching_decisions = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, LocalTwoButtonDecision)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == "mission-1"
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.operation_id == intent.operation_id
+            and candidate.payload.semantic_effect_id == intent.semantic_effect_id
+            and candidate.payload.reference_observation_id
+            == intent.reference_observation_id
+            and candidate.payload.command_digest == effect.command_digest
+        )
+        if not matching_decisions:
+            return False
+        if not any(
+            candidate.action in {
+                M3aAction.EXECUTE,
+                M3aAction.REANCHOR_EXECUTE,
+            }
+            for candidate in matching_decisions
+        ):
+            return False
+        if not effect.command_digest_verified:
+            if (
+                effect.outcome != "UNKNOWN"
+                or effect.physical_contact is not None
+                or effect.command_executed is not None
+                or effect.semantic_goal_attained is not None
+                or effect.a_counter is not None
+                or effect.b_counter is not None
+                or effect.a_latched is not None
+                or effect.b_latched is not None
+            ):
+                return False
+            return True
+        if effect.outcome == "APPLIED" and (
+            effect.command_executed is not True
+            or effect.semantic_goal_attained is not True
+            or effect.physical_contact != effect.target_entity_id
+        ):
+            return False
+        return not (
+            effect.semantic_goal_attained is True and effect.outcome != "APPLIED"
+        )
+
+    def _m3a_effect_matches_binding(
+        self,
+        message: MessageEnvelope,
+        binding: Mapping[str, Any],
+    ) -> bool:
+        """Check a message against the persisted effect and semantic provenance."""
+
+        effect = message.payload
+        bound_effect = binding.get("effect")
+        if not isinstance(effect, TwoButtonEffectEvidence) or not isinstance(
+            bound_effect, TwoButtonEffectEvidence
+        ):
+            return False
+        return (
+            binding.get("operation_id") == str(effect.operation_id)
+            and binding.get("intent_revision") == effect.intent_revision
+            and binding.get("effect_digest")
+            == m3a_canonical_digest(effect.model_dump(mode="json"))
+            and bound_effect.model_dump(mode="json") == effect.model_dump(mode="json")
+            and binding.get("source_id") == message.source_id
+            and binding.get("destination_id") == message.destination_id
+            and binding.get("correlation_id") == str(message.correlation_id)
+        )
+
+    def _m3a_effect_missing_dependency(
+        self,
+        effect: TwoButtonEffectEvidence,
+        *,
+        intent_message: MessageEnvelope,
+        messages: tuple[MessageEnvelope, ...],
+    ) -> str | None:
+        """Return a retry reason when Mission has not received chain facts yet."""
+
+        intent = intent_message.payload
+        assert isinstance(intent, M3aEnsureLatchedIntent)
+        context_binding = self.store.find_m3a_context_binding(
+            effect.contract_id,
+            effect.contract_revision,
+        )
+        if context_binding is None:
+            return "EFFECT_CONTEXT_NOT_YET_PERSISTED"
+        contexts = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, M3aSpatialExecutionContext)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == self.factory.node_id
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.operation_id == intent.operation_id
+            and candidate.payload.intent_revision == intent.intent_revision
+            and candidate.payload.contract_id == effect.contract_id
+            and candidate.payload.contract_revision == effect.contract_revision
+            and candidate.payload.semantic_effect_id == intent.semantic_effect_id
+            and candidate.payload.target_entity_id == intent.target_entity_id
+            and m3a_canonical_digest(candidate.payload.model_dump(mode="json"))
+            == context_binding.get("context_digest")
+        )
+        if not contexts:
+            return "EFFECT_CONTEXT_NOT_YET_PERSISTED"
+        context = contexts[0]
+        if effect.device_id != context.expected_device_id:
+            return None
+        terminal_events = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, ExecutionEvent)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == self.factory.node_id
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.next_state in TERMINAL_STATES
+            and candidate.payload.contract_id == effect.contract_id
+            and candidate.payload.contract_revision == effect.contract_revision
+        )
+        if not terminal_events:
+            return "EFFECT_TERMINAL_NOT_YET_PERSISTED"
+        expected_effect_key = f"press:{effect.operation_id}:{effect.contract_revision}"
+        commands = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, SpatialPressCommand)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == self.factory.node_id
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.effect_key == expected_effect_key
+        )
+        if not commands:
+            return "EFFECT_COMMAND_NOT_YET_PERSISTED"
+        if effect.command_digest not in {command.command_digest for command in commands}:
+            return None
+        decisions = tuple(
+            candidate.payload
+            for candidate in messages
+            if isinstance(candidate.payload, LocalTwoButtonDecision)
+            and candidate.source_id == "field-1"
+            and candidate.destination_id == self.factory.node_id
+            and candidate.correlation_id == intent_message.correlation_id
+            and candidate.payload.operation_id == effect.operation_id
+        )
+        if not decisions:
+            return "EFFECT_DECISION_NOT_YET_PERSISTED"
+        if not any(decision.command_digest == effect.command_digest for decision in decisions):
+            return None
+        return None
+
+    def _m3a_effect_for_view(
+        self,
+        candidates: tuple[MessageEnvelope, ...],
+    ) -> MessageEnvelope | None:
+        """Read the durable first proof, keeping later transport copies inert."""
+
+        ordered = tuple(
+            sorted(candidates, key=lambda value: (value.created_at, str(value.message_id)))
+        )
+        for candidate in ordered:
+            effect = candidate.payload
+            assert isinstance(effect, TwoButtonEffectEvidence)
+            binding = self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            )
+            if binding is None:
+                continue
+            canonical = binding.get("effect_envelope")
+            if isinstance(canonical, MessageEnvelope) and self._m3a_effect_matches_binding(
+                canonical,
+                binding,
+            ):
+                return canonical
+        for candidate in ordered:
+            effect = candidate.payload
+            assert isinstance(effect, TwoButtonEffectEvidence)
+            diagnostic = self.store.find_m3a_effect_diagnostic(
+                effect.contract_id,
+                effect.contract_revision,
+            )
+            if diagnostic is None:
+                continue
+            canonical = diagnostic.get("effect_envelope")
+            if isinstance(canonical, MessageEnvelope) and self._m3a_effect_matches_binding(
+                canonical,
+                diagnostic,
+            ):
+                return canonical
+        # Unverified UNKNOWN is exposed only from its durable diagnostic record;
+        # arbitrary transport copies never become view facts.
+        return None
+
+    def _process_m3a_effect_at_mission(self, envelope: MessageEnvelope) -> None:
+        """Bind a validated Mission-side copy before exposing it in the view."""
+
+        effect = envelope.payload
+        assert isinstance(effect, TwoButtonEffectEvidence)
+        messages = tuple(self.store.inbox_messages()) + tuple(self.store.outbox_messages())
+        intents = tuple(
+            message
+            for message in messages
+            if isinstance(message.payload, M3aEnsureLatchedIntent)
+            and message.payload.operation_id == effect.operation_id
+            and message.correlation_id == envelope.correlation_id
+        )
+        intent_message = max(
+            intents,
+            key=lambda message: (message.created_at, str(message.message_id)),
+            default=None,
+        )
+        route_matches = (
+            envelope.source_id == "field-1"
+            and envelope.destination_id == self.factory.node_id
+            and intent_message is not None
+            and envelope.correlation_id == intent_message.correlation_id
+            and effect.operation_id == intent_message.payload.operation_id
+            and effect.intent_revision == intent_message.payload.intent_revision
+            and effect.semantic_effect_id == intent_message.payload.semantic_effect_id
+            and effect.target_entity_id == intent_message.payload.target_entity_id
+        )
+        if intent_message is None:
+            if (
+                envelope.source_id == "field-1"
+                and envelope.destination_id == self.factory.node_id
+            ):
+                self.store.fail_inbox(
+                    envelope.message_id,
+                    {"reason": "EFFECT_INTENT_NOT_YET_PERSISTED", "retryable": True},
+                )
+            else:
+                self.store.complete_inbox(
+                    envelope.message_id,
+                    processed_at=self.clock.now(),
+                    handler_result_reference="mission-m3a-effect-rejected:attribution",
+                )
+            return
+        if not route_matches:
+            if self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            ) is not None:
+                self.store.record_m3a_effect_conflict(
+                    envelope,
+                    reason="EFFECT_ROUTE_OR_INTENT_MISMATCH",
+                    recorded_at=self.clock.now(),
+                )
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference="mission-m3a-effect-rejected:attribution",
+            )
+            return
+        missing_dependency = self._m3a_effect_missing_dependency(
+            effect,
+            intent_message=intent_message,
+            messages=messages,
+        )
+        if missing_dependency is not None:
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": missing_dependency, "retryable": True},
+            )
+            return
+        if not self._m3a_effect_is_attributable(
+            envelope,
+            intent_message=intent_message,
+            messages=messages,
+        ):
+            if self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            ) is not None:
+                self.store.record_m3a_effect_conflict(
+                    envelope,
+                    reason="EFFECT_ATTRIBUTION_MISMATCH",
+                    recorded_at=self.clock.now(),
+                )
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference="mission-m3a-effect-rejected:attribution",
+            )
+            return
+        try:
+            self.store.bind_m3a_effect(
+                envelope,
+                bound_at=self.clock.now(),
+            )
+        except RecordConflictError as error:
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=f"mission-m3a-effect-conflict:{error}",
+            )
+            return
+        if (
+            not effect.command_digest_verified
+            and self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            )
+            is None
+        ):
+            try:
+                self.store.bind_m3a_effect_diagnostic(
+                    envelope,
+                    recorded_at=self.clock.now(),
+                )
+            except RecordConflictError as error:
+                self.store.complete_inbox(
+                    envelope.message_id,
+                    processed_at=self.clock.now(),
+                    handler_result_reference=f"mission-m3a-effect-diagnostic-conflict:{error}",
+                )
+                return
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference="mission-m3a-effect-bound",
+        )
+        self.emit(
+            "mission.m3a_message",
+            {
+                "message_id": str(envelope.message_id),
+                "message_type": envelope.message_type,
+            },
+        )
+
+    def m3a_view_state(self) -> M3aMissionViewState:
+        messages = tuple(self.store.inbox_messages()) + tuple(self.store.outbox_messages())
+        intent_message = max(
+            (
+                message
+                for message in messages
+                if isinstance(message.payload, M3aEnsureLatchedIntent)
+            ),
+            key=lambda message: (message.created_at, str(message.message_id)),
+            default=None,
+        )
+        operation_id = intent_message.payload.operation_id if intent_message else None
+        correlation_id = intent_message.correlation_id if intent_message else None
+        scoped = tuple(
+            message
+            for message in messages
+            if operation_id is not None
+            and (
+                message.correlation_id == correlation_id
+                or getattr(message.payload, "operation_id", None) == operation_id
+                or (
+                    isinstance(message.payload, ExecutionEvent)
+                    and message.payload.contract_id
+                    in {
+                        candidate.payload.contract_id
+                        for candidate in messages
+                        if isinstance(candidate.payload, ExecutionContract)
+                        and candidate.payload.operation_id == operation_id
+                    }
+                )
+            )
+        )
+        reference = next(
+            (
+                message.payload
+                for message in scoped
+                if isinstance(message.payload, TwoButtonObservation)
+                and intent_message is not None
+                and message.payload.observation_id
+                == intent_message.payload.reference_observation_id
+            ),
+            None,
+        )
+        decision_message = max(
+            (
+                message
+                for message in scoped
+                if isinstance(message.payload, LocalTwoButtonDecision)
+            ),
+            key=lambda message: (message.created_at, str(message.message_id)),
+            default=None,
+        )
+        current = next(
+            (
+                message.payload
+                for message in scoped
+                if isinstance(message.payload, TwoButtonObservation)
+                and decision_message is not None
+                and message.payload.observation_id
+                == decision_message.payload.current_observation_id
+            ),
+            None,
+        )
+        level_message = max(
+            (
+                message
+                for message in scoped
+                if isinstance(message.payload, TwoButtonLevelEvidence)
+            ),
+            key=lambda message: (message.created_at, str(message.message_id)),
+            default=None,
+        )
+        command_message = max(
+            (
+                message
+                for message in scoped
+                if isinstance(message.payload, SpatialPressCommand)
+            ),
+            key=lambda message: (message.created_at, str(message.message_id)),
+            default=None,
+        )
+        contracts = tuple(
+            message.payload
+            for message in scoped
+            if isinstance(message.payload, ExecutionContract)
+        )
+        contract = max(contracts, key=lambda value: str(value.contract_id), default=None)
+        terminal_message = max(
+            (
+                message
+                for message in scoped
+                if isinstance(message.payload, ExecutionEvent)
+                and message.payload.next_state in TERMINAL_STATES
+            ),
+            key=lambda message: (message.payload.occurred_at, str(message.message_id)),
+            default=None,
+        )
+        attributable_effects = tuple(
+            message
+            for message in scoped
+            if isinstance(message.payload, TwoButtonEffectEvidence)
+            and intent_message is not None
+            and self._m3a_effect_is_attributable(
+                message,
+                intent_message=intent_message,
+                messages=messages,
+            )
+        )
+        effect_message = self._m3a_effect_for_view(attributable_effects)
+        level = level_message.payload if level_message else None
+        effect = effect_message.payload if effect_message else None
+        resolved_contract_id = (
+            contract.contract_id
+            if contract is not None
+            else effect.contract_id
+            if effect is not None
+            else terminal_message.payload.contract_id
+            if terminal_message is not None
+            else None
+        )
+        effect_result = effect.model_dump(mode="json") if effect is not None else None
+        if effect is not None:
+            business_result = (
+                "APPLIED"
+                if effect.semantic_goal_attained is True
+                else "NOT_APPLIED_AFTER_UNCERTAIN_DISPATCH"
+                if effect.outcome == "NOT_APPLIED"
+                else "OUTCOME_UNKNOWN"
+            )
+        else:
+            business_result = (
+                "RECOGNIZED_ALREADY_EFFECTIVE"
+                if decision_message is not None
+                and decision_message.payload.action is M3aAction.RECOGNIZE_EFFECT
+                else None
+            )
+        return M3aMissionViewState(
+            source_id=self.factory.node_id,
+            source_sequence=max(1, self._view_sequence + 1),
+            produced_at=self.clock.now(),
+            operation_id=operation_id,
+            correlation_id=correlation_id,
+            configured_one_way_delay_seconds=self.configured_one_way_delay,
+            reference_observation=reference,
+            current_observation=current,
+            level_evidence=level,
+            decision=decision_message.payload if decision_message else None,
+            command=command_message.payload if command_message else None,
+            effect_evidence=effect,
+            contract_id=resolved_contract_id,
+            contract_state=(
+                terminal_message.payload.next_state
+                if terminal_message is not None
+                else None
+            ),
+            terminal_result=effect_result,
+            business_result=business_result,
+            physical_contact=effect.physical_contact if effect is not None else None,
+            a_counter=effect.a_counter if effect is not None else None,
+            b_counter=effect.b_counter if effect is not None else None,
+            a_latched=effect.a_latched if effect is not None else None,
+            b_latched=effect.b_latched if effect is not None else None,
+        )
+
+    def m3a_view(self) -> dict[str, Any]:
+        return self.m3a_view_state().model_dump(mode="json")
+
+    view_m3a = m3a_view
+
+
+class M3aMissionService(_M3aMissionMixin, MissionService):
+    """Mission service with the M3a observed-spatial authoring path enabled."""
+
+
+class _M3aFieldMixin:
+    """Field validation, immutable root binding, and M3a forwarding."""
+
+    m3a_device_id = "two-button-device-1"
+
+    def record_m3a_current_observation(
+        self,
+        observation: TwoButtonObservation | LocalM3aObservation,
+        *,
+        operation_id: UUID,
+        correlation_id: UUID | None = None,
+        observer_id: str | None = None,
+    ) -> MessageEnvelope:
+        """Persist one current observation acquired by Field's local observer.
+
+        This is a local observer entry point: callers invoke it after the
+        Mission-to-Field delay, and the payload is written directly to Field's
+        inbox.  Field forwards the same observed payload to Mission only after
+        its local inbox completion, so the read model can expose the current
+        observation without making Mission the observation author.  The method
+        does not inspect fixture truth.  The returned root envelope can be
+        handed to :meth:`RuntimeService.handle` to run the normal durable inbox path.
+        """
+
+        payload = _m3a_as_wire_observation(observation)
+        correlation = correlation_id or operation_id
+        now = self.clock.now()
+        envelope = self.factory.make(
+            "m3a.two_button.observation",
+            self.factory.node_id,
+            correlation,
+            payload,
+            source_id=observer_id or payload.source_id,
+            created_at=now,
+            message_id=_m3a_uuid(
+                operation_id,
+                f"current-field-local:{payload.observation_id}",
+            ),
+        )
+        self.store.receive(envelope, received_at=now)
+        self.emit(
+            "field.m3a_current_observation_recorded",
+            {
+                "operation_id": str(operation_id),
+                "observation_id": payload.observation_id,
+                "message_id": str(envelope.message_id),
+                "observed_at": payload.observed_at.isoformat(),
+            },
+        )
+        return envelope
+
+    def _m3a_operation_bundle(self, operation_id: UUID) -> tuple[MessageEnvelope, ...]:
+        payloads = tuple(
+            message
+            for message in self.store.outbox_messages()
+            if (
+                isinstance(message.payload, (SiteSnapshot, GroundedOperation, OperationPlan))
+                and getattr(message.payload, "operation_id", None) == operation_id
+            )
+            or (
+                isinstance(message.payload, TaskAssignment)
+                and any(
+                    candidate.payload.plan_id == message.payload.plan_id
+                    for candidate in self.store.outbox_messages()
+                    if isinstance(candidate.payload, OperationPlan)
+                    and candidate.payload.operation_id == operation_id
+                )
+            )
+            or (
+                isinstance(
+                    message.payload,
+                    (ExecutionContract, M3aSpatialExecutionContext),
+                )
+                and message.payload.operation_id == operation_id
+            )
+        )
+        return tuple(
+            sorted(payloads, key=lambda message: (message.created_at, str(message.message_id)))
+        )
+
+    def _m3a_effect_validation_reason(
+        self,
+        envelope: MessageEnvelope,
+        effect: TwoButtonEffectEvidence,
+    ) -> str | None:
+        """Validate post-effect attribution before forwarding it to Mission.
+
+        A proof can arrive before the command or decision because each is an
+        independently retried message.  In that case return a retryable reason;
+        intrinsic source, contract, target, or digest mismatches are terminal
+        for this proof and are never forwarded.
+        """
+
+        if envelope.source_id != self.robot_id:
+            return "EFFECT_SOURCE_MISMATCH"
+        messages = tuple(self.store.inbox_messages()) + tuple(self.store.outbox_messages())
+        contexts = tuple(
+            message
+            for message in messages
+            if isinstance(message.payload, M3aSpatialExecutionContext)
+        )
+        exact_contexts = tuple(
+            message
+            for message in contexts
+            if message.correlation_id == envelope.correlation_id
+            and message.payload.operation_id == effect.operation_id
+            and message.payload.contract_id == effect.contract_id
+            and message.payload.contract_revision == effect.contract_revision
+        )
+        if not exact_contexts:
+            related_context = any(
+                message.payload.operation_id == effect.operation_id
+                or message.correlation_id == envelope.correlation_id
+                for message in contexts
+            )
+            return (
+                "EFFECT_CONTEXT_MISMATCH"
+                if related_context
+                else "EFFECT_CONTEXT_NOT_YET_PERSISTED"
+            )
+        context_digests = {
+            m3a_canonical_digest(message.payload.model_dump(mode="json"))
+            for message in exact_contexts
+        }
+        if len(context_digests) != 1:
+            return "EFFECT_CONTEXT_CONFLICT"
+        context = exact_contexts[0].payload
+        expected_device_id = context.expected_device_id or self.m3a_device_id
+        expected_effect_key = f"press:{effect.operation_id}:{effect.contract_revision}"
+        if (
+            effect.semantic_effect_id != context.semantic_effect_id
+            or effect.target_entity_id != context.target_entity_id
+            or effect.effect_key != expected_effect_key
+            or effect.device_id != expected_device_id
+        ):
+            return "EFFECT_CONTEXT_BINDING_MISMATCH"
+
+        commands = tuple(
+            message.payload
+            for message in messages
+            if isinstance(message.payload, SpatialPressCommand)
+            and message.source_id == self.robot_id
+            and message.destination_id == self.factory.node_id
+            and message.correlation_id == envelope.correlation_id
+            and message.payload.effect_key == expected_effect_key
+        )
+        if not commands:
+            return "EFFECT_COMMAND_NOT_YET_PERSISTED"
+        command_digests = {command.command_digest for command in commands}
+        if len(command_digests) != 1:
+            return "EFFECT_COMMAND_CONFLICT"
+        command = commands[0]
+        if effect.command_digest != command.command_digest:
+            return "EFFECT_COMMAND_DIGEST_MISMATCH"
+
+        decisions = tuple(
+            message.payload
+            for message in messages
+            if isinstance(message.payload, LocalTwoButtonDecision)
+            and message.source_id == self.robot_id
+            and message.destination_id == self.factory.node_id
+            and message.correlation_id == envelope.correlation_id
+            and message.payload.operation_id == effect.operation_id
+        )
+        if not decisions:
+            return "EFFECT_DECISION_NOT_YET_PERSISTED"
+        decision_digests = {decision.command_digest for decision in decisions}
+        if len(decision_digests) != 1:
+            return "EFFECT_DECISION_CONFLICT"
+        decision = decisions[0]
+        if decision.command_digest != effect.command_digest:
+            return "EFFECT_DECISION_DIGEST_MISMATCH"
+        if not effect.command_digest_verified:
+            if (
+                effect.outcome != "UNKNOWN"
+                or effect.physical_contact is not None
+                or effect.command_executed is not None
+                or effect.semantic_goal_attained is not None
+                or effect.a_counter is not None
+                or effect.b_counter is not None
+                or effect.a_latched is not None
+                or effect.b_latched is not None
+            ):
+                return "EFFECT_UNVERIFIED_PROOF_FIELDS"
+            return None
+        if effect.outcome == "APPLIED" and (
+            effect.command_executed is not True
+            or effect.semantic_goal_attained is not True
+            or effect.physical_contact != effect.target_entity_id
+        ):
+            return "EFFECT_SEMANTIC_PROOF_MISSING"
+        if effect.semantic_goal_attained is True and effect.outcome != "APPLIED":
+            return "EFFECT_SEMANTIC_OUTCOME_MISMATCH"
+        return None
+
+    def _process_m3a_effect_evidence(self, envelope: MessageEnvelope) -> None:
+        effect = envelope.payload
+        assert isinstance(effect, TwoButtonEffectEvidence)
+        reason = self._m3a_effect_validation_reason(envelope, effect)
+        if reason is None:
+            try:
+                self.store.bind_m3a_effect(
+                    envelope,
+                    bound_at=self.clock.now(),
+                )
+            except RecordConflictError as error:
+                self._m3a_complete_no_bundle(
+                    envelope,
+                    result=f"m3a-effect-conflict:{error}",
+                )
+                return
+            binding = self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            )
+            if binding is None and not effect.command_digest_verified:
+                try:
+                    self.store.bind_m3a_effect_diagnostic(
+                        envelope,
+                        recorded_at=self.clock.now(),
+                    )
+                except RecordConflictError as error:
+                    self._m3a_complete_no_bundle(
+                        envelope,
+                        result=f"m3a-effect-diagnostic-conflict:{error}",
+                    )
+                    return
+                diagnostic = self.store.find_m3a_effect_diagnostic(
+                    effect.contract_id,
+                    effect.contract_revision,
+                )
+                if diagnostic is not None:
+                    binding = diagnostic
+            canonical_effect = (
+                binding["effect"]
+                if binding is not None
+                and isinstance(binding.get("effect"), TwoButtonEffectEvidence)
+                else effect
+            )
+            self._process_m3a_robot_message(envelope, payload=canonical_effect)
+            return
+        if reason.endswith("NOT_YET_PERSISTED"):
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": reason, "retryable": True},
+            )
+            return
+        if (
+            self.store.find_m3a_effect_binding(
+                effect.contract_id,
+                effect.contract_revision,
+            )
+            is not None
+        ):
+            self.store.record_m3a_effect_conflict(
+                envelope,
+                reason=reason,
+                recorded_at=self.clock.now(),
+            )
+        self._m3a_complete_no_bundle(
+            envelope,
+            result=f"m3a-effect-rejected:{reason}",
+        )
+
+    def _m3a_reference_candidates(
+        self, observation_id: str, correlation_id: UUID
+    ) -> tuple[MessageEnvelope, ...]:
+        return tuple(
+            message
+            for message in self.store.inbox_messages()
+            if isinstance(message.payload, TwoButtonObservation)
+            and message.payload.observation_id == observation_id
+            and message.correlation_id == correlation_id
+        )
+
+    def _m3a_current_candidate(
+        self, reference: TwoButtonObservation, correlation_id: UUID
+    ) -> MessageEnvelope | None:
+        candidates = tuple(
+            message
+            for message in self.store.inbox_messages()
+            if isinstance(message.payload, TwoButtonObservation)
+            and message.correlation_id == correlation_id
+            and message.payload.observation_id != reference.observation_id
+            and message.payload.source_id == reference.source_id
+        )
+        return max(
+            candidates,
+            key=lambda message: (
+                message.payload.world_revision,
+                message.payload.observed_at,
+                message.payload.produced_at,
+                str(message.message_id),
+            ),
+            default=None,
+        )
+
+    def _m3a_hold_envelope(
+        self,
+        cause: MessageEnvelope,
+        intent: M3aEnsureLatchedIntent,
+        current: TwoButtonObservation,
+        *,
+        action: M3aAction,
+        reason: str,
+    ) -> MessageEnvelope:
+        decision = LocalM3aDecision(
+            operation_id=intent.operation_id,
+            intent_revision=intent.intent_revision,
+            semantic_effect_id=intent.semantic_effect_id,
+            reference_observation_id=intent.reference_observation_id,
+            current_observation_id=current.observation_id,
+            action=action,
+            reason=reason,
+            budget_state="NOT_ADMITTED",
+        )
+        return self.factory.make(
+            "m3a.spatial.decision",
+            self.mission_id,
+            cause.correlation_id,
+            _m3a_wire_decision(decision),
+            causation_id=cause.message_id,
+            message_id=_m3a_uuid(intent.operation_id, f"field-hold:{reason}"),
+        )
+
+    def _m3a_complete_no_bundle(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        result: str,
+        outgoing: tuple[MessageEnvelope, ...] = (),
+    ) -> None:
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=result,
+            outgoing=outgoing,
+        )
+
+    def _m3a_make_bundle(
+        self,
+        envelope: MessageEnvelope,
+        intent: M3aEnsureLatchedIntent,
+        reference: TwoButtonObservation,
+        current_message: MessageEnvelope,
+    ) -> tuple[MessageEnvelope, ...]:
+        now = self.clock.now()
+        operation_id = intent.operation_id
+        target_detection = next(
+            detection
+            for detection in reference.detections
+            if detection.detection_id == intent.reference_detection_id
+        )
+        snapshot = self.factory.make(
+            "site.snapshot",
+            self.mission_id,
+            envelope.correlation_id,
+            SiteSnapshot(
+                site_id="two-button-site-1",
+                entities=(intent.target_entity_id,),
+                robot_states=(
+                    RobotState(
+                        robot_id=self.robot_id,
+                        pose=target_detection.pose,
+                        evidence=evidence(
+                            reference.source_id,
+                            reference.observed_at,
+                            ProvenanceKind.MEASURED,
+                            world_revision=reference.world_revision,
+                            produced_at=reference.produced_at,
+                        ),
+                    ),
+                ),
+                evidence=evidence(
+                    reference.source_id,
+                    reference.observed_at,
+                    ProvenanceKind.MEASURED,
+                    world_revision=reference.world_revision,
+                    produced_at=reference.produced_at,
+                ),
+            ),
+            causation_id=envelope.message_id,
+            message_id=_m3a_uuid(operation_id, "snapshot-envelope"),
+            created_at=now,
+        )
+        grounded = self.factory.make(
+            "operation.grounded",
+            self.mission_id,
+            envelope.correlation_id,
+            GroundedOperation(
+                operation_id=operation_id,
+                target_entity_id=intent.target_entity_id,
+                target_pose=target_detection.pose,
+                state=OperationState.ADMITTED,
+                evidence=evidence(
+                    reference.source_id,
+                    reference.observed_at,
+                    ProvenanceKind.MEASURED,
+                    world_revision=reference.world_revision,
+                    produced_at=reference.produced_at,
+                ),
+            ),
+            causation_id=envelope.message_id,
+            message_id=_m3a_uuid(operation_id, "grounded-envelope"),
+            created_at=now + timedelta(microseconds=1),
+        )
+        task_id = _m3a_uuid(operation_id, "task")
+        plan = self.factory.make(
+            "operation.plan",
+            self.mission_id,
+            envelope.correlation_id,
+            OperationPlan(
+                plan_id=_m3a_uuid(operation_id, "plan"),
+                operation_id=operation_id,
+                tasks=(
+                    TaskNode(
+                        task_id=task_id,
+                        skill=OperationType.PRESS_BUTTON,
+                        target_entity_id=intent.target_entity_id,
+                    ),
+                ),
+            ),
+            causation_id=grounded.message_id,
+            message_id=_m3a_uuid(operation_id, "plan-envelope"),
+            created_at=now + timedelta(microseconds=2),
+        )
+        assignment = self.factory.make(
+            "task.assignment",
+            self.robot_id,
+            envelope.correlation_id,
+            TaskAssignment(
+                assignment_id=_m3a_uuid(operation_id, "assignment"),
+                plan_id=plan.payload.plan_id,
+                task_id=task_id,
+                executor_id=self.robot_id,
+            ),
+            causation_id=plan.message_id,
+            message_id=_m3a_uuid(operation_id, "assignment-envelope"),
+            created_at=now + timedelta(microseconds=3),
+        )
+        contract = self.factory.make(
+            "execution.contract",
+            self.robot_id,
+            envelope.correlation_id,
+            ExecutionContract(
+                contract_id=_m3a_uuid(operation_id, "contract"),
+                contract_revision=1,
+                operation_id=operation_id,
+                assignment_id=assignment.payload.assignment_id,
+                state=ContractState.RECEIVED,
+            ),
+            causation_id=assignment.message_id,
+            message_id=_m3a_uuid(operation_id, "contract-envelope"),
+            created_at=now + timedelta(microseconds=4),
+            expires_at=intent.expires_at,
+        )
+        context = self.factory.make(
+            "m3a.spatial.context",
+            self.robot_id,
+            envelope.correlation_id,
+            M3aSpatialExecutionContext(
+                operation_id=operation_id,
+                intent_revision=1,
+                contract_id=contract.payload.contract_id,
+                contract_revision=1,
+                task_id=task_id,
+                semantic_effect_id=intent.semantic_effect_id,
+                target_entity_id=intent.target_entity_id,
+                reference_observation_id=intent.reference_observation_id,
+                reference_detection_id=intent.reference_detection_id,
+                reference_digest=intent.reference_digest,
+                reference_pose=intent.reference_pose,
+                reference_frame_id=intent.reference_frame_id,
+                reference_calibration_version=intent.reference_calibration_version,
+                reference_world_revision=intent.reference_world_revision,
+                reference_observed_at=intent.reference_observed_at,
+                current_observation_envelope_id=current_message.message_id.__str__(),
+                current_observation=current_message.payload,
+                reference_observation=reference,
+                same_identity_only=intent.same_identity_only,
+                max_displacement_m=intent.max_displacement_m,
+                expires_at=intent.expires_at,
+                expected_device_id=self.m3a_device_id,
+            ),
+            causation_id=contract.message_id,
+            message_id=_m3a_uuid(operation_id, "context-envelope"),
+            created_at=now + timedelta(microseconds=5),
+            expires_at=intent.expires_at,
+        )
+        # Mission receives an immutable copy of the Field context so its read
+        # model can bind effect evidence to the same durable contract/device
+        # identity.  The Robot copy above remains the only execution input.
+        mission_context = self.factory.make(
+            "m3a.spatial.context",
+            self.mission_id,
+            envelope.correlation_id,
+            context.payload,
+            causation_id=context.message_id,
+            message_id=_m3a_uuid(operation_id, "context-mission-envelope"),
+            created_at=now + timedelta(microseconds=6),
+            expires_at=intent.expires_at,
+        )
+        # Deliberately place the contract before context.  Robot must remain
+        # retryable until both assignment and matching context are durable;
+        # tests can therefore deliver these dependencies in either order.
+        return (snapshot, grounded, plan, assignment, contract, context, mission_context)
+
+    def _process_m3a_observation(self, envelope: MessageEnvelope) -> None:
+        outgoing: tuple[MessageEnvelope, ...] = ()
+        # A local Field observer uses Field's boot ID.  Remote reference/current
+        # messages retain their originating Mission boot ID and must not loop
+        # back into Mission.  Completing the inbox with this forwarding copy
+        # keeps local observation publication atomic with its processing state.
+        if envelope.source_boot_id == self.factory.boot_id:
+            payload = envelope.payload
+            assert isinstance(payload, TwoButtonObservation)
+            outgoing = (
+                self.factory.make(
+                    "m3a.two_button.observation",
+                    self.mission_id,
+                    envelope.correlation_id,
+                    payload,
+                    causation_id=envelope.message_id,
+                    message_id=uuid5(
+                        NAMESPACE_URL,
+                        f"dtt-m3a:current-forward:{envelope.correlation_id}:{payload.observation_id}",
+                    ),
+                    created_at=self.clock.now(),
+                ),
+            )
+        self._m3a_complete_no_bundle(
+            envelope,
+            result=f"m3a-observation:{getattr(envelope.payload, 'observation_id', '')}",
+            outgoing=outgoing,
+        )
+
+    def _process_m3a_intent(self, envelope: MessageEnvelope) -> None:
+        intent = envelope.payload
+        assert isinstance(intent, M3aEnsureLatchedIntent)
+        # The atomic root binding is checked before reading or creating a
+        # bundle.  This classifies changed source/correlation/semantic claims
+        # durably and leaves the first bundle untouched.
+        semantic_fields = intent.model_dump(mode="json")
+        digest = _m3a_intent_digest(intent)
+        try:
+            fresh_binding = self.store.bind_m3a_intent(
+                operation_id=intent.operation_id,
+                intent_revision=intent.intent_revision,
+                canonical_intent_digest=digest,
+                source_id=envelope.source_id,
+                correlation_id=envelope.correlation_id,
+                semantic_fields=semantic_fields,
+                bound_at=self.clock.now(),
+            )
+        except RecordConflictError as error:
+            self._m3a_complete_no_bundle(
+                envelope,
+                result=f"m3a-intent-conflict:{error}",
+            )
+            self.emit(
+                "field.m3a_intent_conflict",
+                {"operation_id": str(intent.operation_id), "reason": str(error)},
+            )
+            return
+
+        if not fresh_binding:
+            prior_bundle = self._m3a_operation_bundle(intent.operation_id)
+            if prior_bundle:
+                self._m3a_complete_no_bundle(
+                    envelope,
+                    result=f"m3a-duplicate:{intent.operation_id}",
+                    outgoing=prior_bundle,
+                )
+                return
+
+        references = self._m3a_reference_candidates(
+            intent.reference_observation_id, envelope.correlation_id
+        )
+        if not references:
+            # A reference must be durably observed before intent acceptance.
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": "m3a-reference-not-yet-persisted", "retryable": True},
+            )
+            return
+        reference = references[-1].payload
+        assert isinstance(reference, TwoButtonObservation)
+        if len(
+            {
+                (
+                    candidate.payload.canonical_payload_digest,
+                    candidate.payload.frame_id,
+                    candidate.payload.calibration_version,
+                )
+                for candidate in references
+            }
+        ) > 1:
+            # A repeated observation UUID is idempotent only when its payload
+            # is byte-identical.  Do not let SQLite ordering choose between a
+            # changed pose and the original authoring record.
+            context_changed = any(
+                candidate.payload.frame_id != intent.reference_frame_id
+                or candidate.payload.calibration_version
+                != intent.reference_calibration_version
+                for candidate in references
+            )
+            current_message = self._m3a_current_candidate(
+                reference, envelope.correlation_id
+            )
+            outgoing: tuple[MessageEnvelope, ...] = ()
+            if current_message is not None:
+                outgoing = (
+                    self._m3a_hold_envelope(
+                        envelope,
+                        intent,
+                        current_message.payload,
+                        action=(
+                            M3aAction.HOLD_CONTEXT_MISMATCH
+                            if context_changed
+                            else M3aAction.HOLD_REFERENCE_MISMATCH
+                        ),
+                        reason=(
+                            "REFERENCE_CONTEXT_CONFLICT"
+                            if context_changed
+                            else "REFERENCE_OBSERVATION_UUID_CONFLICT"
+                        ),
+                    ),
+                )
+            self._m3a_complete_no_bundle(
+                envelope,
+                result="m3a-reference-uuid-conflict",
+                outgoing=outgoing,
+            )
+            return
+        try:
+            local_intent = _m3a_local_intent(intent)
+            local_reference = _m3a_local_observation(reference)
+            verification = verify_reference(local_intent, local_reference)
+        except (TypeError, ValueError) as error:
+            verification = None
+            self._m3a_complete_no_bundle(
+                envelope,
+                result=f"m3a-reference-mismatch:{error}",
+            )
+            return
+        if verification is not None and not verification.valid:
+            current_message = self._m3a_current_candidate(reference, envelope.correlation_id)
+            outgoing: tuple[MessageEnvelope, ...] = ()
+            if current_message is not None:
+                outgoing = (
+                    self._m3a_hold_envelope(
+                        envelope,
+                        intent,
+                        current_message.payload,
+                        action=M3aAction(verification.action or M3aAction.HOLD_REFERENCE_MISMATCH),
+                        reason=verification.reason,
+                    ),
+                )
+            self._m3a_complete_no_bundle(
+                envelope,
+                result=f"m3a-reference-hold:{verification.reason}",
+                outgoing=outgoing,
+            )
+            return
+
+        current_message = self._m3a_current_candidate(reference, envelope.correlation_id)
+        if current_message is None or not isinstance(current_message.payload, TwoButtonObservation):
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": "m3a-current-observation-not-yet-persisted", "retryable": True},
+            )
+            return
+        current = current_message.payload
+        if (
+            current.source_id != reference.source_id
+            or current.frame_id != intent.reference_frame_id
+            or current.calibration_version != intent.reference_calibration_version
+        ):
+            decision = self._m3a_hold_envelope(
+                envelope,
+                intent,
+                current,
+                action=M3aAction.HOLD_CONTEXT_MISMATCH,
+                reason="CURRENT_OBSERVATION_CONTEXT_MISMATCH",
+            )
+            self._m3a_complete_no_bundle(
+                envelope,
+                result="m3a-current-context-hold",
+                outgoing=(decision,),
+            )
+            return
+        if intent.expires_at is not None and self.clock.now() >= intent.expires_at:
+            decision = self._m3a_hold_envelope(
+                envelope,
+                intent,
+                current,
+                action=M3aAction.HOLD_CONTEXT_MISMATCH,
+                reason="INTENT_EXPIRED",
+            )
+            self._m3a_complete_no_bundle(
+                envelope,
+                result="m3a-expired",
+                outgoing=(decision,),
+            )
+            return
+
+        outgoing = self._m3a_make_bundle(envelope, intent, reference, current_message)
+        self._m3a_complete_no_bundle(
+            envelope,
+            result=f"m3a-admitted:{intent.operation_id}",
+            outgoing=outgoing,
+        )
+        self.emit(
+            "field.m3a_operation_admitted",
+            {
+                "operation_id": str(intent.operation_id),
+                "contract_id": str(outgoing[-1].payload.contract_id),
+                "reference_observation_id": intent.reference_observation_id,
+                "current_observation_id": current.observation_id,
+            },
+        )
+
+    def _process_m3a_robot_message(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        payload: WireModel | None = None,
+    ) -> None:
+        forwarded_payload = payload if payload is not None else envelope.payload
+        forwarded = self.factory.make(
+            envelope.message_type,
+            self.mission_id,
+            envelope.correlation_id,
+            forwarded_payload,
+            causation_id=envelope.message_id,
+            message_id=_m3a_uuid(
+                getattr(forwarded_payload, "operation_id", envelope.correlation_id),
+                f"forward:{envelope.message_id}",
+            ),
+        )
+        self._m3a_complete_no_bundle(
+            envelope,
+            result=f"m3a-forwarded:{forwarded.message_id}",
+            outgoing=(forwarded,),
+        )
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        if isinstance(envelope.payload, TwoButtonObservation):
+            self._process_m3a_observation(envelope)
+            return
+        if isinstance(envelope.payload, M3aEnsureLatchedIntent):
+            self._process_m3a_intent(envelope)
+            return
+        if isinstance(envelope.payload, TwoButtonEffectEvidence):
+            self._process_m3a_effect_evidence(envelope)
+            return
+        if isinstance(
+            envelope.payload,
+            (
+                LocalTwoButtonDecision,
+                TwoButtonLevelEvidence,
+                TwoButtonEffectEvidence,
+                SpatialPressCommand,
+            ),
+        ):
+            self._process_m3a_robot_message(envelope)
+            return
+        if (
+            isinstance(envelope.payload, ExecutionEvent)
+            and envelope.message_type == "execution.event"
+        ):
+            # The standard Field path handles legacy robot events.  M3a Robot
+            # events are forwarded by the same route when their causation is a
+            # M3a decision/level envelope.
+            if any(
+                message.message_id == envelope.causation_id
+                and isinstance(
+                    message.payload,
+                    (LocalTwoButtonDecision, TwoButtonLevelEvidence),
+                )
+                for message in self.store.inbox_messages()
+            ) or any(
+                isinstance(message.payload, M3aSpatialExecutionContext)
+                and message.payload.contract_id == envelope.payload.contract_id
+                and message.payload.contract_revision == envelope.payload.contract_revision
+                for message in self.store.inbox_messages()
+            ) or any(
+                isinstance(message.payload, M3aSpatialExecutionContext)
+                and message.payload.contract_id == envelope.payload.contract_id
+                and message.payload.contract_revision == envelope.payload.contract_revision
+                for message in self.store.outbox_messages()
+            ):
+                self._process_m3a_robot_message(envelope)
+                return
+        await super().process_claimed(envelope)
+
+
+class M3aFieldService(_M3aFieldMixin, FieldService):
+    """Field service with immutable M3a authoring/context binding enabled."""
+
+    def __init__(
+        self,
+        *args: Any,
+        m3a_device_id: str = "two-button-device-1",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if not isinstance(m3a_device_id, str) or not m3a_device_id.strip():
+            raise ValueError("m3a_device_id must be a non-empty string")
+        self.m3a_device_id = m3a_device_id
+
+
+class _M3aRobotMixin:
+    """Robot-side policy, binding, budget, and exact decision replay."""
+
+    _m3a_only = False
+
+    def _m3a_context_for(
+        self,
+        contract: ExecutionContract,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> M3aSpatialExecutionContext | None:
+        """Find the context for a contract, retaining mismatches for refusal.
+
+        An exact contract/revision match wins.  If that is absent, a context
+        with the same operation or transport correlation is still returned so
+        a present-but-mutated context is classified as ``HOLD_CONTEXT_MISMATCH``
+        rather than being mistaken for a retryable missing dependency.
+        """
+
+        candidates = self._m3a_context_candidates_for(contract, correlation_id=correlation_id)
+        return candidates[0].payload if candidates else None
+
+    def _m3a_context_candidates_for(
+        self,
+        contract: ExecutionContract,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> tuple[MessageEnvelope, ...]:
+        messages = tuple(
+            message
+            for message in self.store.inbox_messages()
+            if isinstance(message.payload, M3aSpatialExecutionContext)
+        )
+        exact = tuple(
+            message
+            for message in messages
+            if message.payload.contract_id == contract.contract_id
+            and message.payload.contract_revision == contract.contract_revision
+        )
+        return exact or tuple(
+            message
+            for message in messages
+            if message.payload.operation_id == contract.operation_id
+            or (correlation_id is not None and message.correlation_id == correlation_id)
+        )
+
+    def _m3a_context_has_conflict(
+        self,
+        contract: ExecutionContract,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> bool:
+        """Detect a substituted context before any policy or budget action."""
+
+        candidates = self._m3a_context_candidates_for(
+            contract,
+            correlation_id=correlation_id,
+        )
+        digests = {
+            m3a_canonical_digest(message.payload.model_dump(mode="json"))
+            for message in candidates
+        }
+        if len(digests) > 1:
+            return True
+        if self.store.inspect_m3a_context_conflicts(
+            contract.contract_id,
+            contract.contract_revision,
+        ):
+            return True
+        binding = self.store.find_m3a_context_binding(
+            contract.contract_id,
+            contract.contract_revision,
+        )
+        return binding is not None and bool(digests) and next(iter(digests)) != binding[
+            "context_digest"
+        ]
+
+    @staticmethod
+    def _m3a_intent_from_context(context: LocalM3aContext) -> LocalM3aIntent:
+        return LocalM3aIntent(
+            operation_id=context.operation_id,
+            intent_revision=context.intent_revision,
+            semantic_effect_id=context.semantic_effect_id,
+            target_entity_id=context.target_entity_id,
+            desired_latched=True,
+            reference_observation_id=context.reference_observation_id,
+            reference_detection_id=context.reference_detection_id,
+            reference_digest=context.reference_digest,
+            reference_pose=context.reference_pose,
+            reference_frame_id=context.reference_frame_id,
+            reference_calibration_version=context.reference_calibration_version,
+            reference_world_revision=context.reference_world_revision,
+            reference_observed_at=context.reference_observed_at,
+            same_identity_only=context.same_identity_only,
+            max_displacement_m=context.max_displacement_m,
+            expires_at=context.expires_at,
+        )
+
+    @staticmethod
+    def _m3a_expected_contact(target_entity_id: str) -> str | None:
+        """Map the verified semantic target to the fixture's contact proof."""
+
+        return target_entity_id if target_entity_id in {"A", "B"} else None
+
+    def _m3a_level_from_adapter(
+        self,
+        target_entity_id: str,
+        *,
+        expected_device_id: str,
+    ) -> tuple[LocalM3aLevelEvidence, str | None]:
+        adapter = self.external_effect_adapter
+        if adapter is None:
+            return (
+                LocalM3aLevelEvidence(
+                    target_entity_id=target_entity_id,
+                    desired_latched=True,
+                    actual_latched=False,
+                    device_id=expected_device_id,
+                    counter=0,
+                    observed_at=self.clock.now(),
+                    evidence_observation_id="level:unavailable",
+                ),
+                "LEVEL_ADAPTER_UNAVAILABLE",
+            )
+        reader = getattr(adapter, "level_evidence", None)
+        if not callable(reader):
+            reader = getattr(adapter, "level", None)
+        if not callable(reader):
+            return (
+                LocalM3aLevelEvidence(
+                    target_entity_id=target_entity_id,
+                    desired_latched=True,
+                    actual_latched=False,
+                    device_id=expected_device_id,
+                    counter=0,
+                    observed_at=self.clock.now(),
+                    evidence_observation_id="level:unavailable",
+                ),
+                "LEVEL_READER_UNAVAILABLE",
+            )
+        try:
+            result = reader(target_entity_id, observed_at=self.clock.now())
+            if isinstance(result, TwoButtonLevelEvidence):
+                result = _m3a_local_level(result)
+            if not isinstance(result, LocalM3aLevelEvidence):
+                raise TypeError("level reader must return TwoButtonLevelEvidence")
+            return result, None
+        except (TypeError, ValueError, RuntimeError) as error:
+            return (
+                LocalM3aLevelEvidence(
+                    target_entity_id=target_entity_id,
+                    desired_latched=True,
+                    actual_latched=False,
+                    device_id=expected_device_id,
+                    counter=0,
+                    observed_at=self.clock.now(),
+                    evidence_observation_id="level:error",
+                ),
+                f"LEVEL_READER_ERROR:{type(error).__name__}",
+            )
+
+    def _m3a_envelopes(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        level: LocalM3aLevelEvidence,
+        decision: LocalM3aDecision,
+        held_event: MessageEnvelope | None,
+    ) -> tuple[MessageEnvelope, MessageEnvelope, MessageEnvelope | None]:
+        level_envelope = self.factory.make(
+            "m3a.spatial.level",
+            self.field_id,
+            envelope.correlation_id,
+            _m3a_wire_level(level),
+            causation_id=envelope.message_id,
+            message_id=_m3a_uuid(
+                decision.operation_id,
+                f"level-envelope:{decision.intent_revision}",
+            ),
+        )
+        decision_envelope = self.factory.make(
+            "m3a.spatial.decision",
+            self.field_id,
+            envelope.correlation_id,
+            _m3a_wire_decision(decision),
+            causation_id=level_envelope.message_id,
+            message_id=_m3a_uuid(
+                decision.operation_id,
+                f"decision-envelope:{decision.intent_revision}",
+            ),
+        )
+        return level_envelope, decision_envelope, held_event
+
+    def _m3a_unverified_effect_envelope(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        context: LocalM3aContext,
+        command_digest: str,
+        observation: ExternalEffectObservation,
+        terminal_event: MessageEnvelope,
+        diagnostic: str,
+    ) -> MessageEnvelope:
+        """Build an explicit UNKNOWN diagnostic when the adapter digest is unusable.
+
+        The durable command digest is copied as the expected value so the
+        evidence remains joinable to the dispatch.  ``command_digest_verified``
+        and the diagnostic make clear that this value was not reported by the
+        adapter; all physical contact and level fields stay unknown.
+        """
+
+        proof = TwoButtonEffectEvidence(
+            operation_id=context.operation_id,
+            intent_revision=context.intent_revision,
+            contract_id=context.contract_id,
+            contract_revision=context.contract_revision,
+            semantic_effect_id=context.semantic_effect_id,
+            target_entity_id=context.target_entity_id,
+            effect_key=observation.effect_key,
+            command_digest=command_digest,
+            device_id=observation.device_id,
+            observation_id=observation.observation_id,
+            observed_at=observation.observed_at,
+            outcome=ExternalOutcome.UNKNOWN.value,
+            command_digest_verified=False,
+            command_digest_diagnostic=diagnostic,
+            physical_contact=None,
+            command_executed=None,
+            semantic_goal_attained=None,
+            a_counter=None,
+            b_counter=None,
+            a_latched=None,
+            b_latched=None,
+        )
+        return self.factory.make(
+            "m3a.spatial.effect",
+            self.field_id,
+            envelope.correlation_id,
+            proof,
+            causation_id=terminal_event.message_id,
+            message_id=_m3a_uuid(
+                context.operation_id,
+                f"effect-evidence-envelope:{context.contract_revision}",
+            ),
+            created_at=observation.observed_at,
+        )
+
+    def _m3a_effect_envelope(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        context: LocalM3aContext,
+        command_digest: str,
+        observation: ExternalEffectObservation,
+        terminal_event: MessageEnvelope,
+    ) -> MessageEnvelope:
+        details = dict(observation.details)
+        reported_digest = details.get("command_digest")
+        if reported_digest != command_digest:
+            raise RecordConflictError("M3a effect proof command digest differs from command")
+
+        contact = details.get("contact")
+        if contact not in {"A", "B", "NONE"}:
+            contact = None
+
+        def nonnegative_int(name: str) -> int | None:
+            value = details.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                return None
+            return value
+
+        def optional_bool(name: str) -> bool | None:
+            value = details.get(name)
+            return value if isinstance(value, bool) else None
+
+        command_executed = optional_bool("command_executed")
+        if command_executed is None:
+            command_executed = observation.outcome is ExternalOutcome.APPLIED
+        semantic_goal_attained = optional_bool("semantic_goal_attained")
+        if semantic_goal_attained is None:
+            semantic_goal_attained = (
+                observation.outcome is ExternalOutcome.APPLIED
+                and contact == context.target_entity_id
+            ) if contact is not None else None
+        proof = TwoButtonEffectEvidence(
+            operation_id=context.operation_id,
+            intent_revision=context.intent_revision,
+            contract_id=context.contract_id,
+            contract_revision=context.contract_revision,
+            semantic_effect_id=context.semantic_effect_id,
+            target_entity_id=context.target_entity_id,
+            effect_key=observation.effect_key,
+            command_digest=command_digest,
+            device_id=observation.device_id,
+            observation_id=observation.observation_id,
+            observed_at=observation.observed_at,
+            outcome=observation.outcome.value,
+            command_digest_verified=True,
+            command_digest_diagnostic=None,
+            physical_contact=contact,
+            command_executed=command_executed,
+            semantic_goal_attained=semantic_goal_attained,
+            a_counter=nonnegative_int("a_counter"),
+            b_counter=nonnegative_int("b_counter"),
+            a_latched=optional_bool("a_latched"),
+            b_latched=optional_bool("b_latched"),
+        )
+        return self.factory.make(
+            "m3a.spatial.effect",
+            self.field_id,
+            envelope.correlation_id,
+            proof,
+            causation_id=terminal_event.message_id,
+            message_id=_m3a_uuid(
+                context.operation_id,
+                f"effect-evidence-envelope:{context.contract_revision}",
+            ),
+            created_at=observation.observed_at,
+        )
+
+    def _m3a_held_event(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        previous_state: ContractState = ContractState.RECEIVED,
+    ) -> MessageEnvelope:
+        return self._transition(
+            envelope,
+            previous_state,
+            ContractState.HELD,
+            ordinal=1 if previous_state is ContractState.RECEIVED else 4,
+            occurred_at=self.clock.now(),
+        )
+
+    def _m3a_record_hold(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        level: LocalM3aLevelEvidence,
+        decision: LocalM3aDecision,
+        business_result: str,
+    ) -> None:
+        journal = self.store.find_execution_journal(
+            envelope.payload.contract_id,
+            envelope.payload.contract_revision,
+        )
+        previous_state = (
+            ContractState.ACCEPTED
+            if journal is not None and journal["state"] == ContractState.ACCEPTED.value
+            else ContractState.RECEIVED
+        )
+        held_event = self._m3a_held_event(
+            envelope,
+            previous_state=previous_state,
+        )
+        level_envelope, decision_envelope, _ = self._m3a_envelopes(
+            envelope,
+            level=level,
+            decision=decision,
+            held_event=held_event,
+        )
+        if previous_state is ContractState.ACCEPTED:
+            self.store.complete_budget_scope_denial(
+                envelope.payload.contract_id,
+                envelope.payload.contract_revision,
+                operation_id=envelope.payload.operation_id,
+                reason=business_result,
+                first_envelope=envelope,
+                held_event=held_event,
+                inbox_message_id=envelope.message_id,
+                processed_at=self.clock.now(),
+                m3a_decision_envelope=decision_envelope,
+                m3a_level_envelope=level_envelope,
+                m3a_business_result=business_result,
+            )
+            return
+        self.store.record_m3a_decision(
+            contract_id=envelope.payload.contract_id,
+            contract_revision=envelope.payload.contract_revision,
+            operation_id=envelope.payload.operation_id,
+            decision_envelope=decision_envelope,
+            level_envelope=level_envelope,
+            held_event=held_event,
+            business_result=business_result,
+            recorded_at=self.clock.now(),
+            outgoing=(level_envelope, decision_envelope, held_event),
+        )
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"m3a-held:{business_result}",
+        )
+
+    def _m3a_record_context_payload_hold(
+        self,
+        envelope: MessageEnvelope,
+        context_payload: M3aSpatialExecutionContext,
+        *,
+        reason: str,
+    ) -> None:
+        """Persist a refusal when a delivered context cannot be decoded locally."""
+
+        expected_device_id = getattr(context_payload, "expected_device_id", None)
+        if not isinstance(expected_device_id, str) or not expected_device_id.strip():
+            expected_device_id = "unknown-device"
+        target_entity_id = getattr(context_payload, "target_entity_id", None)
+        if not isinstance(target_entity_id, str) or not target_entity_id.strip():
+            target_entity_id = "unknown-target"
+        level, _ = self._m3a_level_from_adapter(
+            target_entity_id,
+            expected_device_id=expected_device_id,
+        )
+        semantic_effect_id = getattr(context_payload, "semantic_effect_id", None)
+        if not isinstance(semantic_effect_id, str) or not semantic_effect_id.strip():
+            semantic_effect_id = "context-invalid"
+        reference_observation_id = getattr(context_payload, "reference_observation_id", None)
+        if not isinstance(reference_observation_id, str) or not reference_observation_id.strip():
+            reference_observation_id = "context-invalid-reference"
+        current_observation = getattr(context_payload, "current_observation", None)
+        current_observation_id = getattr(current_observation, "observation_id", None)
+        if not isinstance(current_observation_id, str) or not current_observation_id.strip():
+            current_observation_id = "context-invalid-current"
+        decision = LocalM3aDecision(
+            operation_id=envelope.payload.operation_id,
+            intent_revision=1,
+            semantic_effect_id=semantic_effect_id,
+            reference_observation_id=reference_observation_id,
+            current_observation_id=current_observation_id,
+            action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+            reason=reason,
+            budget_state="NOT_ADMITTED",
+        )
+        self._m3a_record_hold(
+            envelope,
+            level=level,
+            decision=decision,
+            business_result="HELD_CONTEXT_PAYLOAD_MISMATCH",
+        )
+
+    def _m3a_command_from_outbox(
+        self, operation_id: UUID, command_digest: str | None
+    ) -> SpatialPressCommand | None:
+        candidates = tuple(
+            message.payload
+            for message in self.store.outbox_messages()
+            if isinstance(message.payload, SpatialPressCommand)
+            and (
+                command_digest is None
+                or message.payload.command_digest == command_digest
+            )
+            and any(
+                isinstance(candidate.payload, LocalTwoButtonDecision)
+                and candidate.payload.operation_id == operation_id
+                for candidate in self.store.outbox_messages()
+            )
+        )
+        return max(candidates, key=lambda value: value.command_id, default=None)
+
+    def _m3a_assert_binding(
+        self,
+        *,
+        contract: ExecutionContract,
+        effect_key: str,
+        expected_device_id: str,
+        command: SpatialPressCommand,
+    ) -> None:
+        budget = self.store.find_autonomy_budget(contract.contract_id, contract.contract_revision)
+        if budget is None:
+            raise RecordConflictError("M3a execution has no durable command-bound budget")
+        if budget.get("command_digest") != command.command_digest:
+            raise RecordConflictError("M3a budget command digest differs from command")
+        binding_reader = getattr(self.external_effect_adapter, "binding", None)
+        if not callable(binding_reader):
+            raise RecordConflictError("M3a adapter cannot prove its immutable command binding")
+        receipt = binding_reader(effect_key)
+        if (
+            getattr(receipt, "device_id", None) != expected_device_id
+            or getattr(receipt, "effect_key", None) != effect_key
+            or getattr(receipt, "command_digest", None) != command.command_digest
+        ):
+            raise RecordConflictError("M3a adapter binding receipt differs from durable command")
+
+    async def _m3a_replay_existing(
+        self,
+        envelope: MessageEnvelope,
+        context: LocalM3aContext,
+        row: Mapping[str, Any],
+    ) -> bool:
+        decision_envelope = row["decision_envelope"]
+        level_envelope = row["level_envelope"]
+        held_event = row["held_event"]
+        if not isinstance(decision_envelope, MessageEnvelope) or not isinstance(
+            level_envelope, MessageEnvelope
+        ):
+            raise RecordConflictError("persisted M3a decision envelopes are malformed")
+        decision = decision_envelope.payload
+        if not isinstance(decision, LocalTwoButtonDecision):
+            raise RecordConflictError("persisted M3a decision payload is malformed")
+        outgoing: list[MessageEnvelope] = [level_envelope]
+        stored_effect_evidence = next(
+            (
+                message
+                for message in self.store.outbox_messages()
+                if isinstance(message.payload, TwoButtonEffectEvidence)
+                and message.payload.operation_id == context.operation_id
+                and message.payload.contract_id == envelope.payload.contract_id
+                and message.payload.contract_revision == envelope.payload.contract_revision
+            ),
+            None,
+        )
+        if stored_effect_evidence is not None:
+            outgoing.append(stored_effect_evidence)
+        stored_command_envelope = row.get("command_envelope")
+        if stored_command_envelope is not None and not isinstance(
+            stored_command_envelope, MessageEnvelope
+        ):
+            raise RecordConflictError("persisted M3a command envelope is malformed")
+        stored_command = (
+            stored_command_envelope.payload
+            if isinstance(stored_command_envelope, MessageEnvelope)
+            else None
+        )
+        if stored_command is not None and not isinstance(stored_command, SpatialPressCommand):
+            raise RecordConflictError("persisted M3a command payload is malformed")
+        command = (
+            stored_command
+            if isinstance(stored_command, SpatialPressCommand)
+            else self._m3a_command_from_outbox(context.operation_id, decision.command_digest)
+        )
+        effect_key = f"press:{context.operation_id}:{context.intent_revision}"
+        if decision.action in {M3aAction.EXECUTE, M3aAction.REANCHOR_EXECUTE}:
+            if command is None:
+                raise RecordConflictError("persisted M3a decision has no command envelope")
+            expected_contact = self._m3a_expected_contact(context.target_entity_id)
+            if expected_contact is None:
+                raise RecordConflictError(
+                    "M3a replay target has no supported physical contact proof"
+                )
+            expected_device_id = context.expected_device_id or self._external_device_id()
+            if expected_device_id is None:
+                raise RecordConflictError("M3a replay has no expected device identity")
+            self._m3a_assert_binding(
+                contract=envelope.payload,
+                effect_key=effect_key,
+                expected_device_id=expected_device_id,
+                command=command,
+            )
+            command_envelope = stored_command_envelope
+            if command_envelope is None:
+                command_envelope = next(
+                    message
+                    for message in self.store.outbox_messages()
+                    if isinstance(message.payload, SpatialPressCommand)
+                    and message.payload.command_digest == command.command_digest
+                )
+            outgoing.append(command_envelope)
+            journal = self.store.find_execution_journal(
+                envelope.payload.contract_id, envelope.payload.contract_revision
+            )
+            outgoing.append(decision_envelope)
+            if held_event is not None:
+                outgoing.append(held_event)
+            if journal is not None and journal["state"] == ContractState.DISPATCH_RECORDED.value:
+                for replay in outgoing:
+                    self._enqueue_if_absent(replay)
+                await self._process_external_contract(
+                    envelope,
+                    effect_key=effect_key,
+                    dispatch_recorded_now=False,
+                    expected_device_id=expected_device_id,
+                    expected_contact=expected_contact,
+                    m3a_context=context,
+                    command_digest=command.command_digest,
+                )
+                return True
+        else:
+            outgoing.append(decision_envelope)
+            if held_event is not None:
+                outgoing.append(held_event)
+        self.store.complete_inbox(
+            envelope.message_id,
+            processed_at=self.clock.now(),
+            handler_result_reference=f"m3a-decision-replay:{decision.action.value}",
+            outgoing=tuple(outgoing),
+        )
+        return True
+
+    async def _process_m3a_contract(self, envelope: MessageEnvelope) -> None:
+        contract = envelope.payload
+        assert isinstance(contract, ExecutionContract)
+        assignment = next(
+            (
+                message.payload
+                for message in self.store.inbox_messages()
+                if isinstance(message.payload, TaskAssignment)
+                and message.payload.assignment_id == contract.assignment_id
+            ),
+            None,
+        )
+        context_payload = self._m3a_context_for(
+            contract,
+            correlation_id=envelope.correlation_id,
+        )
+        if assignment is None or context_payload is None:
+            self.store.fail_inbox(
+                envelope.message_id,
+                {"reason": "m3a-assignment-or-context-not-yet-persisted", "retryable": True},
+            )
+            return
+        existing = self.store.find_m3a_decision(
+            contract.contract_id, contract.contract_revision
+        )
+        context_conflict = self._m3a_context_has_conflict(
+            contract,
+            correlation_id=envelope.correlation_id,
+        )
+        try:
+            local_context = _m3a_local_context(context_payload)
+        except (TypeError, ValueError) as error:
+            self._m3a_record_context_payload_hold(
+                envelope,
+                context_payload,
+                reason=f"CONTEXT_PAYLOAD_INVALID:{type(error).__name__}",
+            )
+            return
+        if context_conflict and existing is None:
+            self._m3a_record_context_payload_hold(
+                envelope,
+                context_payload,
+                reason="CONTEXT_CONTENT_CONFLICT",
+            )
+            return
+        if (
+            assignment.executor_id != self.factory.node_id
+            or context_payload.operation_id != contract.operation_id
+            or context_payload.task_id != assignment.task_id
+            or context_payload.contract_id != contract.contract_id
+        ):
+            # The context is present but inconsistent; retain an auditable
+            # hold with no budget or adapter activity.
+            intent = self._m3a_intent_from_context(local_context)
+            level, _ = self._m3a_level_from_adapter(
+                intent.target_entity_id,
+                expected_device_id=context_payload.expected_device_id or "unknown-device",
+            )
+            decision = LocalM3aDecision(
+                operation_id=contract.operation_id,
+                intent_revision=1,
+                semantic_effect_id=intent.semantic_effect_id,
+                reference_observation_id=intent.reference_observation_id,
+                current_observation_id=local_context.current_observation.observation_id,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason="CONTRACT_CONTEXT_ID_MISMATCH",
+                budget_state="NOT_ADMITTED",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_CONTRACT_CONTEXT_MISMATCH",
+            )
+            return
+
+        if local_context.reference_observation is None:
+            level, _ = self._m3a_level_from_adapter(
+                context_payload.target_entity_id,
+                expected_device_id=context_payload.expected_device_id or "unknown-device",
+            )
+            decision = LocalM3aDecision(
+                operation_id=contract.operation_id,
+                intent_revision=1,
+                semantic_effect_id=context_payload.semantic_effect_id,
+                reference_observation_id=context_payload.reference_observation_id,
+                current_observation_id=context_payload.current_observation.observation_id,
+                action=TwoButtonAction.HOLD_REFERENCE_MISMATCH,
+                reason="REFERENCE_OBSERVATION_NOT_EMBEDDED",
+                budget_state="NOT_ADMITTED",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_REFERENCE_MISMATCH",
+            )
+            return
+        if existing is not None:
+            await self._m3a_replay_existing(envelope, local_context, existing)
+            return
+
+        intent = self._m3a_intent_from_context(local_context)
+        expected_contact = self._m3a_expected_contact(intent.target_entity_id)
+        if expected_contact is None:
+            level, _ = self._m3a_level_from_adapter(
+                intent.target_entity_id,
+                expected_device_id=context_payload.expected_device_id or "unknown-device",
+            )
+            decision = LocalTwoButtonDecision(
+                operation_id=intent.operation_id,
+                intent_revision=1,
+                semantic_effect_id=intent.semantic_effect_id,
+                reference_observation_id=intent.reference_observation_id,
+                current_observation_id=local_context.current_observation.observation_id,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason="UNSUPPORTED_TARGET_CONTACT",
+                budget_state="NOT_ADMITTED",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_UNSUPPORTED_TARGET_CONTACT",
+            )
+            return
+        expected_device_id = context_payload.expected_device_id or self._external_device_id()
+        if expected_device_id is None:
+            level, _ = self._m3a_level_from_adapter(
+                intent.target_entity_id, expected_device_id="unknown-device"
+            )
+            decision = LocalM3aDecision(
+                operation_id=intent.operation_id,
+                intent_revision=1,
+                semantic_effect_id=intent.semantic_effect_id,
+                reference_observation_id=intent.reference_observation_id,
+                current_observation_id=local_context.current_observation.observation_id,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason="ADAPTER_UNAVAILABLE",
+                budget_state="NOT_ADMITTED",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_ADAPTER_UNAVAILABLE",
+            )
+            return
+        level, level_error = self._m3a_level_from_adapter(
+            intent.target_entity_id,
+            expected_device_id=expected_device_id,
+        )
+        decision = decide_two_button(
+            intent,
+            local_context.reference_observation,
+            local_context.current_observation,
+            level,
+            expected_source_id=local_context.reference_observation.source_id,
+            expected_device_id=expected_device_id,
+            budget_state="NOT_ADMITTED",
+        )
+        if level_error is not None:
+            decision = replace(
+                decision,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason=level_error,
+            )
+        if decision.action not in {M3aAction.EXECUTE, M3aAction.REANCHOR_EXECUTE}:
+            business_result = (
+                "RECOGNIZED_ALREADY_EFFECTIVE"
+                if decision.action is M3aAction.RECOGNIZE_EFFECT
+                else f"HELD_{decision.reason}"
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result=business_result,
+            )
+            return
+
+        effect_key = f"press:{contract.operation_id}:{contract.contract_revision}"
+        command_local = derive_spatial_press_command(
+            decision,
+            effect_key=effect_key,
+            command_id=f"command:{contract.operation_id}:{contract.contract_revision}",
+            reference_observation=local_context.reference_observation,
+            current_observation=local_context.current_observation,
+        )
+        command = _m3a_wire_command(command_local)
+        decision = replace(decision, command_digest=command.command_digest)
+        binder = getattr(self.external_effect_adapter, "bind", None)
+        if not callable(binder):
+            decision = replace(
+                decision,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason="ADAPTER_BIND_UNAVAILABLE",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_ADAPTER_BIND_UNAVAILABLE",
+            )
+            return
+        try:
+            # The adapter is a local capability boundary; it receives the
+            # immutable local command object, while the identical wire command
+            # is persisted/transmitted as evidence below.
+            receipt = binder(effect_key, command_local)
+            if (
+                getattr(receipt, "device_id", None) != expected_device_id
+                or getattr(receipt, "effect_key", None) != effect_key
+                or getattr(receipt, "command_digest", None) != command.command_digest
+            ):
+                raise RecordConflictError("M3a adapter binding receipt mismatch")
+        except (TypeError, ValueError, RuntimeError, RecordConflictError) as error:
+            decision = replace(
+                decision,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason=f"ADAPTER_BIND_REJECTED:{type(error).__name__}",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_ADAPTER_BIND_REJECTED",
+            )
+            return
+
+        try:
+            self.store.admit_external_budget_contract(
+                contract_id=contract.contract_id,
+                contract_revision=contract.contract_revision,
+                operation_id=contract.operation_id,
+                task_id=assignment.task_id,
+                effect_key=effect_key,
+                accepted_at=self.clock.now(),
+                max_elapsed_seconds=self.max_elapsed_seconds,
+                command_digest=command.command_digest,
+            )
+        except (
+            BudgetScopeConflictError,
+            BudgetPolicyConflictError,
+            BudgetDeadlineError,
+            BudgetLimitError,
+            RecordConflictError,
+        ) as error:
+            decision = replace(
+                decision,
+                action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                reason=f"BUDGET_ADMISSION_REJECTED:{type(error).__name__}",
+            )
+            self._m3a_record_hold(
+                envelope,
+                level=level,
+                decision=decision,
+                business_result="HELD_BUDGET_ADMISSION_REJECTED",
+            )
+            return
+        journal = self._journal(contract)
+        if journal["state"] == ContractState.ACCEPTED.value:
+            try:
+                dispatch_now = self.store.reserve_external_dispatch_with_budget(
+                    contract.contract_id,
+                    contract.contract_revision,
+                    recorded_at=self.clock.now(),
+                    device_id=expected_device_id,
+                    max_elapsed_seconds=self.max_elapsed_seconds,
+                    command_digest=command.command_digest,
+                )
+            except (
+                BudgetPolicyConflictError,
+                BudgetDeadlineError,
+                BudgetLimitError,
+                RecordConflictError,
+            ) as error:
+                decision = replace(
+                    decision,
+                    action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+                    reason=f"BUDGET_RESERVATION_REJECTED:{type(error).__name__}",
+                )
+                self._m3a_record_hold(
+                    envelope,
+                    level=level,
+                    decision=decision,
+                    business_result="HELD_BUDGET_RESERVATION_REJECTED",
+                )
+                return
+        else:
+            dispatch_now = False
+        decision = replace(decision, budget_state="DISPATCH_RECORDED")
+        level_envelope, decision_envelope, _ = self._m3a_envelopes(
+            envelope,
+            level=level,
+            decision=decision,
+            held_event=None,
+        )
+        command_envelope = self.factory.make(
+            "m3a.spatial.command",
+            self.field_id,
+            envelope.correlation_id,
+            command,
+            causation_id=decision_envelope.message_id,
+            message_id=_m3a_uuid(contract.operation_id, "command-envelope"),
+        )
+        self.store.record_m3a_decision(
+            contract_id=contract.contract_id,
+            contract_revision=contract.contract_revision,
+            operation_id=contract.operation_id,
+            decision_envelope=decision_envelope,
+            level_envelope=level_envelope,
+            held_event=None,
+            business_result="EXECUTION_DECISION",
+            recorded_at=self.clock.now(),
+            command_envelope=command_envelope,
+            outgoing=(level_envelope, decision_envelope, command_envelope),
+        )
+        journal = self._journal(contract)
+        self._assert_external_dispatch_configuration(journal, expected_device_id)
+        self._m3a_assert_binding(
+            contract=contract,
+            effect_key=effect_key,
+            expected_device_id=expected_device_id,
+            command=command,
+        )
+        await self._process_external_contract(
+            envelope,
+            effect_key=effect_key,
+            dispatch_recorded_now=dispatch_now,
+            expected_device_id=expected_device_id,
+            expected_contact=expected_contact,
+            m3a_context=local_context,
+            command_digest=command.command_digest,
+        )
+
+    async def process_claimed(self, envelope: MessageEnvelope) -> None:
+        if isinstance(envelope.payload, M3aSpatialExecutionContext):
+            try:
+                self.store.bind_m3a_context(
+                    envelope,
+                    bound_at=self.clock.now(),
+                )
+            except RecordConflictError as error:
+                self.store.complete_inbox(
+                    envelope.message_id,
+                    processed_at=self.clock.now(),
+                    handler_result_reference=f"m3a-context-conflict:{error}",
+                )
+                return
+            self.store.complete_inbox(
+                envelope.message_id,
+                processed_at=self.clock.now(),
+                handler_result_reference=(
+                    f"m3a-context:{envelope.payload.contract_id}:{envelope.payload.contract_revision}"
+                ),
+            )
+            return
+        if isinstance(envelope.payload, ExecutionContract):
+            context = self._m3a_context_for(
+                envelope.payload,
+                correlation_id=envelope.correlation_id,
+            )
+            if self._m3a_only or context is not None:
+                await self._process_m3a_contract(envelope)
+                return
+        await super().process_claimed(envelope)
+
+
+class M3aRobotService(_M3aRobotMixin, DummyRobotService):
+    """Robot service for the M3a spatial adapter and command-bound budget."""
+
+    _m3a_only = True
+
+
+# Compatibility aliases for integration harnesses that describe the physical
+# role before the M3a slice name.
+TwoButtonMissionService = M3aMissionService
+TwoButtonFieldService = M3aFieldService
+TwoButtonRobotService = M3aRobotService
+SpatialMissionService = M3aMissionService
+SpatialFieldService = M3aFieldService
+SpatialRobotService = M3aRobotService

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -7,8 +7,10 @@ make a future external physical action exactly-once.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
+import re
 import sqlite3
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
@@ -24,9 +26,18 @@ from deferred_teleop.external_effect import (
     ExternalOutcome,
     coerce_observation,
 )
-from deferred_teleop.protocol import ContractState, ExecutionEvent, MessageEnvelope
+from deferred_teleop.protocol import (
+    ContractState,
+    ExecutionEvent,
+    LocalTwoButtonDecision,
+    M3aSpatialExecutionContext,
+    MessageEnvelope,
+    SpatialPressCommand,
+    TwoButtonEffectEvidence,
+    TwoButtonLevelEvidence,
+)
 
-CURRENT_SCHEMA_VERSION = 4
+CURRENT_SCHEMA_VERSION = 9
 DEFAULT_BUSY_TIMEOUT_MS = 5_000
 TERMINAL_STATES = frozenset(
     {
@@ -136,6 +147,22 @@ def _envelope_json(envelope: MessageEnvelope) -> str:
     return _canonical_json(envelope.model_dump(mode="json"))
 
 
+def _m3a_payload_json(payload: object) -> str:
+    model_dump = getattr(payload, "model_dump", None)
+    if not callable(model_dump):
+        raise ValueError("M3a payload must expose model_dump")
+    return json.dumps(
+        model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _m3a_payload_digest(payload_json: str) -> str:
+    return "sha256:" + hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+
+
 def _result_json(result: Mapping[str, Any]) -> str:
     try:
         encoded = _canonical_json(result)
@@ -167,6 +194,17 @@ def _validate_budget_policy(
     if not math.isfinite(value) or value <= 0.0:
         raise ValueError("max_elapsed_seconds must be a finite positive float")
     return value
+
+
+def _validate_command_digest(command_digest: str | None) -> str | None:
+    if command_digest is None:
+        return None
+    if (
+        not isinstance(command_digest, str)
+        or re.fullmatch(r"sha256:[0-9a-f]{64}", command_digest) is None
+    ):
+        raise ValueError("command_digest must be sha256:<64 lowercase hexadecimal digits>")
+    return command_digest
 
 
 def _configure(connection: sqlite3.Connection, busy_timeout_ms: int) -> None:
@@ -374,7 +412,203 @@ def _migration_4(connection: sqlite3.Connection) -> None:
     )
 
 
-MIGRATIONS = {1: _migration_1, 2: _migration_2, 3: _migration_3, 4: _migration_4}
+def _migration_5(connection: sqlite3.Connection) -> None:
+    """Bind an M3a canonical spatial command to its external budget."""
+
+    connection.execute(
+        """
+        ALTER TABLE autonomy_budget ADD COLUMN command_digest TEXT
+            CHECK (command_digest IS NULL OR length(trim(command_digest)) > 0)
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE m3a_intent_binding (
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL CHECK (intent_revision = 1),
+            canonical_intent_digest TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            semantic_json TEXT NOT NULL,
+            bound_at TEXT NOT NULL,
+            PRIMARY KEY (operation_id, intent_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE m3a_intent_conflict (
+            conflict_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL,
+            canonical_intent_digest TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            semantic_json TEXT NOT NULL,
+            recorded_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE m3a_decision (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL CHECK (contract_revision = 1),
+            operation_id TEXT NOT NULL,
+            decision_envelope_json TEXT NOT NULL,
+            level_envelope_json TEXT NOT NULL,
+            held_event_json TEXT,
+            business_result TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX m3a_intent_conflict_operation_idx
+            ON m3a_intent_conflict (operation_id, intent_revision, recorded_at)
+        """
+    )
+
+
+def _migration_6(connection: sqlite3.Connection) -> None:
+    """Retain the canonical execute command beside its immutable decision."""
+
+    connection.execute(
+        """
+        ALTER TABLE m3a_decision ADD COLUMN command_envelope_json TEXT
+        """
+    )
+
+
+def _migration_7(connection: sqlite3.Connection) -> None:
+    """Bind one canonical execution context before Robot policy admission."""
+
+    connection.execute(
+        """
+        CREATE TABLE m3a_context_binding (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL CHECK (contract_revision = 1),
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL CHECK (intent_revision = 1),
+            task_id TEXT NOT NULL,
+            context_digest TEXT NOT NULL,
+            context_json TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            bound_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE m3a_context_conflict (
+            conflict_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL,
+            operation_id TEXT NOT NULL,
+            context_digest TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            context_json TEXT NOT NULL,
+            recorded_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX m3a_context_conflict_contract_idx
+            ON m3a_context_conflict (contract_id, contract_revision, recorded_at)
+        """
+    )
+
+
+def _migration_8(connection: sqlite3.Connection) -> None:
+    """Bind the first attributable M3a effect proof at each service boundary."""
+
+    connection.execute(
+        """
+        CREATE TABLE m3a_effect_binding (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL CHECK (contract_revision = 1),
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL CHECK (intent_revision = 1),
+            effect_digest TEXT NOT NULL,
+            effect_json TEXT NOT NULL,
+            effect_envelope_json TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            destination_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            bound_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE m3a_effect_conflict (
+            conflict_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL,
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL,
+            effect_digest TEXT NOT NULL,
+            effect_json TEXT NOT NULL,
+            effect_envelope_json TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            destination_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            recorded_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX m3a_effect_conflict_contract_idx
+            ON m3a_effect_conflict (contract_id, contract_revision, recorded_at)
+        """
+    )
+
+
+def _migration_9(connection: sqlite3.Connection) -> None:
+    """Retain one unverified UNKNOWN diagnostic without making it attributable."""
+
+    connection.execute(
+        """
+        CREATE TABLE m3a_effect_diagnostic (
+            contract_id TEXT NOT NULL,
+            contract_revision INTEGER NOT NULL CHECK (contract_revision = 1),
+            operation_id TEXT NOT NULL,
+            intent_revision INTEGER NOT NULL CHECK (intent_revision = 1),
+            effect_digest TEXT NOT NULL,
+            effect_json TEXT NOT NULL,
+            effect_envelope_json TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            destination_id TEXT NOT NULL,
+            correlation_id TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            PRIMARY KEY (contract_id, contract_revision)
+        )
+        """
+    )
+
+
+MIGRATIONS = {
+    1: _migration_1,
+    2: _migration_2,
+    3: _migration_3,
+    4: _migration_4,
+    5: _migration_5,
+    6: _migration_6,
+    7: _migration_7,
+    8: _migration_8,
+    9: _migration_9,
+}
 
 
 def initialize_database(
@@ -599,9 +833,7 @@ class NodeStore:
         with self._transaction() as connection:
             return self._insert_outbox(connection, envelope)
 
-    def _insert_outbox(
-        self, connection: sqlite3.Connection, envelope: MessageEnvelope
-    ) -> bool:
+    def _insert_outbox(self, connection: sqlite3.Connection, envelope: MessageEnvelope) -> bool:
         encoded = _envelope_json(envelope)
         existing = connection.execute(
             "SELECT payload_json FROM outbox WHERE message_id = ?", (str(envelope.message_id),)
@@ -642,8 +874,7 @@ class NodeStore:
             (_utc_text(now), _utc_text(now)),
         ).fetchall()
         return [
-            self._decode_envelope("outbox", row["message_id"], row["payload_json"])
-            for row in rows
+            self._decode_envelope("outbox", row["message_id"], row["payload_json"]) for row in rows
         ]
 
     def record_attempt(self, message_id: UUID, *, next_attempt_at: datetime) -> int:
@@ -691,9 +922,7 @@ class NodeStore:
         ).fetchone()
         return dict(row) if row is not None else None
 
-    def budget_legacy_classification(
-        self, contract_id: UUID, contract_revision: int
-    ) -> str | None:
+    def budget_legacy_classification(self, contract_id: UUID, contract_revision: int) -> str | None:
         row = self._connection.execute(
             """
             SELECT classification FROM autonomy_budget_legacy
@@ -717,6 +946,626 @@ class NodeStore:
         ).fetchone()
         return dict(row) if row is not None else None
 
+    def find_m3a_intent_binding(
+        self, operation_id: UUID, intent_revision: int = 1
+    ) -> dict[str, Any] | None:
+        """Return the immutable M3a root binding, if Field has created one."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM m3a_intent_binding
+            WHERE operation_id = ? AND intent_revision = ?
+            """,
+            (str(operation_id), intent_revision),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def bind_m3a_intent(
+        self,
+        *,
+        operation_id: UUID,
+        intent_revision: int,
+        canonical_intent_digest: str,
+        source_id: str,
+        correlation_id: UUID,
+        semantic_fields: Mapping[str, Any],
+        bound_at: datetime,
+    ) -> bool:
+        """Atomically bind an operation/revision before Field creates a bundle.
+
+        ``False`` denotes an exact fresh duplicate.  Any changed claim, root
+        source, or correlation is durable as ``M3A_INTENT_CONFLICT`` and raises
+        before an operation plan, assignment, or contract can be emitted.
+        """
+
+        if intent_revision != 1:
+            raise ValueError("M3a intent binding supports revision 1 only")
+        canonical_intent_digest = _validate_command_digest(canonical_intent_digest)
+        assert canonical_intent_digest is not None
+        if not isinstance(source_id, str) or not source_id.strip():
+            raise ValueError("source_id must not be empty")
+        semantic_json = _result_json(semantic_fields)
+        operation_text = str(operation_id)
+        correlation_text = str(correlation_id)
+        conflict = False
+        with self._transaction() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM m3a_intent_binding
+                WHERE operation_id = ? AND intent_revision = ?
+                """,
+                (operation_text, intent_revision),
+            ).fetchone()
+            if existing is not None:
+                exact = (
+                    existing["canonical_intent_digest"] == canonical_intent_digest
+                    and existing["source_id"] == source_id
+                    and existing["correlation_id"] == correlation_text
+                    and existing["semantic_json"] == semantic_json
+                )
+                if exact:
+                    return False
+                connection.execute(
+                    """
+                    INSERT INTO m3a_intent_conflict (
+                        operation_id, intent_revision, canonical_intent_digest,
+                        source_id, correlation_id, reason, semantic_json, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        operation_text,
+                        intent_revision,
+                        canonical_intent_digest,
+                        source_id,
+                        correlation_text,
+                        "M3A_INTENT_CONFLICT",
+                        semantic_json,
+                        _utc_text(bound_at),
+                    ),
+                )
+                # Do not raise inside ``_transaction``: its rollback is
+                # correct for ordinary handler failures, but would erase the
+                # durable conflict evidence required by the M3a oracle.
+                conflict = True
+            if not conflict:
+                connection.execute(
+                    """
+                    INSERT INTO m3a_intent_binding (
+                        operation_id, intent_revision, canonical_intent_digest,
+                        source_id, correlation_id, semantic_json, bound_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        operation_text,
+                        intent_revision,
+                        canonical_intent_digest,
+                        source_id,
+                        correlation_text,
+                        semantic_json,
+                        _utc_text(bound_at),
+                    ),
+                )
+        if conflict:
+            raise RecordConflictError("M3A_INTENT_CONFLICT")
+        return True
+
+    def record_m3a_decision(
+        self,
+        *,
+        contract_id: UUID,
+        contract_revision: int,
+        operation_id: UUID,
+        decision_envelope: MessageEnvelope,
+        level_envelope: MessageEnvelope,
+        held_event: MessageEnvelope | None,
+        business_result: str,
+        recorded_at: datetime,
+        command_envelope: MessageEnvelope | None = None,
+        outgoing: Sequence[MessageEnvelope] = (),
+    ) -> bool:
+        """Persist one immutable Robot decision and its exact consequences.
+
+        Execute decisions pass the canonical command envelope and all three
+        M3a evidence envelopes in ``outgoing``.  They are committed in the
+        same SQLite transaction as the decision, so a crash cannot leave a
+        durable dispatch without the command needed for exact replay.
+        """
+
+        if contract_revision != 1:
+            raise ValueError("M3a decision storage supports contract revision 1 only")
+        if not isinstance(decision_envelope, MessageEnvelope):
+            raise ValueError("decision_envelope is required")
+        if not isinstance(level_envelope, MessageEnvelope):
+            raise ValueError("level_envelope is required")
+        if held_event is not None and not isinstance(held_event.payload, ExecutionEvent):
+            raise ValueError("held_event must contain ExecutionEvent")
+        if command_envelope is not None and not isinstance(
+            command_envelope.payload, SpatialPressCommand
+        ):
+            raise ValueError("command_envelope must contain SpatialPressCommand")
+        if any(not isinstance(value, MessageEnvelope) for value in outgoing):
+            raise ValueError("outgoing must contain MessageEnvelope values")
+        if not isinstance(business_result, str) or not business_result.strip():
+            raise ValueError("business_result must not be empty")
+        decision_json = _envelope_json(decision_envelope)
+        level_json = _envelope_json(level_envelope)
+        held_json = _envelope_json(held_event) if held_event is not None else None
+        command_json = _envelope_json(command_envelope) if command_envelope is not None else None
+        recorded_text = _utc_text(recorded_at)
+        with self._transaction() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM m3a_decision
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (str(contract_id), contract_revision),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["operation_id"] == str(operation_id)
+                    and existing["decision_envelope_json"] == decision_json
+                    and existing["level_envelope_json"] == level_json
+                    and existing["held_event_json"] == held_json
+                    and existing["command_envelope_json"] == command_json
+                    and existing["business_result"] == business_result
+                ):
+                    for consequence in outgoing:
+                        self._insert_outbox(connection, consequence)
+                    return False
+                raise RecordConflictError("M3a decision is immutable")
+            connection.execute(
+                """
+                INSERT INTO m3a_decision (
+                    contract_id, contract_revision, operation_id,
+                    decision_envelope_json, level_envelope_json, held_event_json,
+                    command_envelope_json, business_result, recorded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(contract_id),
+                    contract_revision,
+                    str(operation_id),
+                    decision_json,
+                    level_json,
+                    held_json,
+                    command_json,
+                    business_result,
+                    recorded_text,
+                ),
+            )
+            for consequence in outgoing:
+                self._insert_outbox(connection, consequence)
+        return True
+
+    def find_m3a_decision(
+        self, contract_id: UUID, contract_revision: int = 1
+    ) -> dict[str, Any] | None:
+        """Return one persisted M3a decision with validated envelope objects."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM m3a_decision
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["decision_envelope"] = self._decode_envelope(
+            "m3a_decision",
+            f"{contract_id}:{contract_revision}:decision",
+            row["decision_envelope_json"],
+        )
+        result["level_envelope"] = self._decode_envelope(
+            "m3a_decision", f"{contract_id}:{contract_revision}:level", row["level_envelope_json"]
+        )
+        result["held_event"] = (
+            self._decode_envelope(
+                "m3a_decision", f"{contract_id}:{contract_revision}:held", row["held_event_json"]
+            )
+            if row["held_event_json"] is not None
+            else None
+        )
+        result["command_envelope"] = (
+            self._decode_envelope(
+                "m3a_decision",
+                f"{contract_id}:{contract_revision}:command",
+                row["command_envelope_json"],
+            )
+            if row["command_envelope_json"] is not None
+            else None
+        )
+        return result
+
+    def find_m3a_context_binding(
+        self, contract_id: UUID, contract_revision: int = 1
+    ) -> dict[str, Any] | None:
+        """Return the first immutable context bound to a contract."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM m3a_context_binding
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def find_m3a_effect_binding(
+        self, contract_id: UUID, contract_revision: int = 1
+    ) -> dict[str, Any] | None:
+        """Return the first attributable effect proof bound to a contract."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM m3a_effect_binding
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["effect_envelope"] = self._decode_envelope(
+            "m3a_effect_binding",
+            f"{contract_id}:{contract_revision}",
+            row["effect_envelope_json"],
+        )
+        result["effect"] = result["effect_envelope"].payload
+        return result
+
+    def find_m3a_effect_diagnostic(
+        self, contract_id: UUID, contract_revision: int = 1
+    ) -> dict[str, Any] | None:
+        """Return the first unverified UNKNOWN diagnostic for a contract."""
+
+        row = self._connection.execute(
+            """
+            SELECT * FROM m3a_effect_diagnostic
+            WHERE contract_id = ? AND contract_revision = ?
+            """,
+            (str(contract_id), contract_revision),
+        ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["effect_envelope"] = self._decode_envelope(
+            "m3a_effect_diagnostic",
+            f"{contract_id}:{contract_revision}",
+            row["effect_envelope_json"],
+        )
+        result["effect"] = result["effect_envelope"].payload
+        return result
+
+    def bind_m3a_effect_diagnostic(
+        self, envelope: MessageEnvelope, *, recorded_at: datetime
+    ) -> bool:
+        """Retain one digest-unverified UNKNOWN without attributing its facts."""
+
+        if not isinstance(envelope.payload, TwoButtonEffectEvidence):
+            raise ValueError("M3a effect diagnostic requires m3a.spatial.effect")
+        effect = envelope.payload
+        if effect.command_digest_verified or effect.outcome != "UNKNOWN":
+            raise ValueError("only digest-unverified UNKNOWN effects are diagnostics")
+        effect_json = _m3a_payload_json(effect)
+        effect_digest = _m3a_payload_digest(effect_json)
+        envelope_json = _envelope_json(envelope)
+        contract_text = str(effect.contract_id)
+        operation_text = str(effect.operation_id)
+        conflict = False
+        with self._transaction() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM m3a_effect_diagnostic
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, effect.contract_revision),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["operation_id"] == operation_text
+                    and existing["intent_revision"] == effect.intent_revision
+                    and existing["effect_digest"] == effect_digest
+                    and existing["effect_json"] == effect_json
+                    and existing["source_id"] == envelope.source_id
+                    and existing["destination_id"] == envelope.destination_id
+                    and existing["correlation_id"] == str(envelope.correlation_id)
+                ):
+                    return False
+                connection.execute(
+                    """
+                    INSERT INTO m3a_effect_conflict (
+                        contract_id, contract_revision, operation_id,
+                        intent_revision, effect_digest, effect_json,
+                        effect_envelope_json, source_id, destination_id,
+                        correlation_id, reason, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        effect.contract_revision,
+                        operation_text,
+                        effect.intent_revision,
+                        effect_digest,
+                        effect_json,
+                        envelope_json,
+                        envelope.source_id,
+                        envelope.destination_id,
+                        str(envelope.correlation_id),
+                        "M3A_EFFECT_DIAGNOSTIC_CONFLICT",
+                        _utc_text(recorded_at),
+                    ),
+                )
+                conflict = True
+            else:
+                connection.execute(
+                    """
+                    INSERT INTO m3a_effect_diagnostic (
+                        contract_id, contract_revision, operation_id,
+                        intent_revision, effect_digest, effect_json,
+                        effect_envelope_json, source_id, destination_id,
+                        correlation_id, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        effect.contract_revision,
+                        operation_text,
+                        effect.intent_revision,
+                        effect_digest,
+                        effect_json,
+                        envelope_json,
+                        envelope.source_id,
+                        envelope.destination_id,
+                        str(envelope.correlation_id),
+                        _utc_text(recorded_at),
+                    ),
+                )
+        if conflict:
+            raise RecordConflictError("M3A_EFFECT_DIAGNOSTIC_CONFLICT")
+        return True
+
+    def bind_m3a_effect(self, envelope: MessageEnvelope, *, bound_at: datetime) -> bool:
+        """Persist the first verified effect and reject changed semantic duplicates.
+
+        Message IDs, source boots, sequence numbers, and timestamps describe a
+        transport attempt and may change on a retry.  The persisted binding
+        compares the complete canonical effect payload and the semantic
+        source/destination/correlation tuple, so a replay of the same proof is
+        harmless while a changed proof is durably recorded as a conflict.
+        Digest-unverified UNKNOWN observations are diagnostics rather than an
+        attributable first proof and therefore do not create the binding.
+        """
+
+        if not isinstance(envelope.payload, TwoButtonEffectEvidence):
+            raise ValueError("M3a effect binding requires m3a.spatial.effect")
+        effect = envelope.payload
+        if effect.intent_revision != 1 or effect.contract_revision != 1:
+            raise ValueError("M3a effect binding supports revision 1 only")
+        effect_json = _m3a_payload_json(effect)
+        effect_digest = _m3a_payload_digest(effect_json)
+        envelope_json = _envelope_json(envelope)
+        contract_text = str(effect.contract_id)
+        operation_text = str(effect.operation_id)
+        conflict = False
+        with self._transaction() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM m3a_effect_binding
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, effect.contract_revision),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["operation_id"] == operation_text
+                    and existing["intent_revision"] == effect.intent_revision
+                    and existing["effect_digest"] == effect_digest
+                    and existing["effect_json"] == effect_json
+                    and existing["source_id"] == envelope.source_id
+                    and existing["destination_id"] == envelope.destination_id
+                    and existing["correlation_id"] == str(envelope.correlation_id)
+                ):
+                    return False
+                connection.execute(
+                    """
+                    INSERT INTO m3a_effect_conflict (
+                        contract_id, contract_revision, operation_id,
+                        intent_revision, effect_digest, effect_json,
+                        effect_envelope_json, source_id, destination_id,
+                        correlation_id, reason, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        effect.contract_revision,
+                        operation_text,
+                        effect.intent_revision,
+                        effect_digest,
+                        effect_json,
+                        envelope_json,
+                        envelope.source_id,
+                        envelope.destination_id,
+                        str(envelope.correlation_id),
+                        "M3A_EFFECT_CONFLICT",
+                        _utc_text(bound_at),
+                    ),
+                )
+                conflict = True
+            elif effect.command_digest_verified:
+                connection.execute(
+                    """
+                    INSERT INTO m3a_effect_binding (
+                        contract_id, contract_revision, operation_id,
+                        intent_revision, effect_digest, effect_json,
+                        effect_envelope_json, source_id, destination_id,
+                        correlation_id, bound_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        effect.contract_revision,
+                        operation_text,
+                        effect.intent_revision,
+                        effect_digest,
+                        effect_json,
+                        envelope_json,
+                        envelope.source_id,
+                        envelope.destination_id,
+                        str(envelope.correlation_id),
+                        _utc_text(bound_at),
+                    ),
+                )
+            else:
+                # An UNKNOWN result whose command digest was not reported is
+                # retained in the normal inbox/outbox audit trail, but cannot
+                # become the immutable first attributable proof.
+                return False
+        if conflict:
+            raise RecordConflictError("M3A_EFFECT_CONFLICT")
+        return True
+
+    def record_m3a_effect_conflict(
+        self,
+        envelope: MessageEnvelope,
+        *,
+        reason: str,
+        recorded_at: datetime,
+    ) -> None:
+        """Record a validated effect divergence without changing its binding."""
+
+        if not isinstance(envelope.payload, TwoButtonEffectEvidence):
+            raise ValueError("M3a effect conflict requires m3a.spatial.effect")
+        if not reason or not reason.strip():
+            raise ValueError("effect conflict reason must not be empty")
+        effect = envelope.payload
+        effect_json = _m3a_payload_json(effect)
+        with self._transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO m3a_effect_conflict (
+                    contract_id, contract_revision, operation_id,
+                    intent_revision, effect_digest, effect_json,
+                    effect_envelope_json, source_id, destination_id,
+                    correlation_id, reason, recorded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(effect.contract_id),
+                    effect.contract_revision,
+                    str(effect.operation_id),
+                    effect.intent_revision,
+                    _m3a_payload_digest(effect_json),
+                    effect_json,
+                    _envelope_json(envelope),
+                    envelope.source_id,
+                    envelope.destination_id,
+                    str(envelope.correlation_id),
+                    reason,
+                    _utc_text(recorded_at),
+                ),
+            )
+
+    def bind_m3a_context(self, envelope: MessageEnvelope, *, bound_at: datetime) -> bool:
+        """Bind one canonical context and durably reject changed duplicates."""
+
+        if not isinstance(envelope.payload, M3aSpatialExecutionContext):
+            raise ValueError("M3a context binding requires m3a.spatial.context")
+        context = envelope.payload
+        if context.intent_revision != 1 or context.contract_revision != 1:
+            raise ValueError("M3a context binding supports revision 1 only")
+        context_json = _m3a_payload_json(context)
+        context_digest = _m3a_payload_digest(context_json)
+        contract_text = str(context.contract_id)
+        operation_text = str(context.operation_id)
+        task_text = str(context.task_id)
+        conflict = False
+        with self._transaction() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM m3a_context_binding
+                WHERE contract_id = ? AND contract_revision = ?
+                """,
+                (contract_text, context.contract_revision),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["context_digest"] == context_digest
+                    and existing["context_json"] == context_json
+                ):
+                    return False
+                connection.execute(
+                    """
+                    INSERT INTO m3a_context_conflict (
+                        contract_id, contract_revision, operation_id,
+                        context_digest, source_id, correlation_id, reason,
+                        context_json, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        context.contract_revision,
+                        operation_text,
+                        context_digest,
+                        envelope.source_id,
+                        str(envelope.correlation_id),
+                        "M3A_CONTEXT_CONFLICT",
+                        context_json,
+                        _utc_text(bound_at),
+                    ),
+                )
+                conflict = True
+            if not conflict:
+                connection.execute(
+                    """
+                    INSERT INTO m3a_context_binding (
+                        contract_id, contract_revision, operation_id,
+                        intent_revision, task_id, context_digest, context_json,
+                        source_id, correlation_id, bound_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        contract_text,
+                        context.contract_revision,
+                        operation_text,
+                        context.intent_revision,
+                        task_text,
+                        context_digest,
+                        context_json,
+                        envelope.source_id,
+                        str(envelope.correlation_id),
+                        _utc_text(bound_at),
+                    ),
+                )
+        if conflict:
+            raise RecordConflictError("M3A_CONTEXT_CONFLICT")
+        return True
+
+    def inspect_m3a_context_conflicts(
+        self,
+        contract_id: UUID | None = None,
+        contract_revision: int = 1,
+    ) -> list[dict[str, Any]]:
+        if contract_id is None:
+            return self._rows(
+                """
+                SELECT * FROM m3a_context_conflict
+                ORDER BY recorded_at, conflict_id
+                """
+            )
+        return [
+            dict(row)
+            for row in self._connection.execute(
+                """
+                SELECT * FROM m3a_context_conflict
+                WHERE contract_id = ? AND contract_revision = ?
+                ORDER BY recorded_at, conflict_id
+                """,
+                (str(contract_id), contract_revision),
+            ).fetchall()
+        ]
+
     def admit_external_budget_contract(
         self,
         *,
@@ -729,6 +1578,7 @@ class NodeStore:
         max_elapsed_seconds: float,
         attempt_limit: int = 1,
         action_limit: int = 1,
+        command_digest: str | None = None,
     ) -> bool:
         """Admit one rev-1 external contract and snapshot its local policy.
 
@@ -747,11 +1597,10 @@ class NodeStore:
             raise ValueError("external autonomy budget admits contract revision 1 only")
         if not isinstance(effect_key, str) or not effect_key.strip():
             raise ValueError("effect_key must be a non-empty string")
+        command_digest = _validate_command_digest(command_digest)
         accepted_text = _utc_text(accepted_at)
         try:
-            deadline_text = _utc_text(
-                accepted_at + timedelta(seconds=policy_seconds)
-            )
+            deadline_text = _utc_text(accepted_at + timedelta(seconds=policy_seconds))
         except (OverflowError, ValueError) as error:
             raise ValueError("max_elapsed_seconds produces an invalid deadline") from error
         operation_text = str(operation_id)
@@ -783,6 +1632,10 @@ class NodeStore:
                     str(journal["effect_key"]),
                 ) != immutable:
                     raise RecordConflictError("contract revision collision")
+                if command_digest is not None and budget["command_digest"] != command_digest:
+                    raise RecordConflictError(
+                        "external command digest differs from durable budget binding"
+                    )
                 return False
 
             prior_denial = connection.execute(
@@ -883,16 +1736,18 @@ class NodeStore:
                 """
                 INSERT INTO autonomy_budget (
                     operation_id, bound_contract_id, bound_contract_revision, effect_key,
+                    command_digest,
                     attempt_limit, action_limit, max_elapsed_seconds,
                     window_started_at, deadline_at, clock_high_water_at,
                     attempts_reserved, actions_reserved, dispatch_reserved_at, resolution
-                ) VALUES (?, ?, ?, ?, 1, 1, ?, ?, ?, ?, 0, 0, NULL, NULL)
+                ) VALUES (?, ?, ?, ?, ?, 1, 1, ?, ?, ?, ?, 0, 0, NULL, NULL)
                 """,
                 (
                     operation_text,
                     contract_text,
                     contract_revision,
                     effect_key,
+                    command_digest,
                     policy_seconds,
                     accepted_text,
                     deadline_text,
@@ -911,6 +1766,7 @@ class NodeStore:
         max_elapsed_seconds: float,
         attempt_limit: int = 1,
         action_limit: int = 1,
+        command_digest: str | None = None,
     ) -> bool:
         """Reserve the sole external action and record dispatch atomically.
 
@@ -926,6 +1782,7 @@ class NodeStore:
         )
         if not isinstance(device_id, str) or not device_id.strip():
             raise ValueError("device_id must be a non-empty string")
+        command_digest = _validate_command_digest(command_digest)
         recorded_text = _utc_text(recorded_at)
 
         with self._transaction() as connection:
@@ -948,9 +1805,7 @@ class NodeStore:
                 (str(journal["operation_id"]),),
             ).fetchone()
             if budget is None:
-                raise RecordConflictError(
-                    "external contract has no durable autonomy budget"
-                )
+                raise RecordConflictError("external contract has no durable autonomy budget")
             if (
                 budget["bound_contract_id"] != str(contract_id)
                 or int(budget["bound_contract_revision"]) != contract_revision
@@ -961,6 +1816,10 @@ class NodeStore:
                     operation_id=str(journal["operation_id"]),
                     bound_contract_id=str(budget["bound_contract_id"]),
                     bound_contract_revision=int(budget["bound_contract_revision"]),
+                )
+            if command_digest is not None and budget["command_digest"] != command_digest:
+                raise RecordConflictError(
+                    "external command digest differs from durable budget binding"
                 )
             if (
                 int(budget["attempt_limit"]) != attempt_limit
@@ -978,9 +1837,7 @@ class NodeStore:
             high_water_at = _parse_utc_text(
                 budget["clock_high_water_at"], field_name="clock_high_water_at"
             )
-            deadline_at = _parse_utc_text(
-                budget["deadline_at"], field_name="deadline_at"
-            )
+            deadline_at = _parse_utc_text(budget["deadline_at"], field_name="deadline_at")
             if recorded_at < accepted_at or recorded_at < high_water_at:
                 raise BudgetClockRollbackError(
                     BUDGET_CLOCK_ROLLBACK
@@ -988,8 +1845,7 @@ class NodeStore:
                 )
             if recorded_at >= deadline_at:
                 raise BudgetDeadlineError(
-                    BUDGET_DEADLINE_EXPIRED
-                    + ": service-clock budget window has elapsed"
+                    BUDGET_DEADLINE_EXPIRED + ": service-clock budget window has elapsed"
                 )
 
             connection.execute(
@@ -1046,6 +1902,9 @@ class NodeStore:
         held_event: MessageEnvelope,
         inbox_message_id: UUID,
         processed_at: datetime,
+        m3a_decision_envelope: MessageEnvelope | None = None,
+        m3a_level_envelope: MessageEnvelope | None = None,
+        m3a_business_result: str | None = None,
     ) -> bool:
         """Persist a pre-dispatch denial, its stable HELD event, and inbox completion.
 
@@ -1085,10 +1944,33 @@ class NodeStore:
             or event.previous_state not in {ContractState.RECEIVED, ContractState.ACCEPTED}
         ):
             raise RecordConflictError("budget denial event does not match pre-dispatch hold")
+        if (m3a_decision_envelope is None) != (m3a_level_envelope is None):
+            raise ValueError("M3a denial evidence requires both decision and level envelopes")
+        if m3a_decision_envelope is not None:
+            if m3a_decision_envelope.message_type != "m3a.spatial.decision":
+                raise ValueError("M3a denial decision envelope has the wrong message type")
+            if m3a_level_envelope is None or m3a_level_envelope.message_type != "m3a.spatial.level":
+                raise ValueError("M3a denial level envelope has the wrong message type")
+            if not isinstance(m3a_decision_envelope.payload, LocalTwoButtonDecision):
+                raise ValueError("M3a denial decision envelope has the wrong payload")
+            if not isinstance(m3a_level_envelope.payload, TwoButtonLevelEvidence):
+                raise ValueError("M3a denial level envelope has the wrong payload")
+            if not isinstance(m3a_business_result, str) or not m3a_business_result.strip():
+                raise ValueError("M3a denial business result must not be empty")
         operation_text = str(operation_id)
         contract_text = str(contract_id)
         first_encoded = _envelope_json(first_envelope)
         candidate_encoded = _envelope_json(held_event)
+        m3a_decision_encoded = (
+            _envelope_json(m3a_decision_envelope)
+            if m3a_decision_envelope is not None
+            else None
+        )
+        m3a_level_encoded = (
+            _envelope_json(m3a_level_envelope)
+            if m3a_level_envelope is not None
+            else None
+        )
         event_occurred_text = _utc_text(event.occurred_at)
         processed_text = _utc_text(processed_at)
 
@@ -1128,9 +2010,7 @@ class NodeStore:
                     raise InvalidStateTransitionError(
                         "an ACCEPTED journal requires an ACCEPTED -> HELD denial"
                     )
-                accepted_at = _parse_utc_text(
-                    journal["accepted_at"], field_name="accepted_at"
-                )
+                accepted_at = _parse_utc_text(journal["accepted_at"], field_name="accepted_at")
                 if event.occurred_at < accepted_at:
                     raise BudgetClockRollbackError(
                         BUDGET_CLOCK_ROLLBACK
@@ -1138,8 +2018,7 @@ class NodeStore:
                     )
             if processed_at < event.occurred_at:
                 raise BudgetClockRollbackError(
-                    BUDGET_CLOCK_ROLLBACK
-                    + ": inbox completion precedes denial timestamp"
+                    BUDGET_CLOCK_ROLLBACK + ": inbox completion precedes denial timestamp"
                 )
 
             existing = connection.execute(
@@ -1188,9 +2067,7 @@ class NodeStore:
                     or durable_first.payload.model_dump(mode="json")
                     != first_envelope.payload.model_dump(mode="json")
                 ):
-                    raise RecordConflictError(
-                        "budget denial first envelope payload is immutable"
-                    )
+                    raise RecordConflictError("budget denial first envelope payload is immutable")
                 durable_event = self._decode_envelope(
                     "autonomy_budget_denial",
                     f"{contract_text}:{contract_revision}:held",
@@ -1247,6 +2124,46 @@ class NodeStore:
                         contract_revision,
                     ),
                 )
+
+            if m3a_decision_encoded is not None and m3a_level_encoded is not None:
+                decision_row = connection.execute(
+                    """
+                    SELECT * FROM m3a_decision
+                    WHERE contract_id = ? AND contract_revision = ?
+                    """,
+                    (contract_text, contract_revision),
+                ).fetchone()
+                if decision_row is None:
+                    connection.execute(
+                        """
+                        INSERT INTO m3a_decision (
+                            contract_id, contract_revision, operation_id,
+                            decision_envelope_json, level_envelope_json, held_event_json,
+                            command_envelope_json, business_result, recorded_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+                        """,
+                        (
+                            contract_text,
+                            contract_revision,
+                            operation_text,
+                            m3a_decision_encoded,
+                            m3a_level_encoded,
+                            candidate_encoded,
+                            m3a_business_result,
+                            processed_text,
+                        ),
+                    )
+                elif (
+                    str(decision_row["operation_id"]) != operation_text
+                    or decision_row["decision_envelope_json"] != m3a_decision_encoded
+                    or decision_row["level_envelope_json"] != m3a_level_encoded
+                    or decision_row["held_event_json"] != candidate_encoded
+                    or decision_row["command_envelope_json"] is not None
+                    or decision_row["business_result"] != m3a_business_result
+                ):
+                    raise RecordConflictError("M3a denial decision is immutable")
+                self._insert_outbox(connection, m3a_level_envelope)
+                self._insert_outbox(connection, m3a_decision_envelope)
 
             durable_event = self._decode_envelope(
                 "autonomy_budget_denial",
@@ -1320,9 +2237,7 @@ class NodeStore:
         recorded_at: datetime,
         device_id: str | None = None,
     ) -> bool:
-        if device_id is not None and (
-            not isinstance(device_id, str) or not device_id.strip()
-        ):
+        if device_id is not None and (not isinstance(device_id, str) or not device_id.strip()):
             raise ValueError("device_id must be a non-empty string when provided")
         with self._transaction() as connection:
             row = self._journal_row(connection, contract_id, contract_revision)
@@ -1410,10 +2325,11 @@ class NodeStore:
         observation: ExternalEffectObservation | Mapping[str, Any] | object | None = None,
         expected_device_id: str | None = None,
         terminal_state: ContractState | None = None,
-        terminal_result: Mapping[str, Any] | None = None,
-        occurred_at: datetime,
-        terminal_event: MessageEnvelope,
-    ) -> bool:
+    terminal_result: Mapping[str, Any] | None = None,
+    occurred_at: datetime,
+    terminal_event: MessageEnvelope,
+    outgoing: Sequence[MessageEnvelope] = (),
+) -> bool:
         """Atomically resolve an effect performed outside the Robot journal.
 
         The external path deliberately leaves ``effect_count`` at zero.  The
@@ -1429,15 +2345,15 @@ class NodeStore:
 
         if observation is None:
             raise ValueError("external observation proof is required")
+        if any(not isinstance(value, MessageEnvelope) for value in outgoing):
+            raise ValueError("outgoing must contain MessageEnvelope values")
 
         row = self._journal_row(self._connection, contract_id, contract_revision)
         expected_effect_key = str(row["effect_key"])
         occurred_text = _utc_text(occurred_at)
         dispatch_recorded_at = row["dispatch_recorded_at"]
         if dispatch_recorded_at is not None:
-            dispatch_at = _parse_utc_text(
-                dispatch_recorded_at, field_name="dispatch_recorded_at"
-            )
+            dispatch_at = _parse_utc_text(dispatch_recorded_at, field_name="dispatch_recorded_at")
             if occurred_at < dispatch_at:
                 raise RecordConflictError(
                     "external terminal resolution cannot precede durable dispatch_recorded_at"
@@ -1541,6 +2457,8 @@ class NodeStore:
                     "external observation device differs from durable dispatch identity"
                 )
             self._insert_outbox(connection, terminal_event)
+            for consequence in outgoing:
+                self._insert_outbox(connection, consequence)
             connection.execute(
                 """
                 UPDATE execution_journal SET state = ?, terminal_at = ?,
@@ -1623,9 +2541,7 @@ class NodeStore:
         return self._rows("SELECT * FROM outbox ORDER BY created_at, message_id")
 
     def inspect_execution_journal(self) -> list[dict[str, Any]]:
-        return self._rows(
-            "SELECT * FROM execution_journal ORDER BY contract_id, contract_revision"
-        )
+        return self._rows("SELECT * FROM execution_journal ORDER BY contract_id, contract_revision")
 
     def inspect_autonomy_budget(self) -> list[dict[str, Any]]:
         return self._rows("SELECT * FROM autonomy_budget ORDER BY operation_id")
@@ -1646,6 +2562,78 @@ class NodeStore:
             """
         )
 
+    def inspect_m3a_intent_bindings(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_intent_binding
+            ORDER BY operation_id, intent_revision
+            """
+        )
+
+    def inspect_m3a_intent_conflicts(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_intent_conflict
+            ORDER BY recorded_at, conflict_id
+            """
+        )
+
+    def inspect_m3a_decisions(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_decision
+            ORDER BY contract_id, contract_revision
+            """
+        )
+
+    def inspect_m3a_context_bindings(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_context_binding
+            ORDER BY contract_id, contract_revision
+            """
+        )
+
+    def inspect_m3a_effect_bindings(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_effect_binding
+            ORDER BY contract_id, contract_revision
+            """
+        )
+
+    def inspect_m3a_effect_diagnostics(self) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT * FROM m3a_effect_diagnostic
+            ORDER BY contract_id, contract_revision
+            """
+        )
+
+    def inspect_m3a_effect_conflicts(
+        self,
+        contract_id: UUID | None = None,
+        contract_revision: int = 1,
+    ) -> list[dict[str, Any]]:
+        if contract_id is None:
+            return self._rows(
+                """
+                SELECT * FROM m3a_effect_conflict
+                ORDER BY recorded_at, conflict_id
+                """
+            )
+        return [
+            dict(row)
+            for row in self._connection.execute(
+                """
+                SELECT * FROM m3a_effect_conflict
+                WHERE contract_id = ? AND contract_revision = ?
+                ORDER BY recorded_at, conflict_id
+                """,
+                (str(contract_id), contract_revision),
+            ).fetchall()
+        ]
+
     def inbox_messages(self) -> list[MessageEnvelope]:
         """Return validated inbox envelopes for recovery and read-model reconstruction."""
 
@@ -1653,8 +2641,7 @@ class NodeStore:
             "SELECT message_id, payload_json FROM inbox ORDER BY received_at, message_id"
         ).fetchall()
         return [
-            self._decode_envelope("inbox", row["message_id"], row["payload_json"])
-            for row in rows
+            self._decode_envelope("inbox", row["message_id"], row["payload_json"]) for row in rows
         ]
 
     def outbox_messages(self) -> list[MessageEnvelope]:
@@ -1664,8 +2651,7 @@ class NodeStore:
             "SELECT message_id, payload_json FROM outbox ORDER BY created_at, message_id"
         ).fetchall()
         return [
-            self._decode_envelope("outbox", row["message_id"], row["payload_json"])
-            for row in rows
+            self._decode_envelope("outbox", row["message_id"], row["payload_json"]) for row in rows
         ]
 
     def causal_history(self, correlation_id: UUID) -> list[dict[str, Any]]:
@@ -1684,9 +2670,7 @@ class NodeStore:
         ).fetchall()
         return [dict(row) for row in rows]
 
-    def contract_history(
-        self, contract_id: UUID, contract_revision: int
-    ) -> dict[str, Any]:
+    def contract_history(self, contract_id: UUID, contract_revision: int) -> dict[str, Any]:
         journal = dict(self._journal_row(self._connection, contract_id, contract_revision))
         audit = self._connection.execute(
             """

--- a/python/src/deferred_teleop/two_button_fixture.py
+++ b/python/src/deferred_teleop/two_button_fixture.py
@@ -1,0 +1,913 @@
+"""Independent spatial two-button device fixture for M3a.
+
+The fixture owns the simulated collision truth and an append-only, fsynced
+device journal.  Services only see :class:`TwoButtonObservation` and level
+evidence; the policy never imports this module and therefore cannot inspect
+the hidden positions, collision radius, or counters.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+from deferred_teleop.external_effect import ExternalEffectObservation, ExternalOutcome
+from deferred_teleop.m3a_types import (
+    EntityDetection,
+    SpatialBindingReceipt,
+    SpatialPressCommand,
+    TwoButtonLevelEvidence,
+    TwoButtonObservation,
+    canonical_bytes,
+    canonical_digest,
+)
+from deferred_teleop.protocol import Pose, Quaternion, SpatialFrame, Vector3
+
+BUTTON_A = "A"
+BUTTON_B = "B"
+BUTTON_IDS = (BUTTON_A, BUTTON_B)
+
+
+class SpatialFixtureError(RuntimeError):
+    """Base error for malformed or inconsistent device-journal state."""
+
+
+class SpatialBindingConflictError(SpatialFixtureError, ValueError):
+    """An effect key was rebound to a different immutable command."""
+
+
+class FixtureScenario(StrEnum):
+    """Scenario setup is fixture-owned and never imported by the policy."""
+
+    S0_NOMINAL = "S0_NOMINAL"
+    S1_BOUNDARY = "S1_BOUNDARY"
+    S1_EPSILON = "S1_EPSILON"
+    S2_SWAP = "S2_SWAP"
+    S4_ALREADY_LATCHED = "S4_ALREADY_LATCHED"
+
+
+TwoButtonScenario = FixtureScenario
+
+
+class ButtonContact(StrEnum):
+    A = BUTTON_A
+    B = BUTTON_B
+    NONE = "NONE"
+
+
+def _utc_text(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise SpatialFixtureError("fixture timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_datetime(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise SpatialFixtureError(f"{field_name} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SpatialFixtureError(f"{field_name} is not an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SpatialFixtureError(f"{field_name} must be timezone-aware")
+    return parsed
+
+
+def _text(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SpatialFixtureError(f"{field_name} must be non-empty")
+    return value
+
+
+def _point(value: object, *, field_name: str) -> tuple[float, float, float]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
+        raise SpatialFixtureError(f"{field_name} must contain three finite numbers")
+    if len(value) != 3:
+        raise SpatialFixtureError(f"{field_name} must contain three finite numbers")
+    result = tuple(float(component) for component in value)
+    if not all(math.isfinite(component) for component in result):
+        raise SpatialFixtureError(f"{field_name} must contain three finite numbers")
+    return result
+
+
+def _distance(first: tuple[float, float, float], second: tuple[float, float, float]) -> float:
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(first, second, strict=True)))
+
+
+def _command_from_journal(record: Mapping[str, Any]) -> SpatialPressCommand:
+    command_json = record.get("command_bytes")
+    if not isinstance(command_json, str):
+        raise SpatialFixtureError("journal command_bytes must be a string")
+    try:
+        payload = json.loads(command_json)
+    except json.JSONDecodeError as error:
+        raise SpatialFixtureError("journal command_bytes is invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise SpatialFixtureError("journal command_bytes must encode an object")
+    try:
+        command = SpatialPressCommand(
+            command_id=payload["command_id"],
+            effect_key=payload["effect_key"],
+            position_m=payload["position_m"],
+            frame_id=payload["frame_id"],
+            calibration_version=payload["calibration_version"],
+            source_observation_id=payload["source_observation_id"],
+            source_detection_id=payload["source_detection_id"],
+            command_digest=record["command_digest"],
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise SpatialFixtureError("journal command is malformed") from error
+    if command.canonical_bytes().decode("utf-8") != command_json:
+        raise SpatialFixtureError("journal command_bytes are not canonical")
+    return command
+
+
+class _FixtureClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+
+class SpatialPressResult:
+    """Result of one physical fixture command, retained outside the journal."""
+
+    __slots__ = (
+        "press_id",
+        "effect_key",
+        "device_id",
+        "contact",
+        "a_counter",
+        "b_counter",
+        "a_latched",
+        "b_latched",
+        "pressed_at",
+        "command_digest",
+    )
+
+    def __init__(
+        self,
+        *,
+        press_id: str,
+        effect_key: str,
+        device_id: str,
+        contact: ButtonContact,
+        a_counter: int,
+        b_counter: int,
+        a_latched: bool,
+        b_latched: bool,
+        pressed_at: datetime,
+        command_digest: str,
+    ) -> None:
+        self.press_id = press_id
+        self.effect_key = effect_key
+        self.device_id = device_id
+        self.contact = contact
+        self.a_counter = a_counter
+        self.b_counter = b_counter
+        self.a_latched = a_latched
+        self.b_latched = b_latched
+        self.pressed_at = pressed_at
+        self.command_digest = command_digest
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:
+        return {
+            "press_id": self.press_id,
+            "effect_key": self.effect_key,
+            "device_id": self.device_id,
+            "contact": self.contact.value,
+            "a_counter": self.a_counter,
+            "b_counter": self.b_counter,
+            "a_latched": self.a_latched,
+            "b_latched": self.b_latched,
+            "pressed_at": _utc_text(self.pressed_at) if mode == "json" else self.pressed_at,
+            "command_digest": self.command_digest,
+        }
+
+
+class TwoButtonFixture:
+    """Hidden-position fixture with a durable command/binding journal.
+
+    ``press_at`` is the only method that resolves a point against collision
+    truth.  The public observation methods expose measured detections but do
+    not expose the private position mapping.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        scenario: FixtureScenario | str = FixtureScenario.S0_NOMINAL,
+        device_id: str = "two-button-device-1",
+        source_id: str = "two-button-observer-1",
+        frame_id: str = "field-world",
+        calibration_version: str = "two-button-cal-1",
+        max_displacement_m: float = 0.05,
+        collision_radius_m: float = 0.025,
+        clock: object | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.device_id = _text(device_id, field_name="device_id")
+        self.source_id = _text(source_id, field_name="source_id")
+        self.frame_id = _text(frame_id, field_name="frame_id")
+        self.calibration_version = _text(
+            calibration_version,
+            field_name="calibration_version",
+        )
+        try:
+            self.scenario = FixtureScenario(scenario)
+        except (TypeError, ValueError) as error:
+            raise ValueError("unknown two-button fixture scenario") from error
+        self.max_displacement_m = float(max_displacement_m)
+        self.collision_radius_m = float(collision_radius_m)
+        if not math.isfinite(self.max_displacement_m) or self.max_displacement_m < 0:
+            raise ValueError("max_displacement_m must be finite and >= 0")
+        if not math.isfinite(self.collision_radius_m) or self.collision_radius_m <= 0:
+            raise ValueError("collision_radius_m must be finite and > 0")
+        self._clock = clock or _FixtureClock()
+        self._reference_positions, self._current_positions = self._scenario_positions()
+        self._read_journal()  # fail loudly on malformed or corrupted evidence
+        if self.scenario is FixtureScenario.S4_ALREADY_LATCHED and not self.press_records:
+            self._seed_prior_impulse()
+
+    @classmethod
+    def for_scenario(
+        cls,
+        path: str | Path,
+        scenario: FixtureScenario | str,
+        **kwargs: Any,
+    ) -> TwoButtonFixture:
+        return cls(path, scenario=scenario, **kwargs)
+
+    @property
+    def journal_records(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self._read_journal())
+
+    @property
+    def records(self) -> tuple[dict[str, Any], ...]:
+        """Return physical press records, excluding immutable bind rows."""
+
+        return tuple(record for record in self._read_journal() if record["record_type"] == "press")
+
+    @property
+    def press_records(self) -> tuple[dict[str, Any], ...]:
+        return self.records
+
+    @property
+    def binding_records(self) -> tuple[dict[str, Any], ...]:
+        return tuple(
+            record for record in self._read_journal() if record["record_type"] == "binding"
+        )
+
+    @property
+    def press_count(self) -> int:
+        return len(self.records)
+
+    @property
+    def a_counter(self) -> int:
+        return int(self._state()[BUTTON_A]["counter"])
+
+    @property
+    def b_counter(self) -> int:
+        return int(self._state()[BUTTON_B]["counter"])
+
+    @property
+    def a_latched(self) -> bool:
+        return bool(self._state()[BUTTON_A]["latched"])
+
+    @property
+    def b_latched(self) -> bool:
+        return bool(self._state()[BUTTON_B]["latched"])
+
+    def reference_observation(
+        self,
+        *,
+        observation_id: str | None = None,
+        observed_at: datetime | None = None,
+        produced_at: datetime | None = None,
+        world_revision: int = 1,
+        source_id: str | None = None,
+        target_entity_id: str = BUTTON_A,
+    ) -> TwoButtonObservation:
+        """Emit the persisted authoring observation for one named button."""
+
+        return self._observation(
+            stage="reference",
+            observation_id=observation_id,
+            observed_at=observed_at,
+            produced_at=produced_at,
+            world_revision=world_revision,
+            source_id=source_id,
+            target_entity_id=target_entity_id,
+        )
+
+    def current_observation(
+        self,
+        *,
+        observation_id: str | None = None,
+        observed_at: datetime | None = None,
+        produced_at: datetime | None = None,
+        world_revision: int = 2,
+        source_id: str | None = None,
+        target_entity_id: str = BUTTON_A,
+    ) -> TwoButtonObservation:
+        """Emit the separately scheduled current observation for one button."""
+
+        return self._observation(
+            stage="current",
+            observation_id=observation_id,
+            observed_at=observed_at,
+            produced_at=produced_at,
+            world_revision=world_revision,
+            source_id=source_id,
+            target_entity_id=target_entity_id,
+        )
+
+    def observe(self, stage: str = "current", **kwargs: Any) -> TwoButtonObservation:
+        if stage == "reference":
+            return self.reference_observation(**kwargs)
+        if stage == "current":
+            return self.current_observation(**kwargs)
+        raise ValueError("observation stage must be reference or current")
+
+    def level_evidence(
+        self,
+        target_entity_id: str,
+        *,
+        observed_at: datetime | None = None,
+        evidence_observation_id: str | None = None,
+    ) -> TwoButtonLevelEvidence:
+        target = _text(target_entity_id, field_name="target_entity_id")
+        if target not in BUTTON_IDS:
+            raise ValueError(f"unknown two-button target {target}")
+        state = self._state()[target]
+        now = observed_at or self._now()
+        return TwoButtonLevelEvidence(
+            target_entity_id=target,
+            desired_latched=True,
+            actual_latched=bool(state["latched"]),
+            device_id=self.device_id,
+            counter=int(state["counter"]),
+            observed_at=now,
+            evidence_observation_id=evidence_observation_id
+            or f"level:{target}:{state['counter']}:{int(bool(state['latched']))}",
+        )
+
+    def level(self, target_entity_id: str, **kwargs: Any) -> TwoButtonLevelEvidence:
+        return self.level_evidence(target_entity_id, **kwargs)
+
+    def bind_command(
+        self,
+        effect_key: str,
+        command: SpatialPressCommand,
+    ) -> SpatialBindingReceipt:
+        """Persist an immutable effect-key to command binding before dispatch."""
+
+        effect = _text(effect_key, field_name="effect_key")
+        if not isinstance(command, SpatialPressCommand):
+            raise TypeError("command must be SpatialPressCommand")
+        if command.effect_key != effect:
+            raise SpatialBindingConflictError("binding effect_key must equal command effect_key")
+        self._assert_command_integrity(command)
+        existing = self._bindings().get(effect)
+        if existing is not None:
+            if existing.command_digest != command.command_digest:
+                raise SpatialBindingConflictError(
+                    f"effect_key {effect} is already bound to a different command"
+                )
+            if existing.canonical_bytes() != command.canonical_bytes():
+                raise SpatialBindingConflictError(
+                    f"effect_key {effect} is already bound to different command bytes"
+                )
+            return SpatialBindingReceipt(
+                device_id=self.device_id,
+                effect_key=effect,
+                command_digest=existing.command_digest,
+            )
+        record = {
+            "record_type": "binding",
+            "binding_id": str(uuid5(NAMESPACE_URL, f"dtt-m3a-binding:{self.device_id}:{effect}")),
+            "effect_key": effect,
+            "device_id": self.device_id,
+            "command_bytes": command.canonical_bytes().decode("utf-8"),
+            "command_bytes_b64": base64.b64encode(command.canonical_bytes()).decode("ascii"),
+            "command_digest": command.command_digest,
+            "bound_at": _utc_text(self._now()),
+        }
+        self._append_record(record)
+        return SpatialBindingReceipt(
+            device_id=self.device_id,
+            effect_key=effect,
+            command_digest=command.command_digest,
+        )
+
+    def bind(self, effect_key: str, command: SpatialPressCommand) -> SpatialBindingReceipt:
+        return self.bind_command(effect_key, command)
+
+    def bound_command(self, effect_key: str) -> SpatialPressCommand:
+        effect = _text(effect_key, field_name="effect_key")
+        binding = self._bindings().get(effect)
+        if binding is None:
+            raise SpatialFixtureError(f"no immutable command binding for {effect}")
+        return binding
+
+    def press_at(self, command: SpatialPressCommand) -> SpatialPressResult:
+        """Resolve and persist one physical press at the supplied point."""
+
+        if not isinstance(command, SpatialPressCommand):
+            raise TypeError("press_at accepts SpatialPressCommand only")
+        self._assert_command_integrity(command)
+        binding = self._bindings().get(command.effect_key)
+        if binding is None:
+            raise SpatialFixtureError(
+                f"effect_key {command.effect_key} has no persisted device binding"
+            )
+        if (
+            binding.command_digest != command.command_digest
+            or binding.canonical_bytes() != command.canonical_bytes()
+        ):
+            raise SpatialBindingConflictError(
+                f"effect_key {command.effect_key} is bound to different command bytes"
+            )
+        return self._press_at_internal(command)
+
+    def _press_at_internal(self, command: SpatialPressCommand) -> SpatialPressResult:
+        """Apply a command for fixture-owned setup before normal binding."""
+
+        contact = self._resolve_contact(
+            command.position_m,
+            frame_id=command.frame_id,
+            calibration_version=command.calibration_version,
+        )
+        state = self._state()
+        if contact in {ButtonContact.A, ButtonContact.B}:
+            state[contact.value]["counter"] += 1
+            state[contact.value]["latched"] = True
+        pressed_at = self._now()
+        press_id = str(uuid4())
+        command_bytes = command.canonical_bytes()
+        record = {
+            "record_type": "press",
+            "press_id": press_id,
+            "effect_key": command.effect_key,
+            "device_id": self.device_id,
+            "command_bytes": command_bytes.decode("utf-8"),
+            "command_bytes_b64": base64.b64encode(command_bytes).decode("ascii"),
+            "command_digest": command.command_digest,
+            "position_m": list(command.position_m),
+            "frame_id": command.frame_id,
+            "calibration_version": command.calibration_version,
+            "contact": contact.value,
+            "a_counter": state[BUTTON_A]["counter"],
+            "b_counter": state[BUTTON_B]["counter"],
+            "a_latched": state[BUTTON_A]["latched"],
+            "b_latched": state[BUTTON_B]["latched"],
+            "pressed_at": _utc_text(pressed_at),
+        }
+        self._append_record(record)
+        return SpatialPressResult(
+            press_id=press_id,
+            effect_key=command.effect_key,
+            device_id=self.device_id,
+            contact=contact,
+            a_counter=state[BUTTON_A]["counter"],
+            b_counter=state[BUTTON_B]["counter"],
+            a_latched=state[BUTTON_A]["latched"],
+            b_latched=state[BUTTON_B]["latched"],
+            pressed_at=pressed_at,
+            command_digest=command.command_digest,
+        )
+
+    def device_state(self) -> dict[str, dict[str, int | bool]]:
+        return self._state()
+
+    def _observation(
+        self,
+        *,
+        stage: str,
+        observation_id: str | None,
+        observed_at: datetime | None,
+        produced_at: datetime | None,
+        world_revision: int,
+        source_id: str | None,
+        target_entity_id: str,
+    ) -> TwoButtonObservation:
+        now = observed_at or self._now()
+        produced = produced_at or now
+        source = source_id or self.source_id
+        target = _text(target_entity_id, field_name="target_entity_id")
+        if target not in BUTTON_IDS:
+            raise ValueError(f"unknown two-button target {target}")
+        if stage == "reference":
+            positions = self._reference_positions
+            default_id = f"{self.scenario.value.lower()}:reference"
+            candidates = {target: (target,)}
+        else:
+            positions = self._current_positions
+            default_id = f"{self.scenario.value.lower()}:current"
+            candidates = (
+                {target: (BUTTON_A, BUTTON_B)}
+                if self.scenario is FixtureScenario.S2_SWAP
+                else {target: (target,)}
+            )
+        detections = tuple(
+            EntityDetection(
+                detection_id=f"detection-{entity.lower()}-{stage}",
+                candidate_entity_ids=candidates[entity],
+                pose=self._pose(positions[entity]),
+                visibility=True,
+                source_evidence_id=f"{source}:evidence:{stage}:{world_revision}",
+            )
+            for entity in (target,)
+        )
+        return TwoButtonObservation(
+            observation_id=observation_id or default_id,
+            source_id=source,
+            world_revision=world_revision,
+            observed_at=now,
+            produced_at=produced,
+            frame_id=self.frame_id,
+            calibration_version=self.calibration_version,
+            detections=detections,
+        )
+
+    def _pose(self, position: tuple[float, float, float]) -> Pose:
+        return Pose(
+            position=Vector3(x=position[0], y=position[1], z=position[2]),
+            orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+            frame=SpatialFrame(
+                frame_id=self.frame_id,
+                calibration_version=self.calibration_version,
+            ),
+        )
+
+    def _scenario_positions(
+        self,
+    ) -> tuple[dict[str, tuple[float, float, float]], dict[str, tuple[float, float, float]]]:
+        reference_a = (0.4, 0.1, 0.2)
+        reference_b = (0.6, 0.1, 0.2)
+        reference = {BUTTON_A: reference_a, BUTTON_B: reference_b}
+        current = dict(reference)
+        if self.scenario is FixtureScenario.S1_BOUNDARY:
+            current[BUTTON_A] = (
+                reference_a[0] + self.max_displacement_m,
+                reference_a[1],
+                reference_a[2],
+            )
+        elif self.scenario is FixtureScenario.S1_EPSILON:
+            current[BUTTON_A] = (
+                reference_a[0] + self.max_displacement_m + 1e-6,
+                reference_a[1],
+                reference_a[2],
+            )
+        elif self.scenario is FixtureScenario.S2_SWAP:
+            current[BUTTON_A] = (reference_a[0] + 0.2, reference_a[1], reference_a[2])
+            current[BUTTON_B] = reference_a
+        return reference, current
+
+    def _resolve_contact(
+        self,
+        position: tuple[float, float, float],
+        *,
+        frame_id: str,
+        calibration_version: str,
+    ) -> ButtonContact:
+        if frame_id != self.frame_id or calibration_version != self.calibration_version:
+            return ButtonContact.NONE
+        contacts = tuple(
+            entity
+            for entity, hidden_position in self._current_positions.items()
+            if _distance(position, hidden_position) <= self.collision_radius_m
+        )
+        return ButtonContact(contacts[0]) if len(contacts) == 1 else ButtonContact.NONE
+
+    def _assert_command_integrity(self, command: SpatialPressCommand) -> None:
+        if command.command_digest != canonical_digest(command._payload_without_digest()):
+            raise SpatialFixtureError("command digest does not match canonical command bytes")
+        if command.effect_key.strip() == "":
+            raise SpatialFixtureError("command effect_key must not be empty")
+
+    def _state(self) -> dict[str, dict[str, int | bool]]:
+        state: dict[str, dict[str, int | bool]] = {
+            BUTTON_A: {"counter": 0, "latched": False},
+            BUTTON_B: {"counter": 0, "latched": False},
+        }
+        for record in self.records:
+            contact = record["contact"]
+            if contact in BUTTON_IDS:
+                state[contact]["counter"] = int(state[contact]["counter"]) + 1
+                state[contact]["latched"] = True
+        return state
+
+    def _seed_prior_impulse(self) -> None:
+        command = SpatialPressCommand.from_pose(
+            command_id="seed-prior-a",
+            effect_key="unrelated:prior:a",
+            pose=self._pose(self._current_positions[BUTTON_A]),
+            source_observation_id="unrelated-prior-observation",
+            source_detection_id="unrelated-prior-detection",
+        )
+        self._press_at_internal(command)
+
+    def _bindings(self) -> dict[str, SpatialPressCommand]:
+        result: dict[str, SpatialPressCommand] = {}
+        for record in self.binding_records:
+            command = _command_from_journal(record)
+            effect = _text(record.get("effect_key"), field_name="effect_key")
+            if record.get("device_id") != self.device_id:
+                raise SpatialFixtureError("binding device identity differs from fixture")
+            if command.effect_key != effect:
+                raise SpatialFixtureError("binding effect_key differs from command")
+            prior = result.get(effect)
+            if prior is not None and prior.canonical_bytes() != command.canonical_bytes():
+                raise SpatialBindingConflictError(
+                    f"journal contains conflicting binding for {effect}"
+                )
+            result[effect] = command
+        return result
+
+    def _read_journal(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        seen_press_ids: set[str] = set()
+        with self.path.open(encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise SpatialFixtureError(
+                        f"invalid device journal JSON at line {line_number}"
+                    ) from error
+                if not isinstance(record, dict):
+                    raise SpatialFixtureError(f"device journal row {line_number} is not an object")
+                record_type = record.get("record_type")
+                if record_type not in {"binding", "press"}:
+                    raise SpatialFixtureError(
+                        f"unknown device journal record at line {line_number}"
+                    )
+                if record.get("device_id") != self.device_id:
+                    raise SpatialFixtureError(
+                        f"device journal device mismatch at line {line_number}"
+                    )
+                if record_type == "binding":
+                    self._validate_binding_record(record, line_number=line_number)
+                else:
+                    self._validate_press_record(record, line_number=line_number)
+                    press_id = record["press_id"]
+                    if press_id in seen_press_ids:
+                        raise SpatialFixtureError(f"duplicate press_id at line {line_number}")
+                    seen_press_ids.add(press_id)
+                records.append(record)
+        return records
+
+    def _validate_binding_record(self, record: Mapping[str, Any], *, line_number: int) -> None:
+        for field_name in (
+            "binding_id",
+            "effect_key",
+            "device_id",
+            "command_bytes",
+            "command_digest",
+            "bound_at",
+        ):
+            if field_name not in record:
+                raise SpatialFixtureError(f"binding row {line_number} is incomplete")
+        _text(record["binding_id"], field_name="binding_id")
+        _text(record["effect_key"], field_name="effect_key")
+        _parse_datetime(record["bound_at"], field_name="bound_at")
+        command = _command_from_journal(record)
+        if command.effect_key != record["effect_key"]:
+            raise SpatialFixtureError(f"binding row {line_number} effect mismatch")
+
+    def _validate_press_record(self, record: Mapping[str, Any], *, line_number: int) -> None:
+        required = {
+            "press_id",
+            "effect_key",
+            "device_id",
+            "command_bytes",
+            "command_digest",
+            "position_m",
+            "frame_id",
+            "calibration_version",
+            "contact",
+            "a_counter",
+            "b_counter",
+            "a_latched",
+            "b_latched",
+            "pressed_at",
+        }
+        if not required.issubset(record):
+            raise SpatialFixtureError(f"press row {line_number} is incomplete")
+        for field_name in (
+            "press_id",
+            "effect_key",
+            "device_id",
+            "frame_id",
+            "calibration_version",
+        ):
+            _text(record[field_name], field_name=field_name)
+        if record["contact"] not in {BUTTON_A, BUTTON_B, ButtonContact.NONE.value}:
+            raise SpatialFixtureError(f"press row {line_number} has invalid contact")
+        for field_name in ("a_counter", "b_counter"):
+            if (
+                isinstance(record[field_name], bool)
+                or not isinstance(record[field_name], int)
+                or record[field_name] < 0
+            ):
+                raise SpatialFixtureError(f"press row {line_number} has invalid counter")
+        for field_name in ("a_latched", "b_latched"):
+            if type(record[field_name]) is not bool:
+                raise SpatialFixtureError(f"press row {line_number} has invalid latch")
+        _parse_datetime(record["pressed_at"], field_name="pressed_at")
+        command = _command_from_journal(record)
+        if command.effect_key != record["effect_key"]:
+            raise SpatialFixtureError(f"press row {line_number} effect mismatch")
+        if list(command.position_m) != record["position_m"]:
+            raise SpatialFixtureError(f"press row {line_number} position mismatch")
+        if (
+            command.frame_id != record["frame_id"]
+            or command.calibration_version != record["calibration_version"]
+        ):
+            raise SpatialFixtureError(f"press row {line_number} context mismatch")
+
+    def _append_record(self, record: Mapping[str, Any]) -> None:
+        encoded = canonical_bytes(record).decode("utf-8")
+        with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(encoded)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        directory_flag = getattr(os, "O_DIRECTORY", None)
+        if directory_flag is None:
+            return
+        try:
+            directory_fd = os.open(self.path.parent, os.O_RDONLY | directory_flag)
+        except OSError:
+            return
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _now(self) -> datetime:
+        now = getattr(self._clock, "now", None)
+        if not callable(now):
+            raise ValueError("fixture clock must expose callable now()")
+        value = now()
+        if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("fixture clock must return timezone-aware datetime")
+        return value
+
+
+class SpatialExternalEffectAdapter:
+    """External adapter that dispatches only a previously bound command."""
+
+    def __init__(self, fixture: TwoButtonFixture) -> None:
+        if not isinstance(fixture, TwoButtonFixture):
+            raise TypeError("fixture must be TwoButtonFixture")
+        self.fixture = fixture
+        self.device_id = fixture.device_id
+
+    @property
+    def press_count(self) -> int:
+        return self.fixture.press_count
+
+    @property
+    def records(self) -> tuple[dict[str, Any], ...]:
+        return self.fixture.records
+
+    def bind(
+        self,
+        effect_key: str,
+        command: SpatialPressCommand,
+    ) -> SpatialBindingReceipt:
+        receipt = self.fixture.bind_command(effect_key, command)
+        if receipt.device_id != self.device_id or receipt.effect_key != effect_key:
+            raise SpatialFixtureError("device binding receipt is inconsistent")
+        if receipt.command_digest != command.command_digest:
+            raise SpatialBindingConflictError("device binding receipt digest differs from command")
+        return receipt
+
+    def binding(self, effect_key: str) -> SpatialBindingReceipt:
+        command = self.fixture.bound_command(effect_key)
+        return SpatialBindingReceipt(
+            device_id=self.device_id,
+            effect_key=effect_key,
+            command_digest=command.command_digest,
+        )
+
+    def level_evidence(
+        self,
+        target_entity_id: str,
+        *,
+        observed_at: datetime | None = None,
+        evidence_observation_id: str | None = None,
+    ) -> TwoButtonLevelEvidence:
+        """Read the independent level sensor without exposing fixture truth."""
+
+        return self.fixture.level_evidence(
+            target_entity_id,
+            observed_at=observed_at,
+            evidence_observation_id=evidence_observation_id,
+        )
+
+    def level(self, target_entity_id: str, **kwargs: Any) -> TwoButtonLevelEvidence:
+        return self.level_evidence(target_entity_id, **kwargs)
+
+    def press(self, effect_key: str) -> ExternalEffectObservation:
+        """Issue one bound command; there is no target-name or point argument."""
+
+        command = self.fixture.bound_command(effect_key)
+        result = self.fixture.press_at(command)
+        outcome = (
+            ExternalOutcome.APPLIED
+            if result.contact is not ButtonContact.NONE
+            else ExternalOutcome.NOT_APPLIED
+        )
+        return ExternalEffectObservation(
+            effect_key=effect_key,
+            device_id=self.device_id,
+            outcome=outcome,
+            observed_at=result.pressed_at,
+            observation_id=f"spatial:{result.press_id}",
+            details={
+                "fixture": "m3a-two-button-v1",
+                "command_digest": result.command_digest,
+                "contact": result.contact.value,
+                "a_counter": result.a_counter,
+                "b_counter": result.b_counter,
+                "a_latched": result.a_latched,
+                "b_latched": result.b_latched,
+            },
+        )
+
+    def observe(self, effect_key: str) -> ExternalEffectObservation:
+        _text(effect_key, field_name="effect_key")
+        matching = [record for record in self.fixture.records if record["effect_key"] == effect_key]
+        if not matching:
+            try:
+                bound_digest = self.fixture.bound_command(effect_key).command_digest
+            except SpatialFixtureError:
+                bound_digest = None
+            details: dict[str, Any] = {"fixture": "m3a-two-button-v1", "press_count_for_effect": 0}
+            if bound_digest is not None:
+                details["command_digest"] = bound_digest
+            return ExternalEffectObservation(
+                effect_key=effect_key,
+                device_id=self.device_id,
+                outcome=ExternalOutcome.NOT_APPLIED,
+                observed_at=self.fixture._now(),
+                observation_id=f"spatial:none:{effect_key}",
+                details=details,
+            )
+        record = matching[-1]
+        outcome = (
+            ExternalOutcome.APPLIED
+            if record["contact"] != ButtonContact.NONE.value
+            else ExternalOutcome.NOT_APPLIED
+        )
+        return ExternalEffectObservation(
+            effect_key=effect_key,
+            device_id=self.device_id,
+            outcome=outcome,
+            observed_at=_parse_datetime(record["pressed_at"], field_name="pressed_at"),
+            observation_id=f"spatial:{record['press_id']}",
+            details={
+                "fixture": "m3a-two-button-v1",
+                "command_digest": record["command_digest"],
+                "contact": record["contact"],
+                "a_counter": record["a_counter"],
+                "b_counter": record["b_counter"],
+                "a_latched": record["a_latched"],
+                "b_latched": record["b_latched"],
+                "press_count_for_effect": len(matching),
+            },
+        )
+
+
+PersistentSpatialTwoButtonFixture = TwoButtonFixture
+
+
+__all__ = [
+    "BUTTON_A",
+    "BUTTON_B",
+    "BUTTON_IDS",
+    "ButtonContact",
+    "FixtureScenario",
+    "PersistentSpatialTwoButtonFixture",
+    "SpatialBindingConflictError",
+    "SpatialExternalEffectAdapter",
+    "SpatialFixtureError",
+    "SpatialPressResult",
+    "TwoButtonFixture",
+    "TwoButtonScenario",
+]

--- a/python/src/deferred_teleop/two_button_policy.py
+++ b/python/src/deferred_teleop/two_button_policy.py
@@ -1,0 +1,444 @@
+"""Pure spatial policy for the M3a two-button slice.
+
+This module intentionally has no fixture import, scenario switch, position map,
+counter, or device access.  It receives only the persisted reference/current
+observations and optional independent level evidence.  Physical contact is
+decided by :mod:`deferred_teleop.two_button_fixture` after Robot has derived a
+command from the returned decision.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from deferred_teleop.m3a_types import (
+    EntityDetection,
+    LocalTwoButtonDecision,
+    M3aEnsureLatchedIntent,
+    SpatialPressCommand,
+    TwoButtonAction,
+    TwoButtonLevelEvidence,
+    TwoButtonObservation,
+    canonical_digest,
+)
+
+
+def _position(pose: Any) -> tuple[float, float, float]:
+    position = pose.position
+    return (float(position.x), float(position.y), float(position.z))
+
+
+def _distance(first: Any, second: Any) -> float:
+    left = _position(first)
+    right = _position(second)
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(left, right, strict=True)))
+
+
+def _same_instant(first: object, second: object) -> bool:
+    return first == second
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceVerification:
+    """Result of checking the exact persisted authoring observation."""
+
+    valid: bool
+    action: TwoButtonAction | None = None
+    reason: str = ""
+
+
+def _decision(
+    intent: M3aEnsureLatchedIntent,
+    current_observation: TwoButtonObservation,
+    *,
+    action: TwoButtonAction,
+    reason: str,
+    selected_detection_id: str | None = None,
+    displacement_m: float | None = None,
+    budget_state: str = "NOT_ADMITTED",
+    level_evidence: TwoButtonLevelEvidence | None = None,
+) -> LocalTwoButtonDecision:
+    return LocalTwoButtonDecision(
+        operation_id=intent.operation_id,
+        intent_revision=intent.intent_revision,
+        semantic_effect_id=intent.semantic_effect_id,
+        reference_observation_id=intent.reference_observation_id,
+        current_observation_id=current_observation.observation_id,
+        action=action,
+        reason=reason,
+        selected_detection_id=selected_detection_id,
+        displacement_m=displacement_m,
+        budget_state=budget_state,
+        level_evidence_observation_id=(
+            level_evidence.evidence_observation_id if level_evidence is not None else None
+        ),
+    )
+
+
+def _hold_reference(
+    intent: M3aEnsureLatchedIntent,
+    current_observation: TwoButtonObservation,
+    reason: str,
+    *,
+    level_evidence: TwoButtonLevelEvidence | None = None,
+) -> LocalTwoButtonDecision:
+    return _decision(
+        intent,
+        current_observation,
+        action=TwoButtonAction.HOLD_REFERENCE_MISMATCH,
+        reason=reason,
+        level_evidence=level_evidence,
+    )
+
+
+def _hold_context(
+    intent: M3aEnsureLatchedIntent,
+    current_observation: TwoButtonObservation,
+    reason: str,
+    *,
+    level_evidence: TwoButtonLevelEvidence | None = None,
+) -> LocalTwoButtonDecision:
+    return _decision(
+        intent,
+        current_observation,
+        action=TwoButtonAction.HOLD_CONTEXT_MISMATCH,
+        reason=reason,
+        level_evidence=level_evidence,
+    )
+
+
+def _hold_ambiguous(
+    intent: M3aEnsureLatchedIntent,
+    current_observation: TwoButtonObservation,
+    reason: str,
+    *,
+    level_evidence: TwoButtonLevelEvidence | None = None,
+    displacement_m: float | None = None,
+    budget_state: str = "NOT_ADMITTED",
+) -> LocalTwoButtonDecision:
+    return _decision(
+        intent,
+        current_observation,
+        action=TwoButtonAction.HOLD_AMBIGUOUS,
+        reason=reason,
+        displacement_m=displacement_m,
+        budget_state=budget_state,
+        level_evidence=level_evidence,
+    )
+
+
+def verify_reference(
+    intent: M3aEnsureLatchedIntent,
+    reference_observation: TwoButtonObservation,
+) -> ReferenceVerification:
+    """Check every reference field against the persisted observation.
+
+    A changed pose or payload under the same observation ID is a reference
+    mismatch.  Frame and calibration mismatches are context mismatches, so the
+    caller can surface those separately.  This function never accepts an
+    embedded pose by itself: the observation ID and its recomputed digest are
+    mandatory.
+    """
+
+    if reference_observation.observation_id != intent.reference_observation_id:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_OBSERVATION_ID_MISMATCH"
+        )
+    if reference_observation.canonical_payload_digest != canonical_digest(
+        reference_observation._payload_without_digest()
+    ):
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_OBSERVATION_DIGEST_INVALID"
+        )
+    if reference_observation.frame_id != intent.reference_frame_id:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_CONTEXT_MISMATCH, "REFERENCE_FRAME_MISMATCH"
+        )
+    if reference_observation.calibration_version != intent.reference_calibration_version:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_CONTEXT_MISMATCH, "REFERENCE_CALIBRATION_MISMATCH"
+        )
+    if reference_observation.canonical_payload_digest != intent.reference_digest:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_OBSERVATION_DIGEST_MISMATCH"
+        )
+    if reference_observation.world_revision != intent.reference_world_revision:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_WORLD_REVISION_MISMATCH"
+        )
+    if not _same_instant(reference_observation.observed_at, intent.reference_observed_at):
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_OBSERVED_AT_MISMATCH"
+        )
+
+    detections = tuple(
+        detection
+        for detection in reference_observation.detections
+        if detection.detection_id == intent.reference_detection_id
+    )
+    if len(detections) != 1:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_DETECTION_ID_MISMATCH"
+        )
+    detection = detections[0]
+    if detection.candidate_entity_ids != (intent.target_entity_id,):
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_AMBIGUOUS, "REFERENCE_DETECTION_AMBIGUOUS"
+        )
+    if detection.pose.frame.frame_id != intent.reference_frame_id:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_CONTEXT_MISMATCH, "REFERENCE_DETECTION_FRAME_MISMATCH"
+        )
+    if detection.pose.frame.calibration_version != intent.reference_calibration_version:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_CONTEXT_MISMATCH, "REFERENCE_DETECTION_CALIBRATION_MISMATCH"
+        )
+    if detection.pose != intent.reference_pose:
+        return ReferenceVerification(
+            False, TwoButtonAction.HOLD_REFERENCE_MISMATCH, "REFERENCE_POSE_MISMATCH"
+        )
+    return ReferenceVerification(True)
+
+
+def _verify_current_context(
+    intent: M3aEnsureLatchedIntent,
+    reference_observation: TwoButtonObservation,
+    current_observation: TwoButtonObservation,
+    *,
+    expected_source_id: str | None,
+) -> tuple[TwoButtonAction | None, str]:
+    if expected_source_id is not None and current_observation.source_id != expected_source_id:
+        return TwoButtonAction.HOLD_CONTEXT_MISMATCH, "CURRENT_SOURCE_MISMATCH"
+    if current_observation.source_id != reference_observation.source_id:
+        return TwoButtonAction.HOLD_CONTEXT_MISMATCH, "CURRENT_SOURCE_MISMATCH"
+    if current_observation.frame_id != intent.reference_frame_id:
+        return TwoButtonAction.HOLD_CONTEXT_MISMATCH, "CURRENT_FRAME_MISMATCH"
+    if current_observation.calibration_version != intent.reference_calibration_version:
+        return TwoButtonAction.HOLD_CONTEXT_MISMATCH, "CURRENT_CALIBRATION_MISMATCH"
+    if current_observation.canonical_payload_digest != canonical_digest(
+        current_observation._payload_without_digest()
+    ):
+        return TwoButtonAction.HOLD_CONTEXT_MISMATCH, "CURRENT_OBSERVATION_DIGEST_INVALID"
+    return None, ""
+
+
+def _matching_unique_detection(
+    observation: TwoButtonObservation,
+    target_entity_id: str,
+) -> tuple[EntityDetection | None, str | None]:
+    matching = tuple(
+        detection
+        for detection in observation.detections
+        if target_entity_id in detection.candidate_entity_ids
+    )
+    if not matching:
+        return None, "TARGET_ABSENT"
+    if len(matching) != 1:
+        return None, "TARGET_NONUNIQUE"
+    detection = matching[0]
+    if detection.candidate_entity_ids != (target_entity_id,):
+        return None, "TARGET_CANDIDATE_SET_AMBIGUOUS"
+    if not detection.visibility:
+        return None, "TARGET_NOT_VISIBLE"
+    return detection, None
+
+
+def decide_two_button(
+    intent: M3aEnsureLatchedIntent,
+    reference_observation: TwoButtonObservation,
+    current_observation: TwoButtonObservation,
+    level_evidence: TwoButtonLevelEvidence | None = None,
+    *,
+    expected_source_id: str | None = None,
+    expected_device_id: str | None = None,
+    budget_state: str = "NOT_ADMITTED",
+) -> LocalTwoButtonDecision:
+    """Return one deterministic action for the supplied immutable evidence.
+
+    The order is deliberate: exact authoring integrity and frame/calibration
+    context are checked before a level shortcut.  A trusted already-latched
+    level can therefore avoid spatial selection and all physical work, but it
+    cannot bypass a stale or mismatched reference contract.
+    """
+
+    reference_result = verify_reference(intent, reference_observation)
+    if not reference_result.valid:
+        if reference_result.action is TwoButtonAction.HOLD_CONTEXT_MISMATCH:
+            return _hold_context(
+                intent, current_observation, reference_result.reason, level_evidence=level_evidence
+            )
+        if reference_result.action is TwoButtonAction.HOLD_AMBIGUOUS:
+            return _hold_ambiguous(
+                intent, current_observation, reference_result.reason, level_evidence=level_evidence
+            )
+        return _hold_reference(
+            intent, current_observation, reference_result.reason, level_evidence=level_evidence
+        )
+
+    context_action, context_reason = _verify_current_context(
+        intent,
+        reference_observation,
+        current_observation,
+        expected_source_id=expected_source_id,
+    )
+    if context_action is not None:
+        return _decision(
+            intent,
+            current_observation,
+            action=context_action,
+            reason=context_reason,
+            budget_state=budget_state,
+            level_evidence=level_evidence,
+        )
+
+    if level_evidence is not None:
+        if level_evidence.target_entity_id != intent.target_entity_id:
+            return _hold_context(
+                intent, current_observation, "LEVEL_TARGET_MISMATCH", level_evidence=level_evidence
+            )
+        if expected_device_id is not None and level_evidence.device_id != expected_device_id:
+            return _hold_context(
+                intent, current_observation, "LEVEL_DEVICE_MISMATCH", level_evidence=level_evidence
+            )
+        if level_evidence.desired_latched is not True:
+            return _hold_reference(
+                intent,
+                current_observation,
+                "LEVEL_DESIRED_STATE_MISMATCH",
+                level_evidence=level_evidence,
+            )
+        if level_evidence.actual_latched:
+            return _decision(
+                intent,
+                current_observation,
+                action=TwoButtonAction.RECOGNIZE_EFFECT,
+                reason="ALREADY_LATCHED",
+                budget_state="ZERO_RESERVATION_REQUIRED",
+                level_evidence=level_evidence,
+            )
+
+    current_detection, ambiguity = _matching_unique_detection(
+        current_observation,
+        intent.target_entity_id,
+    )
+    if current_detection is None:
+        return _hold_ambiguous(
+            intent,
+            current_observation,
+            ambiguity or "TARGET_AMBIGUOUS",
+            budget_state=budget_state,
+            level_evidence=level_evidence,
+        )
+
+    reference_detection = next(
+        detection
+        for detection in reference_observation.detections
+        if detection.detection_id == intent.reference_detection_id
+    )
+    displacement = _distance(reference_detection.pose, current_detection.pose)
+    if displacement > intent.max_displacement_m:
+        return _hold_ambiguous(
+            intent,
+            current_observation,
+            "DISPLACEMENT_EXCEEDS_TOLERANCE",
+            displacement_m=displacement,
+            budget_state=budget_state,
+            level_evidence=level_evidence,
+        )
+    if displacement == 0.0:
+        action = TwoButtonAction.EXECUTE
+        reason = "REFERENCE_STILL_VALID"
+        selected_detection_id = reference_detection.detection_id
+    else:
+        action = TwoButtonAction.REANCHOR_EXECUTE
+        reason = "SAME_ID_REANCHORED"
+        selected_detection_id = current_detection.detection_id
+    return _decision(
+        intent,
+        current_observation,
+        action=action,
+        reason=reason,
+        selected_detection_id=selected_detection_id,
+        displacement_m=displacement,
+        budget_state=budget_state,
+        level_evidence=level_evidence,
+    )
+
+
+def derive_spatial_press_command(
+    decision: LocalTwoButtonDecision,
+    *,
+    effect_key: str,
+    command_id: str,
+    reference_observation: TwoButtonObservation,
+    current_observation: TwoButtonObservation,
+) -> SpatialPressCommand:
+    """Derive the immutable physical command from a prior policy decision."""
+
+    if decision.action not in {TwoButtonAction.EXECUTE, TwoButtonAction.REANCHOR_EXECUTE}:
+        raise ValueError("a hold or recognition decision cannot produce a press command")
+    if decision.selected_detection_id is None:
+        raise ValueError("execute decision has no selected detection")
+    source_observation = (
+        reference_observation if decision.action is TwoButtonAction.EXECUTE else current_observation
+    )
+    detections = tuple(
+        detection
+        for detection in source_observation.detections
+        if detection.detection_id == decision.selected_detection_id
+    )
+    if len(detections) != 1:
+        raise ValueError("selected detection is not present exactly once")
+    command = SpatialPressCommand.from_pose(
+        command_id=command_id,
+        effect_key=effect_key,
+        pose=detections[0].pose,
+        source_observation_id=source_observation.observation_id,
+        source_detection_id=detections[0].detection_id,
+    )
+    # Keep the decision useful as a durable audit record without mutating its
+    # frozen value.  Callers can persist the returned command digest alongside
+    # the original decision.
+    return command
+
+
+class TwoButtonPolicy:
+    """Stateless object façade for callers that prefer dependency injection."""
+
+    def decide(
+        self,
+        intent: M3aEnsureLatchedIntent,
+        reference_observation: TwoButtonObservation,
+        current_observation: TwoButtonObservation,
+        level_evidence: TwoButtonLevelEvidence | None = None,
+        *,
+        expected_source_id: str | None = None,
+        expected_device_id: str | None = None,
+        budget_state: str = "NOT_ADMITTED",
+    ) -> LocalTwoButtonDecision:
+        return decide_two_button(
+            intent,
+            reference_observation,
+            current_observation,
+            level_evidence,
+            expected_source_id=expected_source_id,
+            expected_device_id=expected_device_id,
+            budget_state=budget_state,
+        )
+
+
+decide = decide_two_button
+command_from_decision = derive_spatial_press_command
+
+
+__all__ = [
+    "ReferenceVerification",
+    "TwoButtonPolicy",
+    "command_from_decision",
+    "decide",
+    "decide_two_button",
+    "derive_spatial_press_command",
+    "verify_reference",
+]

--- a/tests/test_m3a_two_button.py
+++ b/tests/test_m3a_two_button.py
@@ -1,0 +1,1322 @@
+"""Focused M3a unit proofs for the pure policy and hidden spatial fixture."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from deferred_teleop.external_effect import ExternalEffectObservation
+from deferred_teleop.m3a_types import (
+    M3aEnsureLatchedIntent,
+    SpatialPressCommand,
+    TwoButtonAction,
+    TwoButtonObservation,
+)
+from deferred_teleop.protocol import (
+    ContractState,
+    ExecutionContract,
+    ExecutionEvent,
+    LocalTwoButtonDecision,
+    M3aSpatialExecutionContext,
+    MessageEnvelope,
+    Quaternion,
+    SpatialFrame,
+    TwoButtonEffectEvidence,
+    Vector3,
+)
+from deferred_teleop.protocol import (
+    M3aEnsureLatchedIntent as WireM3aEnsureLatchedIntent,
+)
+from deferred_teleop.protocol import (
+    SpatialPressCommand as WireSpatialPressCommand,
+)
+from deferred_teleop.runtime import (
+    EnvelopeFactory,
+    M3aFieldService,
+    M3aMissionService,
+    M3aRobotService,
+)
+from deferred_teleop.storage import BudgetDeadlineError, NodeStore
+from deferred_teleop.two_button_fixture import (
+    BUTTON_A,
+    BUTTON_B,
+    ButtonContact,
+    FixtureScenario,
+    SpatialBindingConflictError,
+    SpatialExternalEffectAdapter,
+    SpatialFixtureError,
+    TwoButtonFixture,
+)
+from deferred_teleop.two_button_policy import decide_two_button, derive_spatial_press_command
+
+NOW = datetime(2026, 9, 5, 0, 0, tzinfo=UTC)
+OPERATION_ID = UUID("30000000-0000-4000-8000-000000000001")
+
+
+class Clock:
+    def __init__(self, current: datetime = NOW) -> None:
+        self.current = current
+
+    def now(self) -> datetime:
+        return self.current
+
+    def advance(self, seconds: float) -> None:
+        self.current += timedelta(seconds=seconds)
+
+
+def _intent(
+    reference: TwoButtonObservation,
+    *,
+    operation_id: UUID = OPERATION_ID,
+    tolerance: float = 0.05,
+    target: str = BUTTON_A,
+) -> M3aEnsureLatchedIntent:
+    detection = reference.detections[0]
+    return M3aEnsureLatchedIntent(
+        operation_id=operation_id,
+        intent_revision=1,
+        semantic_effect_id="semantic-effect-1",
+        target_entity_id=target,
+        desired_latched=True,
+        reference_observation_id=reference.observation_id,
+        reference_detection_id=detection.detection_id,
+        reference_digest=reference.canonical_payload_digest,
+        reference_pose=detection.pose,
+        reference_frame_id=reference.frame_id,
+        reference_calibration_version=reference.calibration_version,
+        reference_world_revision=reference.world_revision,
+        reference_observed_at=reference.observed_at,
+        same_identity_only=True,
+        max_displacement_m=tolerance,
+        expires_at=NOW + timedelta(minutes=20),
+    )
+
+
+def test_nominal_policy_command_and_fsynced_binding_reopen(tmp_path: Path) -> None:
+    clock = Clock()
+    path = tmp_path / "spatial-device.jsonl"
+    fixture = TwoButtonFixture(path, clock=clock)
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    intent = _intent(reference)
+
+    decision = decide_two_button(intent, reference, current)
+    assert decision.action is TwoButtonAction.EXECUTE
+    assert decision.selected_detection_id == reference.detections[0].detection_id
+    command = derive_spatial_press_command(
+        decision,
+        effect_key="effect:nominal",
+        command_id="command:nominal",
+        reference_observation=reference,
+        current_observation=current,
+    )
+    adapter = SpatialExternalEffectAdapter(fixture)
+    receipt = adapter.bind(command.effect_key, command)
+    assert receipt.device_id == fixture.device_id
+    assert receipt.command_digest == command.command_digest
+    assert adapter.bind(command.effect_key, command) == receipt
+
+    proof = adapter.press(command.effect_key)
+    assert proof.outcome.value == "APPLIED"
+    assert proof.details["contact"] == BUTTON_A
+    assert fixture.a_counter == 1
+    assert fixture.b_counter == 0
+    assert fixture.a_latched is True
+    assert len(fixture.records) == 1
+    record = fixture.records[0]
+    assert record["command_digest"] == command.command_digest
+    assert record["command_bytes"] == command.canonical_bytes().decode("utf-8")
+    assert record["position_m"] == list(command.position_m)
+    assert record["contact"] == ButtonContact.A.value
+    assert record["a_counter"] == 1
+    assert record["b_counter"] == 0
+
+    reopened = TwoButtonFixture(path, clock=clock)
+    reopened_adapter = SpatialExternalEffectAdapter(reopened)
+    assert reopened.a_counter == 1
+    assert reopened.a_latched is True
+    assert reopened_adapter.binding(command.effect_key) == receipt
+    assert (
+        reopened_adapter.observe(command.effect_key).details["command_digest"]
+        == command.command_digest
+    )
+
+
+def test_boundary_reanchors_and_old_point_is_none_for_fixed_reference(tmp_path: Path) -> None:
+    clock = Clock()
+    fixture = TwoButtonFixture(
+        tmp_path / "boundary.jsonl",
+        scenario=FixtureScenario.S1_BOUNDARY,
+        clock=clock,
+    )
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    intent = _intent(reference, tolerance=fixture.max_displacement_m)
+    decision = decide_two_button(intent, reference, current)
+    assert decision.action is TwoButtonAction.REANCHOR_EXECUTE
+    assert decision.displacement_m == pytest.approx(fixture.max_displacement_m)
+
+    command = derive_spatial_press_command(
+        decision,
+        effect_key="effect:boundary",
+        command_id="command:boundary",
+        reference_observation=reference,
+        current_observation=current,
+    )
+    adapter = SpatialExternalEffectAdapter(fixture)
+    adapter.bind(command.effect_key, command)
+    assert adapter.press(command.effect_key).details["contact"] == BUTTON_A
+
+    baseline = SpatialPressCommand.from_pose(
+        command_id="command:fixed-reference",
+        effect_key="effect:fixed-reference",
+        pose=reference.detections[0].pose,
+        source_observation_id=reference.observation_id,
+        source_detection_id=reference.detections[0].detection_id,
+    )
+    adapter.bind(baseline.effect_key, baseline)
+    assert adapter.press(baseline.effect_key).details["contact"] == ButtonContact.NONE.value
+    assert fixture.a_counter == 1
+
+
+def test_tolerance_plus_epsilon_holds_without_device_activity(tmp_path: Path) -> None:
+    fixture = TwoButtonFixture(
+        tmp_path / "epsilon.jsonl",
+        scenario=FixtureScenario.S1_EPSILON,
+        clock=Clock(),
+    )
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    decision = decide_two_button(_intent(reference), reference, current)
+    assert decision.action is TwoButtonAction.HOLD_AMBIGUOUS
+    assert decision.reason == "DISPLACEMENT_EXCEEDS_TOLERANCE"
+    assert decision.displacement_m > fixture.max_displacement_m
+    assert fixture.press_count == 0
+    assert fixture.binding_records == ()
+
+
+def test_ambiguous_swap_holds_while_fixed_reference_hits_real_b(tmp_path: Path) -> None:
+    fixture = TwoButtonFixture(
+        tmp_path / "swap.jsonl",
+        scenario=FixtureScenario.S2_SWAP,
+        clock=Clock(),
+    )
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    decision = decide_two_button(_intent(reference), reference, current)
+    assert decision.action is TwoButtonAction.HOLD_AMBIGUOUS
+    assert decision.selected_detection_id is None
+
+    # The explicit controller ablation sends the stale authoring point.  The
+    # fixture resolves that point against hidden current truth, which is B.
+    baseline = SpatialPressCommand.from_pose(
+        command_id="command:fixed-reference",
+        effect_key="effect:fixed-reference",
+        pose=reference.detections[0].pose,
+        source_observation_id=reference.observation_id,
+        source_detection_id=reference.detections[0].detection_id,
+    )
+    adapter = SpatialExternalEffectAdapter(fixture)
+    adapter.bind(baseline.effect_key, baseline)
+    assert adapter.press(baseline.effect_key).details["contact"] == BUTTON_B
+    assert fixture.a_counter == 0
+    assert fixture.b_counter == 1
+
+
+def test_already_latched_is_pure_preacceptance_and_reopen_does_not_add_pulse(
+    tmp_path: Path,
+) -> None:
+    clock = Clock()
+    path = tmp_path / "already-latched.jsonl"
+    fixture = TwoButtonFixture(
+        path,
+        scenario=FixtureScenario.S4_ALREADY_LATCHED,
+        clock=clock,
+    )
+    assert fixture.a_counter == 1
+    assert fixture.a_latched is True
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    evidence = fixture.level_evidence(BUTTON_A, observed_at=NOW + timedelta(seconds=2))
+    decision = decide_two_button(_intent(reference), reference, current, evidence)
+    assert decision.action is TwoButtonAction.RECOGNIZE_EFFECT
+    assert decision.reason == "ALREADY_LATCHED"
+    assert decision.budget_state == "ZERO_RESERVATION_REQUIRED"
+    assert decision.selected_detection_id is None
+    assert fixture.press_count == 1
+    assert fixture.binding_records == ()
+
+    reopened = TwoButtonFixture(path, scenario=FixtureScenario.S4_ALREADY_LATCHED, clock=clock)
+    assert reopened.press_count == 1
+    assert reopened.a_counter == 1
+    assert reopened.level_evidence(BUTTON_A).actual_latched is True
+
+
+def test_reference_digest_pose_and_context_mismatches_are_holds(tmp_path: Path) -> None:
+    fixture = TwoButtonFixture(tmp_path / "integrity.jsonl", clock=Clock())
+    reference = fixture.reference_observation(observed_at=NOW)
+    current = fixture.current_observation(observed_at=NOW + timedelta(seconds=1))
+    intent = _intent(reference)
+
+    changed_pose = replace(
+        reference.detections[0],
+        pose=PoseFactory.make(
+            position=(0.41, 0.1, 0.2),
+            frame_id=reference.frame_id,
+            calibration_version=reference.calibration_version,
+        ),
+    )
+    changed_reference = replace(reference, detections=(changed_pose,), canonical_payload_digest="")
+    changed_decision = decide_two_button(intent, changed_reference, current)
+    assert changed_decision.action is TwoButtonAction.HOLD_REFERENCE_MISMATCH
+
+    context_pose = PoseFactory.make(
+        position=(0.4, 0.1, 0.2),
+        frame_id="other-frame",
+        calibration_version=reference.calibration_version,
+    )
+    context_reference = TwoButtonObservation(
+        observation_id=reference.observation_id,
+        source_id=reference.source_id,
+        world_revision=reference.world_revision,
+        observed_at=reference.observed_at,
+        produced_at=reference.produced_at,
+        frame_id="other-frame",
+        calibration_version=reference.calibration_version,
+        detections=(replace(reference.detections[0], pose=context_pose),),
+    )
+    context_decision = decide_two_button(intent, context_reference, current)
+    assert context_decision.action is TwoButtonAction.HOLD_CONTEXT_MISMATCH
+
+
+def test_binding_mismatch_is_rejected_and_policy_has_no_fixture_dependency(tmp_path: Path) -> None:
+    fixture = TwoButtonFixture(tmp_path / "binding.jsonl", clock=Clock())
+    reference = fixture.reference_observation(observed_at=NOW)
+    command = SpatialPressCommand.from_pose(
+        command_id="command:immutable",
+        effect_key="effect:immutable",
+        pose=reference.detections[0].pose,
+        source_observation_id=reference.observation_id,
+        source_detection_id=reference.detections[0].detection_id,
+    )
+    adapter = SpatialExternalEffectAdapter(fixture)
+    adapter.bind(command.effect_key, command)
+    changed = replace(
+        command,
+        position_m=(command.position_m[0] + 0.01, command.position_m[1], command.position_m[2]),
+        command_digest="",
+    )
+    with pytest.raises(SpatialBindingConflictError):
+        adapter.bind(command.effect_key, changed)
+    assert fixture.press_count == 0
+    assert len(fixture.binding_records) == 1
+
+
+def test_binding_key_mismatch_and_unbound_or_mutated_press_have_zero_pulses(
+    tmp_path: Path,
+) -> None:
+    fixture = TwoButtonFixture(tmp_path / "binding-guard.jsonl", clock=Clock())
+    reference = fixture.reference_observation(observed_at=NOW)
+    command = SpatialPressCommand.from_pose(
+        command_id="command:guard",
+        effect_key="effect:command-key",
+        pose=reference.detections[0].pose,
+        source_observation_id=reference.observation_id,
+        source_detection_id=reference.detections[0].detection_id,
+    )
+    adapter = SpatialExternalEffectAdapter(fixture)
+    with pytest.raises(SpatialBindingConflictError):
+        adapter.bind("effect:receipt-key", command)
+    assert fixture.binding_records == ()
+    with pytest.raises(SpatialFixtureError, match="no persisted device binding"):
+        fixture.press_at(command)
+    assert fixture.press_count == 0
+
+    adapter.bind(command.effect_key, command)
+    mutated = replace(
+        command,
+        position_m=(command.position_m[0] + 0.2, command.position_m[1], command.position_m[2]),
+        command_digest="",
+    )
+    with pytest.raises(SpatialBindingConflictError):
+        fixture.press_at(mutated)
+    assert fixture.press_count == 0
+
+
+def test_file_fsync_does_not_require_directory_fsync_constant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = TwoButtonFixture(tmp_path / "file-only-fsync.jsonl", clock=Clock())
+    reference = fixture.reference_observation(observed_at=NOW)
+    command = SpatialPressCommand.from_pose(
+        command_id="command:file-only",
+        effect_key="effect:file-only",
+        pose=reference.detections[0].pose,
+        source_observation_id=reference.observation_id,
+        source_detection_id=reference.detections[0].detection_id,
+    )
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    adapter = SpatialExternalEffectAdapter(fixture)
+    adapter.bind(command.effect_key, command)
+    adapter.press(command.effect_key)
+    reopened = TwoButtonFixture(fixture.path, clock=Clock())
+    assert reopened.a_counter == 1
+
+
+class PoseFactory:
+    @staticmethod
+    def make(
+        *,
+        position: tuple[float, float, float],
+        frame_id: str,
+        calibration_version: str,
+    ):
+        from deferred_teleop.protocol import Pose
+
+        return Pose(
+            position=Vector3(x=position[0], y=position[1], z=position[2]),
+            orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+            frame=SpatialFrame(
+                frame_id=frame_id,
+                calibration_version=calibration_version,
+            ),
+        )
+
+
+class M3aServiceHarness:
+    """Virtual-time Mission/Field/Robot/device harness for the five oracles."""
+
+    def __init__(self, data_dir: Path, scenario: FixtureScenario) -> None:
+        self.data_dir = data_dir
+        self.clock = Clock()
+        self.fixture = TwoButtonFixture(
+            data_dir / "device.jsonl",
+            scenario=scenario,
+            clock=self.clock,
+        )
+        self.mission_store = NodeStore(data_dir / "mission.sqlite3")
+        self.field_store = NodeStore(data_dir / "field.sqlite3")
+        self.robot_store = NodeStore(data_dir / "robot.sqlite3")
+        self.mission = M3aMissionService(
+            self.mission_store,
+            EnvelopeFactory("mission-1", self.clock),
+            configured_one_way_delay=1200.0,
+        )
+        self.field = M3aFieldService(
+            self.field_store,
+            EnvelopeFactory("field-1", self.clock),
+            m3a_device_id=self.fixture.device_id,
+        )
+        self.robot = M3aRobotService(
+            self.robot_store,
+            EnvelopeFactory("dummy-robot-1", self.clock),
+            external_effect_adapter=SpatialExternalEffectAdapter(self.fixture),
+            max_elapsed_seconds=60.0,
+        )
+        self.current_observation: TwoButtonObservation | None = None
+
+    def close(self) -> None:
+        self.robot_store.close()
+        self.field_store.close()
+        self.mission_store.close()
+
+    async def _deliver(
+        self,
+        source_store: NodeStore,
+        target: object,
+        envelope: MessageEnvelope,
+    ) -> bool:
+        if envelope.not_before is not None and self.clock.now() < envelope.not_before:
+            return False
+        target_store = target.store
+        is_new = target_store.receive(envelope, received_at=self.clock.now())
+        try:
+            source_store.acknowledge(envelope.message_id, acked_at=self.clock.now())
+        except KeyError:
+            # Direct duplicate/conflict injections are not necessarily rows in
+            # the source outbox; transport ACK handling is irrelevant to them.
+            pass
+        if is_new:
+            await target.handle(envelope)
+        return is_new
+
+    async def _route(self, source: object, target: object, destination: str) -> bool:
+        progressed = False
+        source_store = source.store
+        for envelope in list(source_store.pending_outbox(now=self.clock.now())):
+            if envelope.destination_id != destination:
+                continue
+            progressed = await self._deliver(source_store, target, envelope) or progressed
+        return progressed
+
+    async def record_local_current_observation(self) -> TwoButtonObservation:
+        """Acquire current truth locally at Field after the virtual transit."""
+
+        intent_message = next(
+            message
+            for message in self.mission_store.outbox_messages()
+            if isinstance(message.payload, WireM3aEnsureLatchedIntent)
+        )
+        intent = intent_message.payload
+        current = self.fixture.current_observation(
+            observed_at=self.clock.now(),
+            target_entity_id=intent.target_entity_id,
+        )
+        self.current_observation = current
+        envelope = self.field.record_m3a_current_observation(
+            current,
+            operation_id=intent.operation_id,
+            correlation_id=intent_message.correlation_id,
+        )
+        await self.field.handle(envelope)
+        return current
+
+    async def settle(self) -> None:
+        # Reference observation is available immediately; intent waits for the
+        # configured 1200-second Mission->Field transit.  Field acquires the
+        # current observation locally only after that delay.
+        assert await self._route(self.mission, self.field, "field-1")
+        assert self.clock.now() == NOW
+        self.clock.advance(1200.0)
+        await self.record_local_current_observation()
+        for _ in range(32):
+            progressed = False
+            for source, target, destination in (
+                (self.mission, self.field, "field-1"),
+                (self.field, self.robot, "dummy-robot-1"),
+                (self.robot, self.field, "field-1"),
+                (self.field, self.mission, "mission-1"),
+            ):
+                progressed = await self._route(source, target, destination) or progressed
+            if not progressed:
+                return
+        raise AssertionError("M3a virtual service harness did not converge")
+
+
+def _run(coroutine: object) -> object:
+    return asyncio.run(coroutine)
+
+
+def _m3a_messages(store: NodeStore, message_type: type) -> list[MessageEnvelope]:
+    return [
+        message
+        for message in store.inbox_messages() + store.outbox_messages()
+        if isinstance(message.payload, message_type)
+    ]
+
+
+def test_m3a_services_nominal_transit_budget_contact_and_reopen(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            intent = harness.mission.submit_ensure_button_latched(
+                reference,
+                max_displacement_m=harness.fixture.max_displacement_m,
+            )
+            assert intent.not_before == NOW + timedelta(seconds=1200)
+            await harness.settle()
+
+            contexts = _m3a_messages(harness.robot_store, M3aSpatialExecutionContext)
+            assert len(contexts) == 1
+            context = contexts[0].payload
+            assert context.reference_observation_id == reference.observation_id
+            assert context.reference_digest == reference.canonical_payload_digest
+            assert context.current_observation_envelope_id
+            assert harness.current_observation is not None
+            assert harness.current_observation.observed_at == NOW + timedelta(seconds=1200)
+            decisions = _m3a_messages(harness.robot_store, LocalTwoButtonDecision)
+            assert len(decisions) == 1
+            decision = decisions[0].payload
+            assert decision.action.value == "EXECUTE"
+            assert decision.current_observation_id == harness.current_observation.observation_id
+            assert decision.command_digest
+            assert len(harness.fixture.records) == 1
+            assert harness.fixture.records[0]["contact"] == BUTTON_A
+            assert harness.fixture.a_counter == 1
+            assert harness.fixture.b_counter == 0
+            journal = harness.robot_store.inspect_execution_journal()
+            budget = harness.robot_store.inspect_autonomy_budget()
+            assert len(journal) == len(budget) == 1
+            assert journal[0]["state"] == ContractState.SUCCEEDED.value
+            assert journal[0]["effect_count"] == 0
+            assert budget[0]["actions_reserved"] == 1
+            assert budget[0]["command_digest"] == decision.command_digest
+            view = harness.mission.m3a_view()
+            assert view["message_type"] == "m3a.view"
+            assert view["current_observation"]["observation_id"] == (
+                harness.current_observation.observation_id
+            )
+            assert view["current_observation"]["observed_at"] == (
+                NOW + timedelta(seconds=1200)
+            ).isoformat().replace("+00:00", "Z")
+            assert view["business_result"] == "APPLIED"
+            assert view["physical_contact"] == BUTTON_A
+            assert view["a_counter"] == 1
+            assert view["b_counter"] == 0
+            assert view["a_latched"] is True
+            assert view["b_latched"] is False
+            assert view["effect_evidence"]["semantic_goal_attained"] is True
+            effect_rows = _m3a_messages(harness.robot_store, TwoButtonEffectEvidence)
+            assert len(effect_rows) == 1
+            assert effect_rows[0].payload.physical_contact == BUTTON_A
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 1
+            assert len(harness.mission_store.inspect_m3a_effect_diagnostics()) == 0
+
+            # Reopen both the SQLite Robot store and the independent device,
+            # then deliver a new transport envelope for the exact contract.
+            contract_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            contract = contract_message.payload
+            harness.robot_store.close()
+            harness.robot_store = NodeStore(tmp_path / "robot.sqlite3")
+            reopened_fixture = TwoButtonFixture(
+                tmp_path / "device.jsonl", clock=harness.clock
+            )
+            harness.robot = M3aRobotService(
+                harness.robot_store,
+                EnvelopeFactory("dummy-robot-1", harness.clock),
+                external_effect_adapter=SpatialExternalEffectAdapter(reopened_fixture),
+                max_elapsed_seconds=60.0,
+            )
+            assert len(_m3a_messages(harness.robot_store, TwoButtonEffectEvidence)) == 1
+            duplicate = harness.field.factory.make(
+                "execution.contract",
+                "dummy-robot-1",
+                contract_message.correlation_id,
+                contract,
+                causation_id=contract_message.causation_id,
+                created_at=harness.clock.now(),
+            )
+            await harness._deliver(harness.field_store, harness.robot, duplicate)
+            assert reopened_fixture.press_count == 1
+            assert harness.robot_store.inspect_autonomy_budget()[0]["actions_reserved"] == 1
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_services_target_b_derives_expected_contact_from_context(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(
+                observed_at=NOW,
+                target_entity_id=BUTTON_B,
+            )
+            harness.mission.submit_ensure_button_latched(
+                reference,
+                target_entity_id=BUTTON_B,
+                semantic_effect_id="ensure-latched:B",
+            )
+            await harness.settle()
+            decision = _m3a_messages(harness.robot_store, LocalTwoButtonDecision)[0].payload
+            assert decision.action.value == "EXECUTE"
+            assert harness.fixture.a_counter == 0
+            assert harness.fixture.b_counter == 1
+            assert harness.fixture.records[0]["contact"] == BUTTON_B
+            assert len(harness.robot_store.inspect_autonomy_budget()) == 1
+            view = harness.mission.m3a_view()
+            assert view["business_result"] == "APPLIED"
+            assert view["physical_contact"] == BUTTON_B
+            assert view["a_counter"] == 0
+            assert view["b_counter"] == 1
+            assert view["a_latched"] is False
+            assert view["b_latched"] is True
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_mission_effect_waits_for_terminal_before_binding(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(reference)
+            assert await harness._route(harness.mission, harness.field, "field-1")
+            harness.clock.advance(1200.0)
+            await harness.record_local_current_observation()
+            assert await harness._route(harness.mission, harness.field, "field-1")
+            assert await harness._route(harness.field, harness.robot, "dummy-robot-1")
+            assert await harness._route(harness.robot, harness.field, "field-1")
+
+            pending = [
+                message
+                for message in harness.field_store.pending_outbox(now=harness.clock.now())
+                if message.destination_id == "mission-1"
+            ]
+            effect = next(
+                message
+                for message in pending
+                if isinstance(message.payload, TwoButtonEffectEvidence)
+            )
+            terminal = next(
+                message
+                for message in pending
+                if isinstance(message.payload, ExecutionEvent)
+                and message.payload.next_state in {ContractState.SUCCEEDED, ContractState.HELD}
+            )
+            for message in pending:
+                if message.message_id in {effect.message_id, terminal.message_id}:
+                    continue
+                await harness._deliver(harness.field_store, harness.mission, message)
+
+            assert await harness._deliver(harness.field_store, harness.mission, effect)
+            effect_row = next(
+                row
+                for row in harness.mission_store.inspect_inbox()
+                if row["message_id"] == str(effect.message_id)
+            )
+            assert effect_row["processing_state"] == "FAILED"
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 0
+            assert harness.mission.m3a_view()["effect_evidence"] is None
+
+            assert await harness._deliver(harness.field_store, harness.mission, terminal)
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 1
+            assert harness.mission.m3a_view()["business_result"] == "APPLIED"
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+@pytest.mark.parametrize("digest_mode", ["missing", "mismatch"])
+def test_m3a_unverified_adapter_digest_closes_unknown_and_replays_without_press(
+    tmp_path: Path,
+    digest_mode: str,
+) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(reference)
+            adapter = harness.robot.external_effect_adapter
+            assert isinstance(adapter, SpatialExternalEffectAdapter)
+            original_observe = adapter.observe
+
+            def unverified_observe(effect_key: str) -> ExternalEffectObservation:
+                observed = original_observe(effect_key)
+                details = dict(observed.details)
+                if digest_mode == "missing":
+                    details.pop("command_digest", None)
+                else:
+                    details["command_digest"] = "sha256:" + "0" * 64
+                return ExternalEffectObservation(
+                    effect_key=observed.effect_key,
+                    device_id=observed.device_id,
+                    outcome=observed.outcome,
+                    observed_at=observed.observed_at,
+                    observation_id=observed.observation_id,
+                    details=details,
+                )
+
+            adapter.observe = unverified_observe  # type: ignore[method-assign]
+            await harness.settle()
+            assert harness.fixture.press_count == 1
+            assert len(harness.fixture.binding_records) == 1
+            assert len(harness.robot_store.inspect_autonomy_budget()) == 1
+            assert harness.robot_store.inspect_autonomy_budget()[0]["actions_reserved"] == 1
+            journal = harness.robot_store.inspect_execution_journal()[0]
+            assert journal["state"] == ContractState.HELD.value
+            effect = _m3a_messages(harness.robot_store, TwoButtonEffectEvidence)[0].payload
+            assert effect.outcome == "UNKNOWN"
+            assert effect.command_digest_verified is False
+            assert effect.command_digest_diagnostic == (
+                "M3A_COMMAND_DIGEST_MISSING"
+                if digest_mode == "missing"
+                else "M3A_COMMAND_DIGEST_MISMATCH"
+            )
+            assert effect.physical_contact is None
+            assert effect.a_counter is None
+            assert effect.b_counter is None
+            assert effect.a_latched is None
+            assert effect.b_latched is None
+            view = harness.mission.m3a_view()
+            assert view["business_result"] == "OUTCOME_UNKNOWN"
+            assert view["physical_contact"] is None
+            assert view["a_counter"] is None
+            assert view["b_counter"] is None
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 0
+            assert len(harness.mission_store.inspect_m3a_effect_diagnostics()) == 1
+
+            contract_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            contract = contract_message.payload
+            harness.robot_store.close()
+            harness.robot_store = NodeStore(tmp_path / "robot.sqlite3")
+            reopened_fixture = TwoButtonFixture(
+                tmp_path / "device.jsonl", clock=harness.clock
+            )
+            harness.robot = M3aRobotService(
+                harness.robot_store,
+                EnvelopeFactory("dummy-robot-1", harness.clock),
+                external_effect_adapter=SpatialExternalEffectAdapter(reopened_fixture),
+                max_elapsed_seconds=60.0,
+            )
+            duplicate = harness.field.factory.make(
+                "execution.contract",
+                "dummy-robot-1",
+                contract_message.correlation_id,
+                contract,
+                causation_id=contract_message.causation_id,
+                created_at=harness.clock.now(),
+            )
+            await harness._deliver(harness.field_store, harness.robot, duplicate)
+            assert reopened_fixture.press_count == 1
+            assert harness.robot_store.inspect_execution_journal()[0]["state"] == (
+                ContractState.HELD.value
+            )
+            harness.mission_store.close()
+            harness.mission_store = NodeStore(tmp_path / "mission.sqlite3")
+            harness.mission = M3aMissionService(
+                harness.mission_store,
+                EnvelopeFactory("mission-1", harness.clock),
+                configured_one_way_delay=1200.0,
+            )
+            assert harness.mission.m3a_view() == view
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 0
+            assert len(harness.mission_store.inspect_m3a_effect_diagnostics()) == 1
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_effect_proof_mutations_cannot_replace_last_valid_view(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(reference)
+            await harness.settle()
+            valid_view = harness.mission.m3a_view()
+            valid_effect_message = _m3a_messages(
+                harness.robot_store, TwoButtonEffectEvidence
+            )[0]
+            valid_effect = valid_effect_message.payload
+            assert valid_view["physical_contact"] == BUTTON_A
+
+            mutations = (
+                valid_effect.model_copy(
+                    update={
+                        "contract_id": UUID(int=(valid_effect.contract_id.int + 1) % (1 << 128))
+                    }
+                ),
+                valid_effect.model_copy(
+                    update={"command_digest": "sha256:" + "0" * 64}
+                ),
+                valid_effect.model_copy(
+                    update={"effect_key": f"press:{valid_effect.operation_id}:99"}
+                ),
+                valid_effect.model_copy(update={"target_entity_id": BUTTON_B}),
+                valid_effect.model_copy(update={"device_id": "other-device"}),
+                valid_effect.model_copy(update={"a_counter": 999}),
+                valid_effect.model_copy(update={"observation_id": "forged-observation"}),
+                valid_effect.model_copy(
+                    update={
+                        "outcome": "UNKNOWN",
+                        "command_digest_verified": False,
+                        "command_digest_diagnostic": "digest-mismatch",
+                        "physical_contact": None,
+                        "command_executed": None,
+                        "semantic_goal_attained": None,
+                        "a_counter": None,
+                        "b_counter": None,
+                        "a_latched": None,
+                        "b_latched": None,
+                    }
+                ),
+            )
+            for mutation in mutations:
+                forged = harness.robot.factory.make(
+                    "m3a.spatial.effect",
+                    "field-1",
+                    valid_effect_message.correlation_id,
+                    mutation,
+                    source_id="dummy-robot-1",
+                    causation_id=valid_effect_message.causation_id,
+                )
+                assert await harness._deliver(harness.robot_store, harness.field, forged)
+
+            wrong_source = harness.robot.factory.make(
+                "m3a.spatial.effect",
+                "field-1",
+                valid_effect_message.correlation_id,
+                valid_effect,
+                source_id="unexpected-robot",
+                causation_id=valid_effect_message.causation_id,
+            )
+            assert await harness._deliver(harness.robot_store, harness.field, wrong_source)
+            # Rejected proofs remain durably auditable in Field's inbox, while
+            # only the canonical proof is forwarded to Mission.
+            assert sum(
+                isinstance(message.payload, TwoButtonEffectEvidence)
+                for message in harness.field_store.outbox_messages()
+            ) == 1
+            assert len(harness.field_store.inspect_m3a_effect_bindings()) == 1
+            assert len(harness.field_store.inspect_m3a_effect_conflicts()) >= 2
+
+            duplicate_robot = harness.robot.factory.make(
+                "m3a.spatial.effect",
+                "field-1",
+                valid_effect_message.correlation_id,
+                valid_effect,
+                source_id="dummy-robot-1",
+                causation_id=valid_effect_message.causation_id,
+                created_at=harness.clock.now(),
+            )
+            assert await harness._deliver(
+                harness.robot_store,
+                harness.field,
+                duplicate_robot,
+            )
+            assert await harness._route(harness.field, harness.mission, "mission-1")
+            assert harness.mission.m3a_view() == valid_view
+
+            # Mission validates direct effect messages and preserves the
+            # canonical proof.
+            bypass = harness.field.factory.make(
+                "m3a.spatial.effect",
+                "mission-1",
+                valid_effect_message.correlation_id,
+                valid_effect.model_copy(update={"target_entity_id": BUTTON_B}),
+                source_id="field-1",
+                causation_id=valid_effect_message.causation_id,
+            )
+            assert await harness._deliver(harness.field_store, harness.mission, bypass)
+            assert harness.mission.m3a_view() == valid_view
+
+            device_bypass = harness.field.factory.make(
+                "m3a.spatial.effect",
+                "mission-1",
+                valid_effect_message.correlation_id,
+                valid_effect.model_copy(update={"device_id": "other-device"}),
+                source_id="field-1",
+                causation_id=valid_effect_message.causation_id,
+            )
+            assert await harness._deliver(harness.field_store, harness.mission, device_bypass)
+            assert harness.mission.m3a_view() == valid_view
+
+            for mutation in (
+                valid_effect.model_copy(update={"a_counter": 999}),
+                valid_effect.model_copy(update={"observation_id": "forged-observation"}),
+                valid_effect.model_copy(
+                    update={
+                        "outcome": "UNKNOWN",
+                        "command_digest_verified": False,
+                        "command_digest_diagnostic": "digest-mismatch",
+                        "physical_contact": None,
+                        "command_executed": None,
+                        "semantic_goal_attained": None,
+                        "a_counter": None,
+                        "b_counter": None,
+                        "a_latched": None,
+                        "b_latched": None,
+                    }
+                ),
+            ):
+                direct_mutation = harness.field.factory.make(
+                    "m3a.spatial.effect",
+                    "mission-1",
+                    valid_effect_message.correlation_id,
+                    mutation,
+                    source_id="field-1",
+                    causation_id=valid_effect_message.causation_id,
+                )
+                assert await harness._deliver(
+                    harness.field_store,
+                    harness.mission,
+                    direct_mutation,
+                )
+                assert harness.mission.m3a_view() == valid_view
+
+            duplicate = harness.field.factory.make(
+                "m3a.spatial.effect",
+                "mission-1",
+                valid_effect_message.correlation_id,
+                valid_effect,
+                source_id="field-1",
+                causation_id=valid_effect_message.causation_id,
+                created_at=harness.clock.now(),
+            )
+            assert await harness._deliver(harness.field_store, harness.mission, duplicate)
+            assert harness.mission.m3a_view() == valid_view
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 1
+            assert len(harness.mission_store.inspect_m3a_effect_conflicts()) >= 3
+
+            canonical_context_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, M3aSpatialExecutionContext)
+                and message.destination_id == "mission-1"
+            )
+            contradictory_context = harness.field.factory.make(
+                "m3a.spatial.context",
+                "mission-1",
+                canonical_context_message.correlation_id,
+                canonical_context_message.payload.model_copy(
+                    update={"expected_device_id": "other-device"}
+                ),
+                source_id="field-1",
+                causation_id=canonical_context_message.message_id,
+            )
+            assert await harness._deliver(
+                harness.field_store,
+                harness.mission,
+                contradictory_context,
+            )
+            assert harness.mission.m3a_view() == valid_view
+
+            harness.mission_store.close()
+            harness.mission_store = NodeStore(tmp_path / "mission.sqlite3")
+            harness.mission = M3aMissionService(
+                harness.mission_store,
+                EnvelopeFactory("mission-1", harness.clock),
+                configured_one_way_delay=1200.0,
+            )
+            assert harness.mission.m3a_view() == valid_view
+            assert len(harness.mission_store.inspect_m3a_effect_bindings()) == 1
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_context_substitution_is_held_before_bind_and_budget(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(
+                reference,
+            )
+            assert await harness._route(harness.mission, harness.field, "field-1")
+            harness.clock.advance(1200.0)
+            await harness.record_local_current_observation()
+            assert await harness._route(harness.mission, harness.field, "field-1")
+            assignment_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if message.message_type == "task.assignment"
+            )
+            contract_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            context_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, M3aSpatialExecutionContext)
+            )
+            await harness._deliver(harness.field_store, harness.robot, assignment_message)
+            await harness._deliver(harness.field_store, harness.robot, context_message)
+            substituted = harness.field.factory.make(
+                "m3a.spatial.context",
+                "dummy-robot-1",
+                context_message.correlation_id,
+                context_message.payload.model_copy(update={"target_entity_id": BUTTON_B}),
+                causation_id=context_message.message_id,
+                created_at=harness.clock.now(),
+            )
+            await harness._deliver(harness.field_store, harness.robot, substituted)
+            await harness._deliver(harness.field_store, harness.robot, contract_message)
+
+            binding = harness.robot_store.find_m3a_context_binding(
+                contract_message.payload.contract_id,
+                contract_message.payload.contract_revision,
+            )
+            assert binding is not None
+            assert len(harness.robot_store.inspect_m3a_context_conflicts()) == 1
+            assert harness.robot_store.inspect_execution_journal() == []
+            assert harness.robot_store.inspect_autonomy_budget() == []
+            assert harness.robot_store.inspect_m3a_decisions()[0]["business_result"] == (
+                "HELD_CONTEXT_PAYLOAD_MISMATCH"
+            )
+            decision = _m3a_messages(harness.robot_store, LocalTwoButtonDecision)[0].payload
+            assert decision.action.value == "HOLD_CONTEXT_MISMATCH"
+            assert harness.fixture.press_count == 0
+            assert harness.fixture.binding_records == ()
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_decision_command_outbox_is_atomic_across_crash_reopen(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(
+                reference,
+            )
+
+            async def crash_before_external_dispatch(*_args: object, **_kwargs: object) -> None:
+                raise RuntimeError("crash after decision transaction")
+
+            harness.robot._process_external_contract = crash_before_external_dispatch  # type: ignore[method-assign]
+            with pytest.raises(RuntimeError, match="decision transaction"):
+                await harness.settle()
+            contract_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            assert harness.fixture.press_count == 0
+            assert len(harness.fixture.binding_records) == 1
+            journal = harness.robot_store.find_execution_journal(
+                contract_message.payload.contract_id,
+                contract_message.payload.contract_revision,
+            )
+            assert journal is not None
+            assert journal["state"] == ContractState.DISPATCH_RECORDED.value
+            decision_row = harness.robot_store.inspect_m3a_decisions()[0]
+            assert decision_row["command_envelope_json"] is not None
+            command_messages = _m3a_messages(harness.robot_store, WireSpatialPressCommand)
+            assert len(command_messages) == 1
+
+            harness.robot_store.close()
+            harness.robot_store = NodeStore(tmp_path / "robot.sqlite3")
+            reopened_fixture = TwoButtonFixture(tmp_path / "device.jsonl", clock=harness.clock)
+            harness.robot = M3aRobotService(
+                harness.robot_store,
+                EnvelopeFactory("dummy-robot-1", harness.clock),
+                external_effect_adapter=SpatialExternalEffectAdapter(reopened_fixture),
+                max_elapsed_seconds=60.0,
+            )
+            assert await harness.robot.recover() == 1
+            # Reservation is the M1.8c dispatch boundary.  After a crash at
+            # this frontier recovery observes the device and never presses a
+            # second time when no physical pulse was recorded.
+            assert reopened_fixture.press_count == 0
+            assert harness.robot_store.find_execution_journal(
+                contract_message.payload.contract_id,
+                contract_message.payload.contract_revision,
+            )["state"] == ContractState.HELD.value
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_budget_refusal_closes_accepted_journal_with_coherent_hold(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(
+                reference,
+            )
+
+            def reject_reservation(*_args: object, **_kwargs: object) -> bool:
+                raise BudgetDeadlineError("BUDGET_DEADLINE_EXPIRED: injected oracle")
+
+            harness.robot.store.reserve_external_dispatch_with_budget = reject_reservation  # type: ignore[method-assign]
+            await harness.settle()
+            contract_message = next(
+                message
+                for message in harness.field_store.outbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            journal = harness.robot_store.find_execution_journal(
+                contract_message.payload.contract_id,
+                contract_message.payload.contract_revision,
+            )
+            assert journal is not None
+            assert journal["state"] == ContractState.HELD.value
+            assert journal["dispatch_recorded_at"] is None
+            assert harness.robot_store.inspect_autonomy_budget()[0]["actions_reserved"] == 0
+            assert harness.robot_store.inspect_autonomy_budget()[0]["resolution"] == (
+                "HELD_BUDGET_RESERVATION_REJECTED"
+            )
+            held = [
+                message.payload
+                for message in harness.robot_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+                and message.payload.next_state is ContractState.HELD
+            ]
+            assert len(held) == 1
+            assert held[0].previous_state is ContractState.ACCEPTED
+            assert harness.fixture.press_count == 0
+            assert len(harness.fixture.binding_records) == 1
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_action", "expected_contact", "expected_press"),
+    [
+        (
+            FixtureScenario.S1_BOUNDARY,
+            "REANCHOR_EXECUTE",
+            BUTTON_A,
+            1,
+        ),
+        (
+            FixtureScenario.S1_EPSILON,
+            "HOLD_AMBIGUOUS",
+            None,
+            0,
+        ),
+        (
+            FixtureScenario.S2_SWAP,
+            "HOLD_AMBIGUOUS",
+            None,
+            0,
+        ),
+    ],
+)
+def test_m3a_services_spatial_boundary_epsilon_and_swap_oracles(
+    tmp_path: Path,
+    scenario: FixtureScenario,
+    expected_action: str,
+    expected_contact: str | None,
+    expected_press: int,
+) -> None:
+    async def run_scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, scenario)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(
+                reference,
+                max_displacement_m=harness.fixture.max_displacement_m,
+            )
+            await harness.settle()
+            decision = _m3a_messages(harness.robot_store, LocalTwoButtonDecision)[0].payload
+            assert decision.action.value == expected_action
+            assert harness.fixture.press_count == expected_press
+            assert len(harness.robot_store.inspect_autonomy_budget()) == (
+                1 if expected_press else 0
+            )
+            if expected_contact is not None:
+                assert harness.fixture.records[0]["contact"] == expected_contact
+            else:
+                assert harness.robot_store.inspect_execution_journal() == []
+                assert harness.fixture.binding_records == ()
+        finally:
+            harness.close()
+
+    _run(run_scenario())
+
+
+def test_m3a_services_already_latched_is_preacceptance_and_exact_replay(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S4_ALREADY_LATCHED)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            harness.mission.submit_ensure_button_latched(
+                reference,
+            )
+            await harness.settle()
+            decision = _m3a_messages(harness.robot_store, LocalTwoButtonDecision)[0].payload
+            assert decision.action.value == "RECOGNIZE_EFFECT"
+            assert decision.reason == "ALREADY_LATCHED"
+            assert harness.fixture.press_count == 1  # unrelated seed impulse only
+            assert harness.fixture.binding_records == ()
+            assert harness.robot_store.inspect_execution_journal() == []
+            assert harness.robot_store.inspect_autonomy_budget() == []
+            held = [
+                message.payload
+                for message in harness.robot_store.outbox_messages()
+                if isinstance(message.payload, ExecutionEvent)
+                and message.payload.next_state is ContractState.HELD
+            ]
+            assert len(held) == 1
+            assert held[0].previous_state is ContractState.RECEIVED
+            view = harness.mission.m3a_view()
+            assert view["effect_evidence"] is None
+            assert view["physical_contact"] is None
+            assert view["a_counter"] is None
+            assert view["b_counter"] is None
+            assert view["a_latched"] is None
+            assert view["b_latched"] is None
+            assert view["business_result"] == "RECOGNIZED_ALREADY_EFFECTIVE"
+        finally:
+            harness.close()
+
+    _run(scenario())
+
+
+def test_m3a_intent_duplicate_bytes_and_mutated_claim_are_durable_conflicts(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        harness = M3aServiceHarness(tmp_path, FixtureScenario.S0_NOMINAL)
+        try:
+            reference = harness.fixture.reference_observation(observed_at=NOW)
+            intent_message = harness.mission.submit_ensure_button_latched(
+                reference,
+            )
+            await harness._route(harness.mission, harness.field, "field-1")
+            harness.clock.advance(1200.0)
+            await harness.record_local_current_observation()
+            await harness._route(harness.mission, harness.field, "field-1")
+            before = {
+                row["message_id"]: row["payload_json"]
+                for row in harness.field_store.inspect_outbox()
+            }
+            duplicate = harness.field.factory.make(
+                "m3a.ensure_latched.intent",
+                "field-1",
+                intent_message.correlation_id,
+                intent_message.payload,
+                source_id=intent_message.source_id,
+                source_boot_id=intent_message.source_boot_id,
+                created_at=harness.clock.now(),
+            )
+            assert await harness._deliver(harness.mission_store, harness.field, duplicate)
+            after_duplicate = {
+                row["message_id"]: row["payload_json"]
+                for row in harness.field_store.inspect_outbox()
+            }
+            assert after_duplicate == before
+
+            mutated_payload = intent_message.payload.model_copy(
+                update={"target_entity_id": "B"}
+            )
+            mutated = harness.field.factory.make(
+                "m3a.ensure_latched.intent",
+                "field-1",
+                intent_message.correlation_id,
+                mutated_payload,
+                source_id=intent_message.source_id,
+                source_boot_id=intent_message.source_boot_id,
+                created_at=harness.clock.now(),
+            )
+            assert await harness._deliver(harness.mission_store, harness.field, mutated)
+            assert len(harness.field_store.inspect_m3a_intent_conflicts()) == 1
+            assert {
+                row["message_id"]: row["payload_json"]
+                for row in harness.field_store.inspect_outbox()
+            } == before
+            harness.field_store.close()
+            harness.field_store = NodeStore(tmp_path / "field.sqlite3")
+            assert len(harness.field_store.inspect_m3a_intent_conflicts()) == 1
+        finally:
+            harness.close()
+
+    _run(scenario())


### PR DESCRIPTION
A delayed intent can refer to a world that has changed before execution. This bounded M3a.1 simulation carries one immutable revision-1 `EnsureButtonLatched` intent through Mission, 1200 seconds of virtual transit, a fresh Field-local observation, Robot admission, and an independently journaled spatial contact. The policy re-anchors the same identified target within tolerance, holds on ambiguity or excessive displacement, and recognizes an already-latched result without a new impulse.

The spatial command, device binding and durable single-action reservation remain consistent across injected failures and store/device reopen. Post-dispatch recovery observes the external device instead of dispatching again. Missing or inconsistent command evidence yields explicit UNKNOWN. Field and Mission persist canonical effect evidence; reordered prerequisites remain retryable, and divergent copies cannot replace the accepted result. The programmatic Mission snapshot reports the independently observed contact, counters and latches.

All 175 Python tests pass, including 23 focused spatial/recovery/attribution cases. The separately executed six-scenario service runner, Ruff, schema and generated-fixture checks, and historical M1 release gate also pass; six M1 golden artifacts remain byte-identical. The machine-readable [service proof](https://github.com/YannickPr/Deferred-Teleoperation/blob/fa28753e27e6f93d7f79b15908157f1d42b4d55e/docs/m3/evidence/two-button-service-proof.json) binds the final source and result hashes; the [guide](https://github.com/YannickPr/Deferred-Teleoperation/blob/fa28753e27e6f93d7f79b15908157f1d42b4d55e/docs/m3/M3A_TWO_BUTTON.md) describes reproduction and limits. No Unreal source changes are included.

This is an in-process simulation with separate stores, virtual time and injected exceptions/reopen, without an OS-crash, distributed-network, VR or physical-hardware claim. It assumes one active Robot per database/device and configured trusted services; it does not authenticate the first message cryptographically. Full M3a S0–S10, physical M3b, cross-revision causality/effect identity, and issues #45, #47, #20 and #21 remain open. README, roadmap and status distinguish the implemented slice from those remaining gates.
