### PR TITLE
Fence local Robot handling and recovery through external I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,19 @@ jobs:
         run: python -m deferred_teleop.release_gate verify --scope ci --skip-pytest
       - name: Test
         run: pytest
+
+  robot-ownership-windows:
+    name: Robot ownership (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Test local Robot ownership
+        run: python -m pytest -q tests/test_robot_ownership.py --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ### Fixed
 
+- Robot handle/recovery now holds an exclusive local owner lock through external I/O and
+  durable resolution. A competing service on the same canonical database path fails before
+  mutating work; process death permits observe-only recovery. See the
+  [scope and subprocess tests](docs/m1/EXCLUSIVE_ROBOT_OWNERSHIP.md).
+
 - exact model-reference and protocol-literal comparisons in the M2 articulated view,
   robot-description parser, preview and actor topology reuse. Case-only mutations are covered
   by strengthened assertions in the existing 43-test Unreal suite, passing on Linux and Win64;
@@ -38,7 +43,7 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
   duplicate-contract recovery and receiving-site expiry boundaries;
 - bounded M1.8c Robot-local external-action budget for one revision-1 reservation per operation,
   a finite service-clock window, atomic dispatch/device binding, durable pre-dispatch holds, and
-  conservative v3-to-v4 legacy classification; cross-revision identity and multiprocess fencing
+  conservative v3-to-v4 legacy classification; cross-revision identity
   remain open;
 - pinned SO-101 structural source, canonical generated description and cross-platform drift gate.
 - strict M2.2 articulated robot-state/model-reference protocol (#14), including finite canonical
@@ -87,12 +92,12 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 ### Status
 
 - M1.8 remains in progress after the bounded M1.8c budget slice: stable effect identity across
-  contract revisions and multiprocess fencing remain open, and no physical hardware validation is
+  contract revisions remains open, and no physical hardware validation is
   claimed.
 - M2.4 is complete, including the cross-version reference check and native Linux/Win64 Kinematics
   validation.
 - M2.2 is complete. Its raw articulated feed does not validate model geometry; an FK consumer must
-  call the explicit description-backed validator. The integrated Python suite passes 175 tests;
+  call the explicit description-backed validator. The integrated Python suite passes 185 tests;
   the historical M2.2 135/20 snapshot remains identified in its platform record.
 - M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK and the M2.8a
   preview math core are complete with Linux/Win64 evidence. The bounded M2.9a articulated-scene

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Status:** M0 and the historical M1 dummy gate are complete. Bounded delay/recovery,
 > autonomy-budget and M2 kinematics/presentation slices are implemented. M3a.1 adds a delayed
 > two-button simulation with bounded re-anchoring and independently recorded effects.
-> The integrated Python suite passes 175 tests. For M2.9a, Linux and Win64 UE 5.8.2 each pass 50
+> The integrated Python suite passes 185 tests. For M2.9a, Linux and Win64 UE 5.8.2 each pass 50
 > contextual tests (48 successes plus two expected negative-case warnings), with build/editor exit code 0.
 > Full M1.7/M1.8, M2 authoring/integration and M3a/M3b remain open. The desktop image is synthetic;
 > no physical robot or VR authoring result is claimed.
@@ -34,7 +34,7 @@ The first physical demonstration will use a SO-101 arm and an independently inst
 | Unreal Engine plugin | M1 Mission view, strict client and reconciliation scene; verified with UE 5.8.2 on Windows |
 | Delay-tolerant dummy | Runnable M1 Mission / Field / dummy-Robot development slice |
 | M1 release gate | Passed: golden replay, adversarial matrix, portable CI, and Windows UE 5.8.2 evidence |
-| M1.8 external effect | M1.8b delayed proof and bounded M1.8c one-reservation local budget implemented; cross-revision identity and multiprocess fencing remain open |
+| M1.8 external effect | M1.8b delayed proof and bounded M1.8c one-reservation local budget implemented; local ownership is enforced; cross-revision identity remains open |
 | SO-101 twin | M2.2 articulated-state protocol (#14), M2.3 canonical transforms/generic FK code (#15), M2.4 cross-language numerical oracle (#16), and the bounded M2.5 rigid-link actor are complete with Python 3.11/3.12 and Linux/Win64 UE 5.8.2 evidence; the M2.7 constrained-IK implementation and M2.8a local preview math core are complete with Linux/Win64 UE 5.8.2 evidence; the bounded M2.9a opt-in articulated-scene tranche is complete with Linux/Win64 native evidence and a synthetic desktop capture; full M2.9, desktop/VR authoring, and #20/#21 integration remain open |
 | Autonomous delayed button press | [M3a.1 two-button simulation](docs/m3/M3A_TWO_BUTTON.md) implemented; full M3a S0–S10 and physical M3b remain open |
 | Hardware control | Disabled by default; not implemented publicly |
@@ -124,7 +124,7 @@ tests. Version 2 fixes the reference operation order so Python 3.11 and 3.12 gen
 bytes; the final native validation passes the eight-test `DeferredTeleop.M2.Kinematics` selector
 on Linux and Win64, as recorded in the [M2.4 platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 alongside the earlier full 14-test context. The post-rebase integrated Python validation passes
-175 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
+185 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. The raw articulated feed does not validate SO-101
 geometry: an FK consumer must call the description-backed validator and retain its diagnostics.
 M2.4 supplies the numerical FK oracle. The bounded M2.7 constrained-IK implementation (#19)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,10 +116,12 @@ adds one local attempt/action reservation for each revision-1 operation, a confi
 service-clock window (60 seconds by default), atomic reservation/dispatch/device binding, and
 durable pre-dispatch holds with v3-to-v4 legacy classification.
 
-M1.8c assumes one active Robot instance per SQLite database and external adapter. SQLite serializes
-the durable reservation, but it does not fence external I/O after that commit; two active workers
-can still produce an observe-versus-press race. Fencing or an exclusive process lock and a
-multiprocess oracle remain future work ([issue #45](https://github.com/YannickPr/Deferred-Teleoperation/issues/45)).
+An [exclusive local Robot owner lock](docs/m1/EXCLUSIVE_ROBOT_OWNERSHIP.md) now covers the
+complete handle/recovery operation, including external I/O and its durable resolution. A competing
+service on the same canonical SQLite path fails before claim, recovery reset, or adapter I/O;
+process death releases the lock for observe-only recovery. This closes the local race in
+[issue #45](https://github.com/YannickPr/Deferred-Teleoperation/issues/45), not multi-host fencing
+or independent databases addressing the same device.
 
 M1.8 adds the smallest deterministic proof that a recorded execution event is not itself proof
 of an external effect. A fake button device keeps an effect counter or state in storage separate
@@ -134,7 +136,7 @@ validity so that admission, execution and expiry are evaluated at the receiving 
 inferred from a link profile name.
 
 The M1.8b bounded combined slice is implemented and covered by six focused tests. M1.8c adds
-eleven persistent budget cases; the current Python suite passes 175 tests. These slices do not
+eleven persistent budget cases; the current Python suite passes 185 tests. These slices do not
 validate physical hardware, a real network, or a whole-OS restart.
 Positive and ambiguous observation recovery are covered under long delay; absent external
 evidence remains covered by the separate M1.8a recovery proof. It covers contract revision 1;
@@ -150,7 +152,7 @@ M1.8 closes when deterministic evidence shows that:
 - restart and retransmission do not reset the effect identity or autonomy budget.
 
 The bounded budget portion satisfies the one-reservation invariant for revision 1. Full M1.8
-remains open for stable effect identity across plan revisions, multiprocess fencing, and the
+remains open for stable effect identity across plan revisions and the
 machine-readable evidence that joins those decisions to the independent effect record.
 
 No hardware-control path is introduced by this increment.
@@ -199,7 +201,7 @@ Python 3.11 and 3.12 produce identical bytes, and its final native validation pa
 `DeferredTeleop.M2.Kinematics` selector on both targets. The [M2.4 fixture contract](docs/m2/KINEMATICS_FIXTURES.md)
 defines nine SO-101 cases, six independent Python reference tests, and three Unreal Automation
 tests; the integrated oracle snapshot reports 121 Python tests. The post-rebase integrated Python
-validation passes 175 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
+validation passes 185 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 retains the earlier full 14-test run as context. The raw articulated feed preserves a model
 reference but does not validate geometry; an FK consumer must call the explicit description-backed
 validator. The recorded M2.5 Linux and Win64 runs pass their full Automation reports with build and
@@ -274,7 +276,7 @@ proof. Missing or inconsistent command evidence resolves to explicit UNKNOWN rat
 attributed contact. This slice does not close the full S0–S10 matrix or physical M3b.
 
 Next, extend the same independent oracles to the remaining matrix rows before broadening the
-policy. Cross-revision effect identity and causal lineage, multiprocess fencing (#45), and the
+policy. Cross-revision effect identity and causal lineage, and the
 separate M2 parser/authoring/integration issues (#47, #20 and #21) remain open. Future 2D/VR
 comparisons retain the same controller and local autonomy.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ progress. The [roadmap](../ROADMAP.md) defines the corresponding evidence gates.
 | M1 | **Implemented; `v0.1.0` historical** | Delay-tolerant dummy, persistence, replay and Mission reconciliation |
 | M1.7a | **Implemented; PR #30** | Bounded correlation selection and compatible Mission-view layer filtering |
 | M1.7 | **Planned after M1.7a** | Full causal coherence for concurrent operations and reordered Mission-view data |
-| M1.8 | **In progress; M1.8b proof and bounded M1.8c budget implemented** | One revision-1 local reservation/window is durable; cross-revision identity and multiprocess fencing remain open |
+| M1.8 | **In progress; M1.8b proof and bounded M1.8c budget implemented** | One revision-1 local reservation/window is durable; local ownership is enforced; cross-revision identity remains open |
 | M2 | **In progress; target `v0.2.0`** | M2.1 structural model, M2.2 articulated-state protocol, M2.3 FK math core, M2.4 oracle, M2.5 actor, and M2.8a local preview math core are complete with Linux/Win64 UE evidence; M2.7 constrained IK is complete with Linux/Win64 UE evidence; bounded M2.9a articulated-scene tranche is complete with Linux/Win64 native evidence and a synthetic desktop capture; full M2.9, desktop/VR authoring and #20/#21 remain |
 | M3 | **In progress; bounded M3a.1 implemented** | [Two-button service proof](m3/evidence/two-button-service-proof.json); full M3a S0–S10 and physical M3b remain open |
 | M4/M5 | **Planned** | Broader robot-agnostic assignment, context acquisition and replanning |
@@ -123,7 +123,7 @@ records the machine-readable eight-test native results and retains the earlier f
 context. The generated SO-101 structural check and the M2.4 fixture contract have distinct roles:
 the latter supplies the numerical FK oracle. Wire parsing and the live Mission view preserve the
 articulated model reference without validating SO-101 geometry; an FK consumer must call the
-explicit description-backed validator. The post-rebase integrated Python validation passes 175
+explicit description-backed validator. The post-rebase integrated Python validation passes 185
 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. Remaining M2 work is described in the [M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md).
 
@@ -248,16 +248,18 @@ durably; recovery observes without blind replay and rejects a missing or substit
 unknown outcome remains held, and a terminal event alone does not manufacture measured completion
 telemetry in the normal Field.
 
-The integrated Python suite passes 175 tests, including six M1.8b scenarios and eleven persistent
-M1.8c budget cases. The historical golden session and its six committed files remain unchanged,
+The integrated Python suite passes 185 tests, including six M1.8b scenarios, eleven persistent
+M1.8c budget cases, and ten local ownership cases. The historical golden session and its six committed files remain unchanged,
 and the release gate remains unchanged. Its explicit dummy fixture compatibility is documented;
-it is not an external observation guarantee. M1.8c assumes one active Robot instance per SQLite
-database and adapter: SQLite serializes the reservation, but does not fence external I/O between
-active workers.
+it is not an external observation guarantee. The [exclusive local Robot owner lock](m1/EXCLUSIVE_ROBOT_OWNERSHIP.md)
+now excludes competing services on the same canonical database path through external I/O and
+durable resolution. Contention is retryable before inbox/recovery mutation; owner process death
+permits observe-only recovery. Separate databases and multi-host/device fencing remain outside
+this guarantee.
 
 The remaining full M1.8 gate requires:
 
-- stable effect identity across plan revisions and multiprocess fencing for the external I/O race;
+- stable effect identity and causal lineage across plan revisions;
 - machine-readable evidence connecting those decisions and the independently recorded effect.
 
 ### Remaining M2 work

--- a/docs/m1/DURABLE_EXTERNAL_ACTION_BUDGET.md
+++ b/docs/m1/DURABLE_EXTERNAL_ACTION_BUDGET.md
@@ -16,12 +16,13 @@ action; recovery observes the addressed device and never presses again.
 The focused proof covers crashes before adapter I/O and after the device effect;
 both paths reopen and observe without a second press.
 
-The scope assumes one active Robot instance per SQLite database and external
-adapter. `BEGIN IMMEDIATE` serializes the durable reservation, but it cannot
-fence an external I/O call after the commit. Two active workers can therefore
-still race between one worker's observe and another worker's press; fencing or
-an exclusive process lock and a multiprocess oracle remain outside M1.8c.
-The follow-up is tracked in [issue #45](https://github.com/YannickPr/Deferred-Teleoperation/issues/45).
+The original M1.8c proof assumed one active Robot instance: `BEGIN IMMEDIATE`
+serializes a reservation but cannot fence external I/O after its commit.
+The follow-up [exclusive local owner lock](EXCLUSIVE_ROBOT_OWNERSHIP.md) now
+covers this gap for cooperating services on the same canonical database path,
+including owner death and observe-only recovery. The original budget proof
+remains a record of its earlier source snapshot; the new subprocess tests
+supply the concurrency evidence.
 
 The policy is compared only before a new press. A changed restart configuration
 holds an unreserved accepted contract with `BUDGET_POLICY_CONFLICT`; it cannot

--- a/docs/m1/EXCLUSIVE_ROBOT_OWNERSHIP.md
+++ b/docs/m1/EXCLUSIVE_ROBOT_OWNERSHIP.md
@@ -1,0 +1,55 @@
+# Exclusive local Robot ownership
+
+`NodeStore.exclusive_robot_owner()` fences Robot services that use the same
+local SQLite database.  `DummyRobotService.handle()` and
+`DummyRobotService.recover()` acquire this non-blocking owner lock before
+claiming inbox work or resetting interrupted processing and release it only
+after the press/observe operation and its terminal durable commit.  M3a Robot
+services inherit the same boundary.
+
+The lock is a sidecar beside the canonical database path:
+
+```text
+<resolved-database-path>.robot-owner.lock
+```
+
+The database path and sidecar path are resolved once when `NodeStore` is
+constructed, so relative paths and symlink aliases address the same sidecar.
+The sidecar is created on first use, remains on disk after release, and stays
+empty.  Unix uses the non-blocking exclusive `fcntl.flock` operation; Windows
+uses non-blocking `msvcrt.locking` for one byte at offset zero.  The Windows
+region may extend past EOF, so no marker byte or owner metadata is written.
+See the Python [`fcntl`](https://docs.python.org/3/library/fcntl.html) and
+[`msvcrt`](https://docs.python.org/3/library/msvcrt.html) documentation for
+the platform primitives.
+
+If another service owns the sidecar, acquisition raises `BusyError`
+immediately.  Filesystem, permissions, and unsupported-lock errors are
+propagated unchanged.  The caller should retry the complete `handle()` or
+`recover()` operation according to its delivery loop; there is no hidden wait
+or retry in the owner lock.  A busy `handle()` has not claimed its inbox row,
+and a busy `recover()` has not reset `PROCESSING`, so neither operation emits a
+new `HELD` result or performs adapter I/O.
+
+The operating system releases the lock when its owner exits, including a
+crash or forced termination.  Durable recovery then follows the existing
+uncertain-dispatch rule: a crash before the adapter press is observed as
+`NOT_APPLIED` and resolves to `HELD` without a press; a crash after the press
+is observed as `APPLIED` and resolves to `SUCCEEDED` with the one persisted
+press.  Normal return, an exception, and asyncio cancellation release the
+sidecar through the context manager's `finally` path.  Reopening the database
+reuses the retained sidecar.
+
+This is a local process fence for cooperating services on one canonical path.
+It does not provide a lease, fencing token, migration, DDL, or cross-host
+coordination.  Hard-linked database spellings, distinct database files on the
+same device, NFS or other filesystems with weaker lock semantics, and multiple
+hosts are outside this guarantee.  SQLite and the sidecar do not make a real
+actuator exactly-once; the external adapter's durable attributable observation
+remains the recovery authority.
+
+Focused proof:
+
+```text
+PYTHONPATH=python/src python -m pytest -q tests/test_robot_ownership.py --tb=short
+```

--- a/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
+++ b/docs/m1/EXTERNAL_EFFECT_RECOVERY.md
@@ -44,11 +44,12 @@ zero. The counter belongs only to the historical database dummy path. The
 fixture's persistent press record is the independent evidence used by
 `observe`; the runtime never reads a test counter.
 
-The bounded M1.8c budget assumes one active Robot instance per SQLite database
-and external adapter. SQLite serializes the reservation commit, but it cannot
-fence external I/O after that commit; two active workers can still race between
-one worker's observation and another worker's press. Multiprocess fencing or an
-exclusive process lock remains future work.
+SQLite serializes the reservation commit, but that transaction alone cannot
+fence external I/O. The [exclusive local owner lock](EXCLUSIVE_ROBOT_OWNERSHIP.md)
+now covers Robot handling and recovery through adapter I/O and terminal commit.
+Competing services on the same canonical database path receive a retryable busy
+error before claiming or resetting work. Multiple databases addressing the same
+device and cross-host fencing remain outside this guarantee.
 
 The Field only emits a reconciled site snapshot for `SUCCEEDED` when it has a
 compatible measured or fused `RobotState` with the same correlation and robot

--- a/python/src/deferred_teleop/runtime.py
+++ b/python/src/deferred_teleop/runtime.py
@@ -1398,6 +1398,18 @@ class DummyRobotService(RuntimeService):
     def effect_counter(self) -> int:
         return sum(int(row["effect_count"]) for row in self.store.inspect_execution_journal())
 
+    async def handle(self, envelope: MessageEnvelope) -> None:
+        """Process one delivery while exclusively owning this Robot database."""
+
+        with self.store.exclusive_robot_owner():
+            await super().handle(envelope)
+
+    async def recover(self) -> int:
+        """Reset and retry interrupted Robot work under the same owner lock."""
+
+        with self.store.exclusive_robot_owner():
+            return await super().recover()
+
     async def process_claimed(self, envelope: MessageEnvelope) -> None:
         if isinstance(envelope.payload, TaskAssignment):
             self.store.complete_inbox(

--- a/python/src/deferred_teleop/storage.py
+++ b/python/src/deferred_teleop/storage.py
@@ -7,9 +7,11 @@ make a future external physical action exactly-once.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
 from collections.abc import Iterator, Mapping, Sequence
@@ -51,6 +53,10 @@ TERMINAL_STATES = frozenset(
 
 class StorageError(RuntimeError):
     """Base class for durable-store failures."""
+
+
+class BusyError(StorageError):
+    """The local Robot database is currently owned by another service."""
 
 
 class IncompatibleSchemaError(StorageError):
@@ -664,7 +670,10 @@ class NodeStore:
         *,
         busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
     ) -> None:
-        self.path = Path(path)
+        # Resolve before opening SQLite or deriving the sidecar path.  Two
+        # relative/symlinked spellings of one database must use one lock file.
+        self.path = Path(path).resolve(strict=False)
+        self._robot_owner_lock_path = Path(f"{self.path}.robot-owner.lock")
         self.path.parent.mkdir(parents=True, exist_ok=True)
         initialize_database(self.path, busy_timeout_ms=busy_timeout_ms)
         self._connection = sqlite3.connect(self.path, isolation_level=None)
@@ -679,6 +688,63 @@ class NodeStore:
 
     def __exit__(self, *_args: object) -> None:
         self.close()
+
+    @contextmanager
+    def exclusive_robot_owner(self) -> Iterator[None]:
+        """Hold the process-lifetime Robot owner lock for one service action.
+
+        The lock is deliberately a sidecar rather than SQLite state: it spans
+        the complete ``handle``/``recover`` call, including external adapter
+        I/O and the terminal commit.  The sidecar is retained after release so
+        that all path aliases continue to address the same inode.
+        """
+
+        lock_path = self._robot_owner_lock_path
+        with lock_path.open("a+b") as lock_file:
+            acquired = False
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    lock_file.seek(0)
+                    try:
+                        # ``msvcrt.locking`` may lock beyond EOF; no marker byte
+                        # is written because the sidecar is only a lock inode.
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                    except OSError as error:
+                        if error.errno in {
+                            errno.EACCES,
+                            errno.EAGAIN,
+                            errno.EDEADLK,
+                        }:
+                            raise BusyError(
+                                f"Robot database ownership is busy: {lock_path}"
+                            ) from error
+                        raise
+                else:
+                    import fcntl
+
+                    try:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except OSError as error:
+                        if error.errno in {errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK}:
+                            raise BusyError(
+                                f"Robot database ownership is busy: {lock_path}"
+                            ) from error
+                        raise
+                acquired = True
+                yield
+            finally:
+                if acquired:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        lock_file.seek(0)
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     @contextmanager
     def _transaction(self) -> Iterator[sqlite3.Connection]:

--- a/tests/test_robot_ownership.py
+++ b/tests/test_robot_ownership.py
@@ -1,0 +1,449 @@
+"""Process fencing for two Robot services sharing one local SQLite database."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import queue
+import subprocess
+import sys
+import textwrap
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from deferred_teleop.protocol import ExecutionContract
+from deferred_teleop.runtime import (
+    DummyRobotService,
+    EnvelopeFactory,
+    FieldService,
+    M3aRobotService,
+    MissionService,
+    SystemClock,
+)
+from deferred_teleop.storage import BusyError, NodeStore
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON = sys.executable
+WORKER = textwrap.dedent(
+    """
+    import asyncio
+    import json
+    import sys
+    from pathlib import Path
+
+    from deferred_teleop.external_effect import PersistentDummyExternalEffect
+    from deferred_teleop.protocol import ExecutionContract
+    from deferred_teleop.runtime import DummyRobotService, EnvelopeFactory, SystemClock
+    from deferred_teleop.storage import NodeStore
+
+
+    def emit(value):
+        sys.stdout.write(json.dumps(value, separators=(",", ":")) + "\\n")
+        sys.stdout.flush()
+
+
+    class GateAdapter(PersistentDummyExternalEffect):
+        def __init__(self, path, gate):
+            super().__init__(path)
+            self.gate = gate
+
+        def _wait(self, event):
+            emit({"event": event})
+            for line in sys.stdin:
+                if line.strip() == "release":
+                    return
+            raise RuntimeError("control pipe closed while Robot was gated")
+
+        def press(self, effect_key):
+            if self.gate == "before-press":
+                self._wait("press_entered")
+            result = super().press(effect_key)
+            if self.gate == "after-press":
+                self._wait("press_persisted")
+            return result
+
+
+    class CountingAdapter(PersistentDummyExternalEffect):
+        def __init__(self, path, device_id="dummy-external-button-1"):
+            super().__init__(path, device_id=device_id)
+            self.observe_calls = 0
+
+        def observe(self, effect_key):
+            self.observe_calls += 1
+            return super().observe(effect_key)
+
+
+    async def main():
+        database = Path(sys.argv[1])
+        external = Path(sys.argv[2])
+        mode = sys.argv[3]
+        clock = SystemClock()
+        if mode == "no-adapter":
+            adapter = None
+        elif mode in {"before-press", "after-press"}:
+            adapter = GateAdapter(external, mode)
+        elif mode == "different-device":
+            adapter = CountingAdapter(external, device_id="different-device")
+        else:
+            adapter = CountingAdapter(external)
+        store = NodeStore(database)
+        service = DummyRobotService(
+            store,
+            EnvelopeFactory("dummy-robot-1", clock),
+            phase_duration=0.0,
+            external_effect_adapter=adapter,
+        )
+        try:
+            for line in sys.stdin:
+                command = line.strip()
+                if command == "quit":
+                    return
+                try:
+                    if command == "handle":
+                        contract = next(
+                            message
+                            for message in store.inbox_messages()
+                            if isinstance(message.payload, ExecutionContract)
+                        )
+                        await service.handle(contract)
+                        emit({"event": "done", "command": command})
+                    elif command == "recover":
+                        recovered = await service.recover()
+                        emit({"event": "done", "command": command, "recovered": recovered})
+                    elif command == "inspect":
+                        journals = store.inspect_execution_journal()
+                        inbox = store.inspect_inbox()
+                        emit(
+                            {
+                                "event": "inspect",
+                                "inbox": [row["processing_state"] for row in inbox],
+                                "journal": [row["state"] for row in journals],
+                                "press_count": (
+                                    adapter.press_count if adapter is not None else None
+                                ),
+                                "observe_calls": (
+                                    adapter.observe_calls if adapter is not None else None
+                                ),
+                            }
+                        )
+                    else:
+                        emit({"event": "error", "type": "ValueError", "message": command})
+                except BaseException as error:
+                    emit({"event": "error", "type": type(error).__name__, "message": str(error)})
+        finally:
+            store.close()
+
+
+    asyncio.run(main())
+    """
+)
+
+
+class VirtualClock:
+    def __init__(self) -> None:
+        self.current = datetime(2026, 9, 5, tzinfo=UTC)
+
+    def now(self) -> datetime:
+        return self.current
+
+    async def sleep(self, _seconds: float) -> None:
+        return None
+
+
+class CancellationClock(VirtualClock):
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def sleep(self, _seconds: float) -> None:
+        self.entered.set()
+        await self.release.wait()
+
+
+async def _prepare_robot_database(tmp_path: Path) -> tuple[Path, Path]:
+    clock = VirtualClock()
+    mission_path = tmp_path / "mission.sqlite3"
+    field_path = tmp_path / "field.sqlite3"
+    robot_path = tmp_path / "robot.sqlite3"
+    with NodeStore(mission_path) as mission_store, NodeStore(field_path) as field_store:
+        mission = MissionService(
+            mission_store,
+            EnvelopeFactory("mission-1", clock),
+            configured_one_way_delay=0.0,
+        )
+        field = FieldService(field_store, EnvelopeFactory("field-1", clock))
+        intent = mission.submit_press_button()
+        assert field_store.receive(intent, received_at=clock.now())
+        await field.handle(intent)
+        assignment = next(
+            message
+            for message in field_store.outbox_messages()
+            if message.message_type == "task.assignment"
+        )
+        contract = next(
+            message
+            for message in field_store.outbox_messages()
+            if message.message_type == "execution.contract"
+        )
+    with NodeStore(robot_path) as robot_store:
+        assert robot_store.receive(assignment, received_at=clock.now())
+        assert robot_store.receive(contract, received_at=clock.now())
+    return robot_path, tmp_path / "external.jsonl"
+
+
+def _worker_process(database: Path, external: Path, mode: str) -> subprocess.Popen[str]:
+    environment = os.environ.copy()
+    package_path = str(ROOT / "python" / "src")
+    environment["PYTHONPATH"] = package_path + os.pathsep + environment.get("PYTHONPATH", "")
+    return subprocess.Popen(
+        [PYTHON, "-u", "-c", WORKER, str(database), str(external), mode],
+        cwd=ROOT,
+        env=environment,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _send(process: subprocess.Popen[str], command: str) -> None:
+    assert process.stdin is not None
+    process.stdin.write(command + "\n")
+    process.stdin.flush()
+
+
+def _event(process: subprocess.Popen[str]) -> dict[str, Any]:
+    assert process.stdout is not None
+    result: queue.Queue[tuple[str, object]] = queue.Queue(maxsize=1)
+
+    def read_line() -> None:
+        try:
+            result.put(("line", process.stdout.readline()))
+        except BaseException as error:
+            result.put(("error", error))
+
+    threading.Thread(target=read_line, daemon=True).start()
+    try:
+        kind, value = result.get(timeout=10)
+    except queue.Empty as error:
+        _kill(process)
+        raise AssertionError("worker did not emit an event within 10 seconds") from error
+    if kind == "error":
+        assert isinstance(value, BaseException)
+        raise value
+    line = value
+    assert isinstance(line, str)
+    assert line, _process_error(process)
+    return json.loads(line)
+
+
+def _process_error(process: subprocess.Popen[str]) -> str:
+    if process.stderr is None:
+        return "worker exited without an event"
+    if process.poll() is None:
+        return "worker did not emit an event before its process exited"
+    return f"worker exited: {process.stderr.read()}"
+
+
+def _stop(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        _send(process, "quit")
+    assert process.wait(timeout=10) == 0, _process_error(process)
+
+
+def _kill(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.kill()
+    process.wait(timeout=10)
+
+
+@pytest.mark.parametrize("gate", ["before-press", "after-press"])
+def test_owner_death_recovery_observes_without_repressing(tmp_path: Path, gate: str) -> None:
+    async def scenario() -> None:
+        database, external = await _prepare_robot_database(tmp_path)
+        owner = _worker_process(database, external, gate)
+        try:
+            _send(owner, "handle")
+            expected_event = "press_entered" if gate == "before-press" else "press_persisted"
+            assert _event(owner) == {"event": expected_event}
+            owner.kill()
+            owner_exit = owner.wait(timeout=10)
+            assert owner_exit < 0 if os.name != "nt" else owner_exit != 0
+
+            observer = _worker_process(database, external, "observer")
+            try:
+                _send(observer, "recover")
+                result = _event(observer)
+                assert result == {"event": "done", "command": "recover", "recovered": 1}
+                _send(observer, "inspect")
+                state = _event(observer)
+                assert state["inbox"] == ["PROCESSED", "PROCESSED"]
+                assert state["journal"] == [
+                    "SUCCEEDED" if gate == "after-press" else "HELD"
+                ]
+                assert state["press_count"] == (1 if gate == "after-press" else 0)
+                assert state["observe_calls"] == 1
+            finally:
+                _stop(observer)
+        finally:
+            _kill(owner)
+
+    asyncio.run(scenario())
+
+
+def test_owner_blocks_handle_and_recover_until_terminal_commit(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        database, external = await _prepare_robot_database(tmp_path)
+        owner = _worker_process(database, external, "before-press")
+        contender = None
+        try:
+            _send(owner, "handle")
+            assert _event(owner) == {"event": "press_entered"}
+            contender = _worker_process(database, external, "observer")
+            _send(contender, "handle")
+            assert _event(contender)["type"] == "BusyError"
+            _send(contender, "recover")
+            assert _event(contender)["type"] == "BusyError"
+            _send(contender, "inspect")
+            state = _event(contender)
+            assert sorted(state["inbox"]) == ["PROCESSING", "RECEIVED"]
+            assert state["journal"] == ["DISPATCH_RECORDED"]
+            assert state["press_count"] == 0
+            assert state["observe_calls"] == 0
+
+            _send(owner, "release")
+            assert _event(owner) == {"event": "done", "command": "handle"}
+            _send(contender, "recover")
+            assert _event(contender) == {"event": "done", "command": "recover", "recovered": 0}
+            _send(contender, "inspect")
+            state = _event(contender)
+            assert state["journal"] == ["SUCCEEDED"]
+            assert state["press_count"] == 1
+            assert state["observe_calls"] == 0
+        finally:
+            _kill(owner)
+            if contender is not None:
+                _kill(contender)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("mode", ["no-adapter", "different-device"])
+def test_busy_wins_before_robot_configuration_or_external_io(tmp_path: Path, mode: str) -> None:
+    async def scenario() -> None:
+        database, external = await _prepare_robot_database(tmp_path)
+        with NodeStore(database) as owner:
+            with owner.exclusive_robot_owner():
+                contender = _worker_process(database, external, mode)
+                try:
+                    _send(contender, "handle")
+                    result = _event(contender)
+                    assert result["type"] == "BusyError"
+                    _send(contender, "inspect")
+                    state = _event(contender)
+                    assert state["press_count"] == (None if mode == "no-adapter" else 0)
+                    assert state["observe_calls"] == (None if mode == "no-adapter" else 0)
+                finally:
+                    _kill(contender)
+
+    asyncio.run(scenario())
+
+
+def test_store_lock_is_canonical_and_retained_after_release(tmp_path: Path) -> None:
+    database = tmp_path / "real" / "robot.sqlite3"
+    database.parent.mkdir()
+    alias = tmp_path / "alias.sqlite3"
+    try:
+        alias.symlink_to(database)
+    except OSError as error:
+        if os.name == "nt":
+            pytest.skip(f"Windows symlink privilege is unavailable: {error}")
+        raise
+    with NodeStore(database) as owner, NodeStore(alias) as contender:
+        assert owner.path == contender.path == database.resolve()
+        with owner.exclusive_robot_owner():
+            with pytest.raises(BusyError, match="ownership is busy"):
+                with contender.exclusive_robot_owner():
+                    raise AssertionError("unreachable")
+        lock_file = Path(f"{database.resolve()}.robot-owner.lock")
+        assert lock_file.exists()
+        assert lock_file.stat().st_size == 0
+        with contender.exclusive_robot_owner():
+            pass
+
+
+def test_independent_databases_do_not_share_owner_lock(tmp_path: Path) -> None:
+    with NodeStore(tmp_path / "one.sqlite3") as first, NodeStore(
+        tmp_path / "two.sqlite3"
+    ) as second:
+        with first.exclusive_robot_owner():
+            with second.exclusive_robot_owner():
+                pass
+
+
+def test_m3_robot_inherits_owner_fence_without_a_second_harness(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        database, _external = await _prepare_robot_database(tmp_path)
+        with NodeStore(database) as first_store, NodeStore(database) as second_store:
+            second = M3aRobotService(
+                second_store,
+                EnvelopeFactory("m3-second", SystemClock()),
+                phase_duration=0.0,
+            )
+            envelope = next(
+                message
+                for message in second_store.inbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            with first_store.exclusive_robot_owner():
+                with pytest.raises(BusyError):
+                    await second.handle(envelope)
+
+    asyncio.run(scenario())
+
+
+def test_owner_lock_releases_on_exception_and_replay_can_reopen(tmp_path: Path) -> None:
+    database = tmp_path / "robot.sqlite3"
+    with NodeStore(database) as store:
+        with pytest.raises(RuntimeError):
+            with store.exclusive_robot_owner():
+                raise RuntimeError("owner body failed")
+        with store.exclusive_robot_owner():
+            pass
+    with NodeStore(database) as reopened:
+        with reopened.exclusive_robot_owner():
+            pass
+
+
+def test_asyncio_cancellation_releases_owner_during_dummy_phase(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        database, _external = await _prepare_robot_database(tmp_path)
+        clock = CancellationClock()
+        with NodeStore(database) as store:
+            service = DummyRobotService(
+                store,
+                EnvelopeFactory("dummy-robot-1", clock),
+                phase_duration=1.0,
+            )
+            contract = next(
+                message
+                for message in store.inbox_messages()
+                if isinstance(message.payload, ExecutionContract)
+            )
+            running = asyncio.create_task(service.handle(contract))
+            await clock.entered.wait()
+            running.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await running
+
+        with NodeStore(database) as contender:
+            with contender.exclusive_robot_owner():
+                pass
+
+    asyncio.run(scenario())


### PR DESCRIPTION
A second Robot process could recover a durable dispatch while its owner was paused before pressing, producing an observe-versus-press race. Robot `handle()` and `recover()` now hold a non-blocking OS lock for one canonical SQLite path through external I/O and terminal resolution. Contention raises `BusyError` before claim/reset/I/O; process death releases ownership for observe-only recovery. No lease, schema migration, or new dependency is introduced.

Closes #45 for cooperating services on the same local database. Separate databases addressing one device, cross-host fencing, NFS-like lock semantics, and physical exactly-once behavior remain outside the guarantee. The roadmap retains cross-revision effect identity as unfinished work.

Validation: 185 Python tests, Ruff, schema check, and CI release gate pass under Linux. After integration with the merged M3a cleanup, all 33 M3a/ownership tests pass. Ten ownership cases include true subprocess contention, owner death before/after press, cancellation, configuration mismatch, and M3a inheritance. A focused Windows CI job validates the msvcrt implementation; merge is gated on its success. Independent critical review: GO source and PR, conditional on Windows CI.