### PR TITLE
Reject case-only JSON field aliases and collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 
 ### Fixed
 
+- exact JSON field-name validation in the legacy Mission, articulated Mission, and robot-model
+  parsers. A shared Unreal token preflight rejects case-only collisions before DOM construction;
+  strict field checks reject case-only aliases. Exact duplicates retain last-wins behavior.
+  See the [shared regression matrix and platform evidence](docs/m2/JSON_FIELD_CONFORMANCE.md).
+
 - Robot handle/recovery now holds an exclusive local owner lock through external I/O and
   durable resolution. A competing service on the same canonical database path fails before
   mutating work; process death permits observe-only recovery. See the
@@ -86,8 +91,7 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
   in the final Linux and Win64 receipts: each platform records build/editor exit code 0 and 50
   tests (48 `Success` plus two expected `SuccessWithWarnings` for missing-model and
   duplicate-sequence negative cases), with zero failures. The final desktop image is a 1920x1080
-  `RenderOffscreenVulkan` capture; JSON field-name exactness remains tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47),
-  and full M2.9/#20/#21 remain open.
+  `RenderOffscreenVulkan` capture; full M2.9/#20/#21 remain open.
 
 ### Status
 
@@ -97,7 +101,7 @@ tagged releases; the experimental `dtt/0` protocol can still change incompatibly
 - M2.4 is complete, including the cross-version reference check and native Linux/Win64 Kinematics
   validation.
 - M2.2 is complete. Its raw articulated feed does not validate model geometry; an FK consumer must
-  call the explicit description-backed validator. The integrated Python suite passes 185 tests;
+  call the explicit description-backed validator. The integrated Python suite passes 200 tests;
   the historical M2.2 135/20 snapshot remains identified in its platform record.
 - M2.5 is complete for the bounded kinematic-actor slice. M2.7 constrained IK and the M2.8a
   preview math core are complete with Linux/Win64 evidence. The bounded M2.9a articulated-scene

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Status:** M0 and the historical M1 dummy gate are complete. Bounded delay/recovery,
 > autonomy-budget and M2 kinematics/presentation slices are implemented. M3a.1 adds a delayed
 > two-button simulation with bounded re-anchoring and independently recorded effects.
-> The integrated Python suite passes 185 tests. For M2.9a, Linux and Win64 UE 5.8.2 each pass 50
+> The integrated Python suite passes 200 tests. For M2.9a, Linux and Win64 UE 5.8.2 each pass 50
 > contextual tests (48 successes plus two expected negative-case warnings), with build/editor exit code 0.
 > Full M1.7/M1.8, M2 authoring/integration and M3a/M3b remain open. The desktop image is synthetic;
 > no physical robot or VR authoring result is claimed.
@@ -124,7 +124,7 @@ tests. Version 2 fixes the reference operation order so Python 3.11 and 3.12 gen
 bytes; the final native validation passes the eight-test `DeferredTeleop.M2.Kinematics` selector
 on Linux and Win64, as recorded in the [M2.4 platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 alongside the earlier full 14-test context. The post-rebase integrated Python validation passes
-185 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
+200 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. The raw articulated feed does not validate SO-101
 geometry: an FK consumer must call the description-backed validator and retain its diagnostics.
 M2.4 supplies the numerical FK oracle. The bounded M2.7 constrained-IK implementation (#19)
@@ -168,8 +168,8 @@ failures. The final 1920x1080 `RenderOffscreenVulkan` image is a `SYNTHETIC FIXT
 illustrating the three layers from runtime status labels; it is not a pose/root oracle or a
 pixel-identical output of the public generator alone. See
 the [platform record](docs/m2/evidence/articulated-scene-platform-validation.json), [scene guide](docs/m2/ARTICULATED_SCENE.md),
-and [capture](docs/m2/evidence/m2-9a-articulated-scene.png). JSON field-name exactness remains
-tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47). This
+and [capture](docs/m2/evidence/m2-9a-articulated-scene.png). The [JSON field conformance correction](docs/m2/JSON_FIELD_CONFORMANCE.md)
+closes #47 with token-level collision rejection and exact field-name checks. This
 presentation seam does not add Target authoring, IK, VR, hardware, or an execution command path,
 and it does not close the full M2.9 milestone or #20/#21.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,7 +136,7 @@ validity so that admission, execution and expiry are evaluated at the receiving 
 inferred from a link profile name.
 
 The M1.8b bounded combined slice is implemented and covered by six focused tests. M1.8c adds
-eleven persistent budget cases; the current Python suite passes 185 tests. These slices do not
+eleven persistent budget cases; the current Python suite passes 200 tests. These slices do not
 validate physical hardware, a real network, or a whole-OS restart.
 Positive and ambiguous observation recovery are covered under long delay; absent external
 evidence remains covered by the separate M1.8a recovery proof. It covers contract revision 1;
@@ -201,7 +201,7 @@ Python 3.11 and 3.12 produce identical bytes, and its final native validation pa
 `DeferredTeleop.M2.Kinematics` selector on both targets. The [M2.4 fixture contract](docs/m2/KINEMATICS_FIXTURES.md)
 defines nine SO-101 cases, six independent Python reference tests, and three Unreal Automation
 tests; the integrated oracle snapshot reports 121 Python tests. The post-rebase integrated Python
-validation passes 185 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
+validation passes 200 tests; the M2.2 record retains its historical 135/20 context. Its [platform summary](docs/m2/evidence/fk-oracle-platform-validation.json)
 retains the earlier full 14-test run as context. The raw articulated feed preserves a model
 reference but does not validate geometry; an FK consumer must call the explicit description-backed
 validator. The recorded M2.5 Linux and Win64 runs pass their full Automation reports with build and
@@ -238,16 +238,15 @@ grouped production tests cover exact description bytes, strict model and evidenc
 three persistent semantic layers, stale/last-good transaction behavior, and connection ordering.
 The identity correction makes protocol and robot-description literals exact in the existing
 articulated-view and robot-description JSON C++ parsers while preserving the standalone client's
-`LegacyView` default and M1 behavior. JSON field-name exactness remains a separate parser
-conformance concern tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
+`LegacyView` default and M1 behavior. The [JSON field conformance correction](docs/m2/JSON_FIELD_CONFORMANCE.md)
+closes #47 with shared raw-input cases, token-level collision rejection, and exact field-name checks.
 The [platform record](docs/m2/evidence/articulated-scene-platform-validation.json) binds 63
 selected files and records build, editor, and automation exit code 0 on both Linux and Win64.
 Each platform reports 50 tests: 48 `Success`, 2 expected `SuccessWithWarnings` for the
 missing-model and duplicate-sequence negative cases, and zero failures. The final 1920x1080
 `RenderOffscreenVulkan` image is a `SYNTHETIC FIXTURE REPLAY` illustrating the three layers from
 runtime status labels; it is not a pose/root oracle or a pixel-identical output of the public
-generator alone. It is documented in the guide and committed at [the capture](docs/m2/evidence/m2-9a-articulated-scene.png). JSON field-name
-exactness remains tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
+generator alone. It is documented in the guide and committed at [the capture](docs/m2/evidence/m2-9a-articulated-scene.png).
 The tranche does not close full M2.9, #20 or #21.
 
 ## M3 — Autonomous delayed button press with bounded re-anchoring
@@ -277,7 +276,7 @@ attributed contact. This slice does not close the full S0–S10 matrix or physic
 
 Next, extend the same independent oracles to the remaining matrix rows before broadening the
 policy. Cross-revision effect identity and causal lineage, and the
-separate M2 parser/authoring/integration issues (#47, #20 and #21) remain open. Future 2D/VR
+remaining M2 authoring/integration issues (#20 and #21) remain open. Future 2D/VR
 comparisons retain the same controller and local autonomy.
 
 ### M3a — Deterministic simulation gate

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -123,7 +123,7 @@ records the machine-readable eight-test native results and retains the earlier f
 context. The generated SO-101 structural check and the M2.4 fixture contract have distinct roles:
 the latter supplies the numerical FK oracle. Wire parsing and the live Mission view preserve the
 articulated model reference without validating SO-101 geometry; an FK consumer must call the
-explicit description-backed validator. The post-rebase integrated Python validation passes 185
+explicit description-backed validator. The post-rebase integrated Python validation passes 200
 tests; the M2.4 oracle record retains its 121-test snapshot and the M2.2 record retains its
 historical 135/20 context. Remaining M2 work is described in the [M2 design](design/M2_SO101_MATHEMATICAL_TWIN.md).
 
@@ -186,8 +186,8 @@ and records build, editor, and automation exit code `0` on Linux and Win64. Each
 50 tests: 48 `Success`, 2 expected `SuccessWithWarnings` for the missing-model and
 duplicate-sequence negative cases, and zero failures. The identity correction makes protocol and
 robot-description literals exact in the two existing C++ parsers while preserving the standalone
-client's `LegacyView` default and M1 behavior. JSON field-name exactness remains a separate
-parser-conformance concern tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
+client's `LegacyView` default and M1 behavior. The [JSON field conformance correction](m2/JSON_FIELD_CONFORMANCE.md)
+closes #47 with token-level collision rejection and exact field-name checks.
 
 The final desktop capture is a 1920x1080 `RenderOffscreenVulkan` render labelled
 `SYNTHETIC FIXTURE REPLAY`; it is an illustration of the three layers using labels from the
@@ -248,7 +248,7 @@ durably; recovery observes without blind replay and rejects a missing or substit
 unknown outcome remains held, and a terminal event alone does not manufacture measured completion
 telemetry in the normal Field.
 
-The integrated Python suite passes 185 tests, including six M1.8b scenarios, eleven persistent
+The integrated Python suite passes 200 tests, including six M1.8b scenarios, eleven persistent
 M1.8c budget cases, and ten local ownership cases. The historical golden session and its six committed files remain unchanged,
 and the release gate remains unchanged. Its explicit dummy fixture compatibility is documented;
 it is not an external observation guarantee. The [exclusive local Robot owner lock](m1/EXCLUSIVE_ROBOT_OWNERSHIP.md)

--- a/docs/m2/ARTICULATED_SCENE.md
+++ b/docs/m2/ARTICULATED_SCENE.md
@@ -62,9 +62,10 @@ guards: Confirmed is `MEASURED`/`FUSED`, Arrival is `PREDICTED` with a strictly 
 The identity correction also makes protocol and robot-description literals exact in the two
 existing C++ parsers, `Private/Articulated/DeferredTeleopArticulatedViewParser.cpp` and
 `Private/RobotModel/DeferredTeleopRobotModelJson.cpp`.  This preserves the standalone client's
-`LegacyView` default and existing M1 behavior.  JSON object field-name
-lookup still follows Unreal's case-insensitive alias behavior in this slice; exact JSON key
-validation and parser conformance remain tracked by [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
+`LegacyView` default and existing M1 behavior.  The subsequent
+[JSON field conformance correction](JSON_FIELD_CONFORMANCE.md) rejects case-only
+field aliases and collisions before information can be lost in the Unreal DOM.
+Exact duplicates retain their existing last-wins behavior.
 
 For a valid candidate the scene performs `InitializeModel` and `ApplyState` on
 the existing layer actor.  Each layer retains a last-good tuple containing its
@@ -143,9 +144,8 @@ The generator is bound by SHA-256
 `690ca1f5b0fb2233e5e4dc8a56d8b8bce5976284a4b91cf7c15a69cce9a79b3a`. The capture is desktop
 presentation evidence only; it adds no VR or hardware path.
 
-JSON field-name exactness remains a separate parser-conformance concern tracked by
-[issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47); the native
-`FName` topology lookup remains case-insensitive. The full M2.9 milestone and #20/#21 remain
+The native `FName` topology lookup remains case-insensitive, separately from
+[exact JSON field names](JSON_FIELD_CONFORMANCE.md). The full M2.9 milestone and #20/#21 remain
 open.
 
 ## Deterministic checks

--- a/docs/m2/IDENTITY_CASE_SENSITIVITY.md
+++ b/docs/m2/IDENTITY_CASE_SENSITIVITY.md
@@ -20,12 +20,12 @@ robot-description parser applies the same rule to its schema literal and the
 coordinate-convention and `fixed`/`revolute` joint type literals. This keeps
 wire vocabulary distinct from free-form identifiers.
 
-This correction applies to field values. Unreal's JSON object lookup still
-accepts case-only aliases in field names, unlike the Python wire models, and
-can collapse those keys before validation. Exact key validation and shared
-parser-conformance cases are tracked in
-[issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
-The final parsed model-reference values still undergo the exact comparisons above.
+This correction applies to field values. The subsequent
+[JSON field conformance correction](JSON_FIELD_CONFORMANCE.md) addresses field
+names separately: raw token validation rejects case-only collisions before
+Unreal can collapse them, and exact comparisons reject aliases of required
+fields. Exact duplicate keys retain their existing last-wins behavior.
+The original 43-test evidence below remains a snapshot before that follow-up.
 
 Model topology names stored as `FName` retain Unreal's case-insensitive lookup
 semantics. Consumers needing exact joint-name matching must compare the wire

--- a/docs/m2/JSON_FIELD_CONFORMANCE.md
+++ b/docs/m2/JSON_FIELD_CONFORMANCE.md
@@ -1,0 +1,49 @@
+# Exact JSON field names
+
+UE 5.8.2 accepts case-only aliases and collapses their collisions while building
+`FJsonObject`. Checking its field count and `HasField` after deserialization
+therefore cannot enforce exact wire field names. The shared native tests
+reproduce this gap in [issue #47](https://github.com/YannickPr/Deferred-Teleoperation/issues/47).
+
+The correction has two parts. A shared preflight uses Unreal's JSON token
+reader to reject differently spelled names that compare equal without case
+inside one object, before the DOM can collapse them. The three strict field
+helpers then compare the spelling of each stored key with the expected names.
+This does not introduce another JSON parser or duplicate the protocol schema.
+
+Case-only aliases of required fields are rejected. Collisions such as `foo`
+and `FOO` are rejected in either order, including in otherwise opaque extension
+objects. A unique uppercase extension key is allowed wherever the existing
+parser allows free-form data. Duplicate keys with identical spelling retain
+the existing last-wins behavior; producers should emit each field once.
+
+The shared [mutation matrix](../../fixtures/m2/json-field-exactness.json) exercises
+raw JSON in the legacy Mission view, articulated Mission view, and Unreal
+robot-description parser. Each case replaces a unique fragment of a valid
+fixture before parsing, so neither spelling nor duplicate keys are normalized
+away by a dictionary round trip. Rejection preserves the previous parsed value.
+
+The two Mission-view formats have Python wire models and run the same cases
+through Pydantic and Unreal. Robot-description cases additionally exercise the
+Unreal importer; the Python numerical reference loader is not a strict wire
+parser and is not claimed as a differential counterpart. This is a bounded
+conformance check, not a claim that every JSON input has identical treatment.
+
+Run the portable cases with:
+
+```sh
+PYTHONPATH=python/src python -m pytest -q tests/test_json_field_exactness.py
+```
+
+Build the plugin and run `Automation RunTests DeferredTeleop.; SoftQuit` with
+UE 5.8.2 to include the native matrix and existing last-good view tests. The
+[platform record](evidence/json-field-platform-validation.json) records the
+source and report hashes, including the failing regression baseline and the
+corrected Linux and Win64 checks.
+
+The corrected runs each execute 52 tests: 50 successes and two expected warning
+cases (missing model and duplicate sequence), with zero failures or unexecuted
+tests. Both JSON test groups pass without warnings. The unchanged 21-case
+matrix produced 54 failed assertions before the correction on both platforms.
+Validate report counters and registered test names as well as build/editor exit
+codes; the Windows failing baseline returned editor exit code zero.

--- a/docs/m2/evidence/json-field-platform-validation.json
+++ b/docs/m2/evidence/json-field-platform-validation.json
@@ -1,0 +1,238 @@
+{
+  "base_commit": "95418bbe07517d092b038307d3d04048da2a94f7",
+  "commands": {
+    "editor": "UnrealEditor-Cmd <project> -unattended -nop4 -nosplash -NullRHI -ExecCmds=\"Automation RunTests DeferredTeleop.; SoftQuit\" -ReportExportPath=<report-directory>",
+    "linux_build": "Build.sh UnrealEditor Linux Development -Project=<project> -Plugin=<plugin> -NoUBTMakefiles -NoHotReload -MaxParallelActions=4 -UBARootDir=<writable-cache> -UBAStoreCapacityGb=1 -UBADisableRemote",
+    "note": "Use an already-built UE 5.8.2 editor. These runs built the plugin (2 Linux actions, 4 Windows actions); they were not full engine builds.",
+    "plugin": "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/DeferredTeleop.uplugin",
+    "project": "unreal/DeferredTeleopDemo/DeferredTeleopDemo.uproject",
+    "windows_build": "Build.bat UnrealEditor Win64 Development -Project=<project> -Plugin=<plugin> -NoUBTMakefiles -NoHotReload -MaxParallelActions=4",
+    "windows_preparation": "For the reused project, move its generated Intermediate/Build/Win64/x64/UnrealEditor/Development/Makefile.bin out of Intermediate before building, so new test files are discovered. A fresh checkout has no such cached makefile."
+  },
+  "engine_build_versions": {
+    "linux_build_version": {
+      "BranchName": "UE5",
+      "Changelist": 0,
+      "CompatibleChangelist": 55116800,
+      "IsLicenseeVersion": 0,
+      "IsPromotedBuild": 0,
+      "MajorVersion": 5,
+      "MinorVersion": 8,
+      "PatchVersion": 2
+    },
+    "windows_build_version": {
+      "BranchName": "UE5",
+      "Changelist": 0,
+      "CompatibleChangelist": 55116800,
+      "IsLicenseeVersion": 0,
+      "IsPromotedBuild": 0,
+      "MajorVersion": 5,
+      "MinorVersion": 8,
+      "PatchVersion": 2
+    }
+  },
+  "engine_version": "5.8.2",
+  "expected_warning_tests": {
+    "DeferredTeleop.M2.ArticulatedScene.InvalidModelPreservesLastGood": "missing-model negative case",
+    "DeferredTeleop.M2.ArticulatedScene.SourceSequenceAndConnectionGeneration": "duplicate-sequence negative case"
+  },
+  "limits": [
+    "Case-folded collisions are rejected throughout the Unreal JSON document, including opaque objects; unique uppercase opaque keys remain allowed.",
+    "Exact duplicate decoded names keep the existing DOM last-wins behavior.",
+    "This bounded matrix is not a claim of complete Python/Unreal JSON parity; the numerical robot reference loader is not a strict wire parser.",
+    "Prior 43/50-test evidence records remain historical snapshots.",
+    "No hardware, VR, or full M2.9/#20/#21 closure is claimed."
+  ],
+  "platforms": {
+    "LinuxEditor": {
+      "after": {
+        "build_exit_code": 0,
+        "counters": {
+          "failed": 0,
+          "inProcess": 0,
+          "notRun": 0,
+          "succeeded": 50,
+          "succeededWithWarnings": 2
+        },
+        "editor_exit_code": 0,
+        "json_tests": [
+          {
+            "errors": 0,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.NonSchemaObjects",
+            "state": "Success",
+            "warnings": 0
+          },
+          {
+            "errors": 0,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.SharedMatrix",
+            "state": "Success",
+            "warnings": 0
+          }
+        ],
+        "report_sha256": "8ac3c5afa6ff048d9ec84b0323128d6e194839acc346275503aacdf5b257397c",
+        "total_tests": 52
+      },
+      "before": {
+        "build_exit_code": 0,
+        "counters": {
+          "failed": 1,
+          "inProcess": 0,
+          "notRun": 0,
+          "succeeded": 48,
+          "succeededWithWarnings": 2
+        },
+        "editor_exit_code": 255,
+        "json_tests": [
+          {
+            "errors": 54,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.SharedMatrix",
+            "state": "Fail",
+            "warnings": 0
+          }
+        ],
+        "report_sha256": "1a8c572854477d159e65bf24a27e248e881e56906d316bf80458892de6106409",
+        "total_tests": 51
+      }
+    },
+    "WindowsEditor": {
+      "after": {
+        "build_exit_code": 0,
+        "counters": {
+          "failed": 0,
+          "inProcess": 0,
+          "notRun": 0,
+          "succeeded": 50,
+          "succeededWithWarnings": 2
+        },
+        "editor_exit_code": 0,
+        "json_tests": [
+          {
+            "errors": 0,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.NonSchemaObjects",
+            "state": "Success",
+            "warnings": 0
+          },
+          {
+            "errors": 0,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.SharedMatrix",
+            "state": "Success",
+            "warnings": 0
+          }
+        ],
+        "report_sha256": "6f236054202aa47ebd04b11e095a1614d72192b3e989eb3e8fced96439e90cff",
+        "total_tests": 52
+      },
+      "before": {
+        "build_exit_code": 0,
+        "counters": {
+          "failed": 1,
+          "inProcess": 0,
+          "notRun": 0,
+          "succeeded": 48,
+          "succeededWithWarnings": 2
+        },
+        "editor_exit_code": 0,
+        "json_tests": [
+          {
+            "errors": 54,
+            "name": "DeferredTeleop.M2.JsonFieldExactness.SharedMatrix",
+            "state": "Fail",
+            "warnings": 0
+          }
+        ],
+        "report_sha256": "92ec217c62b09325e2926e26ac32bf3469a727d114960100e9e36fb5985c8b69",
+        "total_tests": 51
+      }
+    }
+  },
+  "regression_baseline": {
+    "failure": "18 case-only alias/collision cases were accepted; SharedMatrix recorded 54 failed assertions on each platform. The three exact-duplicate cases already passed.",
+    "input_manifest_sha256": "adbda332ccd11ba60ffe0ba092c63fc4d310f5b73390c9f6528a23c1d0d9919a",
+    "reproduction": "At base_commit, add only the matrix fixture and SharedMatrix test from this change, then build and run DeferredTeleop. The same 21 raw cases fail before the parser correction.",
+    "unchanged_test_inputs": {
+      "fixtures/m2/json-field-exactness.json": "bc41b4ff561ea6b48b36067e6200733cc507ee401e4dc97c24a096bdc24fc0a1",
+      "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopJsonFieldExactnessTests.cpp": "6e7818b56a883fb1ff02068bb9d95a4f91db1d284005d633023706df16656553"
+    }
+  },
+  "schema_version": "dtt.json-field-platform-validation/0",
+  "scope": {
+    "integrated_python_tests_passed": 200,
+    "opaque_objects_test": "DeferredTeleop.M2.JsonFieldExactness.NonSchemaObjects",
+    "production_change": "UE token-reader preflight for case-folded duplicate keys, then exact stored-key checks in the three parsers",
+    "python_matrix_tests_passed": 15,
+    "python_wire_parsers": [
+      "legacy Mission view",
+      "articulated Mission view"
+    ],
+    "shared_raw_cases": 21,
+    "unreal_parsers": [
+      "legacy Mission view",
+      "articulated Mission view",
+      "robot description"
+    ]
+  },
+  "source_files": {
+    "fixtures/m1/golden-session/expected-mission-view.json": "5412ade4288360091807e7be4040d319873d2089822564683a99eeb4f5033512",
+    "fixtures/m2/articulated-state/valid-articulated-view.json": "ca7e5582ae7f668b96f410f5112c656b02dbff25fcb06201b0d21ae9d375b884",
+    "fixtures/m2/json-field-exactness.json": "bc41b4ff561ea6b48b36067e6200733cc507ee401e4dc97c24a096bdc24fc0a1",
+    "robots/so101/generated/so101.kinematics.json": "36ce321332248351f5304630a9ccc4887d6665666e17b6933e3302874735e5f2",
+    "unreal/DeferredTeleopDemo/DeferredTeleopDemo.uproject": "86ba4cc0c07997bdf0b8083b43236a7b79ea642144105aa6263e6bfba24e1b39",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/DeferredTeleop.uplugin": "5587a5d087cf44eabdea70e2d9de4edc157c20989ba75d9c7cc6221d8c0b6427",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/DeferredTeleopRuntime.Build.cs": "bd82250e7eeb6aa8e50870ae98c2fd7f0d444e094d474aadb0023f7da502152e",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedSceneActor.cpp": "0e2a96345764d54a83374f7cf6185e74e76359ad1aed56b65d739afc2c44ea8d",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedSceneValidation.cpp": "f41c95736eb2431b9cac3499d1924372dff1a60e9e811ade1a0e98897cd3530a",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedSceneValidation.h": "a4c8d675fa4fe021f3541420d1ca8c5b12e6d979c06b989a0424e8d1760f7fd4",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.cpp": "9a2d2e2299b082c8d0c98477129a27fb18db56d20b7c40bff6eca4b2af116bad",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.h": "6803ec5686544aa6f40f0af52979262bc9c5f921fc275216c911ed46962579e9",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionClientComponent.cpp": "19c388acc73be63c5e59224d99d44695166566dbf9155761b49dbd0fa577da1a",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.cpp": "ce32acdb940337a02a0340c1090229aa7ebfc61bee549a50292171860fec37c3",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.h": "7a00e323cf9a27a07e0af16833d71746b7ec20b72e865b6d17b880a35bc0f38d",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopRuntime.cpp": "c3e3c943960d18a1d9a34742aae5fe9770061191187b39bc5517c5d9b90ae887",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStateVisualizationActor.cpp": "e6bf490426bfe6a8610a64747d12d2dc1d5bfa00e047daa37b41d67aea576235",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStrictJsonFields.h": "052fb5069db7a0d47b9e44c384d54005163fb48d36edf5c5116d71be15f2b902",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVersionLibrary.cpp": "cbb763125de0ae7830795d16860140a1e0bc18038ec7f2fdf15ab3b6dfdbeeef",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopVisualizationLibrary.cpp": "e88d55a276d4de67d09969db610049732ff6a17b9476846b1e08ddc6ec1e4a3c",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopIKLibrary.cpp": "1074e64b7dabe1a637e057381388b3bc923a550c3a8ad7ca87e4f24acd3a749a",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopIKTestBridge.h": "89b216145d9eb9cd8cbfe945b356eab21e5339798b58b3ca4ec42b7fb880e254",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicPreviewLibrary.cpp": "2da9d58615ee840a2767a2838ac9420e0a85bec8abf9443e9a97fa475e809934",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Kinematics/DeferredTeleopKinematicsLibrary.cpp": "17e07edf30e6bda519da3c0415f0f0cf0563403ac33b9ae0c0ad32a079900773",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp": "915489693edf00dcbebd78ed4d06b64cf6d81070548c9d7bf4fe87e65026c1bc",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelTypes.cpp": "ca9693125f9ff761105c67cf165b5c16bbc2ee43dc6b8fd58fee4cacbd8a74e0",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopArticulatedSceneTests.cpp": "dc8413b238cff17c01315b881bb118bdbe60bb61218ff62063e613afe6f87e17",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopArticulatedViewTests.cpp": "3c304ecb1949d93c2c04639341ea1dd5befb795d7c18871385ab495d39df3cea",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopFrameConversionContractTests.cpp": "9aa5cf021b6839fa54165630d9e3915d82d91c41ae1b359955f9832eb49e1fbc",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopIKTests.cpp": "2ce22c575d5495a62f449a16c9844b0c079eb59a23849d23a2b064bc98d6b84e",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopJsonFieldExactnessTests.cpp": "6e7818b56a883fb1ff02068bb9d95a4f91db1d284005d633023706df16656553",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicPreviewTests.cpp": "ae94d23c9f02bd558a1048bf5982c66e8066236413cf16ee55cc920c725a1539",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicRobotActorTests.cpp": "53e578c3d9f3fa9b26e38b14dd4dce66190e61b8fc0844ebb71af35688118284",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsFixtureTests.cpp": "489c209cba968cf198750cf7228844092ad7c1d93613e1208f5c499f5248300b",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopKinematicsTests.cpp": "88a28057b19d46d4c1b17ad861f1c26ff57132e97ce2132bee9dbd55cb2c02b4",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopMissionViewTests.cpp": "e06ef5cdd7e2a0282f5770006f201a7e374992b436ceb702711e1b22c7f9d1ac",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopStrictJsonFieldsTests.cpp": "4a0fd047400d8a97b23231193f50f37b8581a2618557d120ad2bfb87fb0a74c2",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Visualization/DeferredTeleopKinematicRobotActor.cpp": "dd6b2d8debde8545b7b82ea3dcc767ec4068bab7d2446fa4600e62844a6816e4",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Articulated/DeferredTeleopArticulatedSceneActor.h": "5093d8c1f926f2e5dbda84bf80e7c400c6f2024ea6fd7995444442f6b6d3b50b",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Articulated/DeferredTeleopArticulatedSceneTypes.h": "e8cef3edf3508021031126b1b32b3b26137057ea4955c11f0a15f006d096f849",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Articulated/DeferredTeleopArticulatedViewTypes.h": "4ded7520fb560d9d4d42f8d76fef53cbbd1fc1e9e9b6c9e3b0a45e8991ba6c3d",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionClientComponent.h": "fc11bb0efd07e318fcd52f674552551eac8098b5f34ac904e3b40209369f7d75",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopMissionViewTypes.h": "a6ab1e5b9b9d23d8693b99b59ae3ed20eee71e6dd71742f43189e329467378ce",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopRuntime.h": "5ab43d0e84c526acd869d73a2ea98391de5635e7fd75e10663a532051c0a128d",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopStateVisualizationActor.h": "4c7123a741f1108cdb1f5abfcc502b125ebe5d19f338b352bdce6169df8eb734",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVersionLibrary.h": "903971ea5a3b55d07a45751acbad2fbf9114a8865d5490d4a286756a19d54f04",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/DeferredTeleopVisualizationLibrary.h": "0669fd5f9123f8eafc8e7bca5913822a6c3f8cb1efae1da459d8f75eb40fd93c",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopIKLibrary.h": "e7e0444ffa6400a8c68098c1487dd234989c7e8083b6945a4c69e6e4fa454b2d",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopIKTypes.h": "637ab3db0b187ea8eb046e24668dd79d0e21b4dc6e947f7592e932d034610035",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewLibrary.h": "08bfa2b6e9caed7dada7cbb412094f18875bbaf568c771d41164ce6a7325e7e5",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicPreviewTypes.h": "e3e41dd5faaef980b1e8f9a5cad6d2a6d65df27ddef68ff9b3b4d83160c4b1cf",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Kinematics/DeferredTeleopKinematicsLibrary.h": "697f41e5611ba0f35c564d779e5e5a3d8ec447dc258afd428725c3bfeb5ec705",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/RobotModel/DeferredTeleopRobotModelTypes.h": "b10aea77aac60a5b8d539d4c00c481250ca465564cf7f83a118d7e287e8939d4",
+    "unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Public/Visualization/DeferredTeleopKinematicRobotActor.h": "18a41f6569c8ba405214adf8690932ef5bf2f2387741bf5ab7fe61c4d989901b"
+  },
+  "source_hash_verification": {
+    "all_linux_match": true,
+    "all_windows_match": true,
+    "compiled_input_manifest_sha256": "a8dffa5505e204ab8db5b69d696afc228547b8177bae3ca291d3a5548014b82c",
+    "selected_inputs": 54
+  },
+  "status": "complete_for_bounded_json_field_scope",
+  "validated_at_utc": "2026-09-05T06:36:50.208871+00:00"
+}

--- a/fixtures/m2/json-field-exactness.json
+++ b/fixtures/m2/json-field-exactness.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": "dtt.json-field-exactness/0",
+  "description": "Shared raw JSON mutations for exact field-name and duplicate-key conformance.",
+  "cases": [
+    {
+      "name": "mission-root-case-only",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"protocol_version\": \"dtt/0\",",
+      "after": "\"PROTOCOL_VERSION\": \"dtt/0\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-nested-case-only",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"mission_to_field\": \"CONNECTED\"",
+      "after": "\"MISSION_TO_FIELD\": \"CONNECTED\"",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-nested-collision-canonical-first",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"robot_id\": \"dummy-robot-1\",\n    \"site_id\": \"dummy-site-1\"",
+      "after": "\"robot_id\": \"dummy-robot-1\",\n    \"site_id\": \"canonical-site\",\n    \"SITE_ID\": \"alias-site\"",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-nested-collision-alias-first",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"robot_id\": \"dummy-robot-1\",\n    \"site_id\": \"dummy-site-1\"",
+      "after": "\"robot_id\": \"dummy-robot-1\",\n    \"SITE_ID\": \"alias-site\",\n    \"site_id\": \"canonical-site\"",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-root-collision-canonical-first",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"source_id\": \"mission-1\",",
+      "after": "\"source_id\": \"canonical-source\",\n  \"SOURCE_ID\": \"alias-source\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-root-collision-alias-first",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"source_id\": \"mission-1\",",
+      "after": "\"SOURCE_ID\": \"alias-source\",\n  \"source_id\": \"canonical-source\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "mission-root-exact-duplicate-last-wins",
+      "parser": "mission_view",
+      "fixture": "fixtures/m1/golden-session/expected-mission-view.json",
+      "before": "\"source_id\": \"mission-1\",",
+      "after": "\"source_id\": \"first-source\",\n  \"source_id\": \"last-source\",",
+      "expected": "ACCEPT",
+      "value_path": "source_id",
+      "value": "last-source"
+    },
+    {
+      "name": "robot-root-case-only",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"schema_version\": \"dtt.robot-description/0\",",
+      "after": "\"SCHEMA_VERSION\": \"dtt.robot-description/0\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-nested-case-only",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"repository\": \"https://github.com/TheRobotStudio/SO-ARM100\",",
+      "after": "\"REPOSITORY\": \"https://github.com/TheRobotStudio/SO-ARM100\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-nested-collision-canonical-first",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"repository\": \"https://github.com/TheRobotStudio/SO-ARM100\",",
+      "after": "\"repository\": \"https://github.com/TheRobotStudio/SO-ARM100\",\n    \"REPOSITORY\": \"https://example.invalid/alias\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-nested-collision-alias-first",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"repository\": \"https://github.com/TheRobotStudio/SO-ARM100\",",
+      "after": "\"REPOSITORY\": \"https://example.invalid/alias\",\n    \"repository\": \"https://github.com/TheRobotStudio/SO-ARM100\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-root-collision-canonical-first",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"model_id\": \"so101_new_calib\",",
+      "after": "\"model_id\": \"canonical-model\",\n  \"MODEL_ID\": \"alias-model\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-root-collision-alias-first",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"model_id\": \"so101_new_calib\",",
+      "after": "\"MODEL_ID\": \"alias-model\",\n  \"model_id\": \"canonical-model\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "robot-root-exact-duplicate-last-wins",
+      "parser": "robot_model",
+      "fixture": "robots/so101/generated/so101.kinematics.json",
+      "before": "\"model_id\": \"so101_new_calib\",",
+      "after": "\"model_id\": \"first-model\",\n  \"model_id\": \"so101_new_calib\",",
+      "expected": "ACCEPT",
+      "value_path": "model_id",
+      "value": "so101_new_calib"
+    },
+    {
+      "name": "articulated-root-case-only",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"protocol_version\": \"dtt/0\",",
+      "after": "\"PROTOCOL_VERSION\": \"dtt/0\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-nested-case-only",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"so101_new_calib\",",
+      "after": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"MODEL_ID\": \"so101_new_calib\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-nested-collision-canonical-first",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"so101_new_calib\",",
+      "after": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"so101_new_calib\",\n      \"MODEL_ID\": \"so101_new_calib\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-nested-collision-alias-first",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"so101_new_calib\",",
+      "after": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"MODEL_ID\": \"so101_new_calib\",\n      \"model_id\": \"so101_new_calib\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-root-collision-canonical-first",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"source_id\": \"mission-1\",",
+      "after": "\"source_id\": \"canonical-source\",\n  \"SOURCE_ID\": \"alias-source\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-root-collision-alias-first",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"source_id\": \"mission-1\",",
+      "after": "\"SOURCE_ID\": \"alias-source\",\n  \"source_id\": \"canonical-source\",",
+      "expected": "REJECT"
+    },
+    {
+      "name": "articulated-nested-exact-duplicate-last-wins",
+      "parser": "articulated_view",
+      "fixture": "fixtures/m2/articulated-state/valid-articulated-view.json",
+      "before": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"so101_new_calib\",",
+      "after": "\"confirmed_robot_state\": {\n    \"robot_id\": \"so101-follower-1\",\n    \"model_reference\": {\n      \"model_id\": \"first-model\",\n      \"model_id\": \"last-model\",",
+      "expected": "ACCEPT",
+      "value_path": "confirmed_robot_state.model_reference.model_id",
+      "value": "last-model"
+    }
+  ]
+}

--- a/tests/test_json_field_exactness.py
+++ b/tests/test_json_field_exactness.py
@@ -1,0 +1,71 @@
+"""Python half of the shared exact JSON field-name conformance matrix."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from deferred_teleop.mission_view import ArticulatedMissionViewState, MissionViewState
+from pydantic import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "fixtures" / "m2" / "json-field-exactness.json"
+PYTHON_PARSERS = {
+    "mission_view": MissionViewState.model_validate_json,
+    "articulated_view": ArticulatedMissionViewState.model_validate_json,
+}
+
+
+def _cases() -> list[dict[str, Any]]:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "dtt.json-field-exactness/0"
+    return manifest["cases"]
+
+
+def _mutated_json(case: dict[str, Any]) -> str:
+    fixture = ROOT / case["fixture"]
+    raw = fixture.read_text(encoding="utf-8")
+    before = case["before"]
+    assert raw.count(before) == 1, case["name"]
+    return raw.replace(before, case["after"], 1)
+
+
+def _value_at(model: Any, path: str) -> Any:
+    for name in path.split("."):
+        model = getattr(model, name)
+    return model
+
+
+def test_shared_matrix_has_one_compact_case_set_for_each_unreal_parser() -> None:
+    cases = _cases()
+    assert len({case["name"] for case in cases}) == len(cases)
+    assert {case["parser"] for case in cases} == {
+        "mission_view",
+        "robot_model",
+        "articulated_view",
+    }
+    assert {case["expected"] for case in cases} == {"ACCEPT", "REJECT"}
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        case
+        for case in _cases()
+        if case["parser"] in PYTHON_PARSERS
+    ],
+    ids=lambda case: case["name"],
+)
+def test_python_matches_shared_exact_field_name_matrix(case: dict[str, Any]) -> None:
+    parse = PYTHON_PARSERS[case["parser"]]
+    mutated = _mutated_json(case)
+
+    if case["expected"] == "REJECT":
+        with pytest.raises(ValidationError):
+            parse(mutated)
+        return
+
+    parsed = parse(mutated)
+    assert _value_at(parsed, case["value_path"]) == case["value"]

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Articulated/DeferredTeleopArticulatedViewParser.cpp
@@ -1,5 +1,6 @@
 #include "Articulated/DeferredTeleopArticulatedViewParser.h"
 
+#include "DeferredTeleopStrictJsonFields.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -37,7 +38,16 @@ bool RequireExactFields(
     }
     for (const TCHAR* Name : Names)
     {
-        if (!Object->HasField(FStringView(Name)))
+        bool bFoundCaseSensitive = false;
+        for (const auto& Entry : Object->Values)
+        {
+            if (Entry.Key.ToView().Equals(FStringView(Name), ESearchCase::CaseSensitive))
+            {
+                bFoundCaseSensitive = true;
+                break;
+            }
+        }
+        if (!bFoundCaseSensitive)
         {
             return Fail(OutError, Path, FString::Printf(TEXT("missing field '%s'"), Name));
         }
@@ -752,6 +762,10 @@ bool ParseArticulated(
     FString& OutError)
 {
     OutError.Reset();
+    if (!DeferredTeleop::Json::ValidateFieldNameSpelling(Json, OutError))
+    {
+        return false;
+    }
     FJsonObjectPtr Root;
     const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
     if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopMissionViewParser.cpp
@@ -1,5 +1,6 @@
 #include "DeferredTeleopMissionViewParser.h"
 
+#include "DeferredTeleopStrictJsonFields.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -35,7 +36,16 @@ bool RequireExactFields(
     }
     for (const TCHAR* Name : Names)
     {
-        if (!Object->HasField(FStringView(Name)))
+        bool bFoundCaseSensitive = false;
+        for (const auto& Entry : Object->Values)
+        {
+            if (Entry.Key.ToView().Equals(FStringView(Name), ESearchCase::CaseSensitive))
+            {
+                bFoundCaseSensitive = true;
+                break;
+            }
+        }
+        if (!bFoundCaseSensitive)
         {
             return Fail(OutError, Path, FString::Printf(TEXT("missing field '%s'"), Name));
         }
@@ -786,6 +796,10 @@ namespace DeferredTeleop::MissionView
 bool Parse(const FString& Json, FDeferredTeleopMissionViewState& OutState, FString& OutError)
 {
     OutError.Reset();
+    if (!DeferredTeleop::Json::ValidateFieldNameSpelling(Json, OutError))
+    {
+        return false;
+    }
     FJsonObjectPtr Root;
     const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
     if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStrictJsonFields.h
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/DeferredTeleopStrictJsonFields.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "Containers/Array.h"
+#include "Containers/Set.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonTypes.h"
+
+namespace DeferredTeleop::Json
+{
+namespace Private
+{
+struct FJsonScope
+{
+    EJsonNotation Notation = EJsonNotation::Error;
+    // FString's UE key equality and hash are case-insensitive. Keep the first spelling so
+    // an exact duplicate remains valid while a distinct case variant can be rejected.
+    TSet<FString> FieldNames;
+};
+}
+
+// FJsonObject may merge field names that differ only by case before a parser can inspect them.
+// Scan the reader tokens first, retaining each decoded spelling. Exact duplicate names remain
+// valid and keep the existing DOM last-wins behavior; only case-insensitive collisions are rejected.
+inline bool ValidateFieldNameSpelling(const FString& Json, FString& OutError)
+{
+    const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+    TArray<Private::FJsonScope> Scopes;
+    EJsonNotation Notation = EJsonNotation::Error;
+
+    while (Reader->ReadNext(Notation))
+    {
+        if (Notation == EJsonNotation::Error)
+        {
+            OutError = Reader->GetErrorMessage();
+            return false;
+        }
+
+        // For every value token emitted while the current reader scope is an object,
+        // GetIdentifier() contains that member's raw decoded field spelling. This check
+        // happens before the DOM stores it and can merge case variants.
+        if (Scopes.Num() > 0
+            && Scopes.Last().Notation == EJsonNotation::ObjectStart
+            && Notation != EJsonNotation::ObjectEnd)
+        {
+            const FString& RawName = Reader->GetIdentifier();
+            const FString* ExistingName = Scopes.Last().FieldNames.Find(RawName);
+            if (ExistingName != nullptr
+                && !RawName.Equals(*ExistingName, ESearchCase::CaseSensitive))
+            {
+                OutError = FString::Printf(
+                    TEXT("JSON field names differ only by case: '%s' and '%s'"),
+                    **ExistingName,
+                    *RawName);
+                return false;
+            }
+            Scopes.Last().FieldNames.Add(RawName);
+        }
+
+        switch (Notation)
+        {
+        case EJsonNotation::ObjectStart:
+        {
+            Private::FJsonScope Scope;
+            Scope.Notation = EJsonNotation::ObjectStart;
+            Scopes.Add(MoveTemp(Scope));
+            break;
+        }
+        case EJsonNotation::ArrayStart:
+        {
+            Private::FJsonScope Scope;
+            Scope.Notation = EJsonNotation::ArrayStart;
+            Scopes.Add(MoveTemp(Scope));
+            break;
+        }
+        case EJsonNotation::ObjectEnd:
+        case EJsonNotation::ArrayEnd:
+        {
+            const EJsonNotation ExpectedStart = Notation == EJsonNotation::ObjectEnd
+                ? EJsonNotation::ObjectStart
+                : EJsonNotation::ArrayStart;
+            if (Scopes.Num() == 0 || Scopes.Last().Notation != ExpectedStart)
+            {
+                OutError = TEXT("JSON scope terminator does not match its opener");
+                return false;
+            }
+            Scopes.Pop();
+            break;
+        }
+        case EJsonNotation::Boolean:
+        case EJsonNotation::String:
+        case EJsonNotation::Number:
+        case EJsonNotation::Null:
+            break;
+        case EJsonNotation::Error:
+            // Handled above; keep the switch exhaustive for UE's enum.
+            break;
+        }
+    }
+
+    if (!Reader->GetErrorMessage().IsEmpty())
+    {
+        OutError = Reader->GetErrorMessage();
+        return false;
+    }
+    if (Scopes.Num() != 0)
+    {
+        OutError = TEXT("JSON ended before all scopes were closed");
+        return false;
+    }
+    return true;
+}
+} // namespace DeferredTeleop::Json

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/RobotModel/DeferredTeleopRobotModelJson.cpp
@@ -1,6 +1,7 @@
 #include "RobotModel/DeferredTeleopRobotModelTypes.h"
 
 #include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "DeferredTeleopStrictJsonFields.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -37,7 +38,16 @@ bool RequireExactFields(
     }
     for (const TCHAR* Name : Names)
     {
-        if (!Object->HasField(FStringView(Name)))
+        bool bFoundCaseSensitive = false;
+        for (const auto& Entry : Object->Values)
+        {
+            if (Entry.Key.ToView().Equals(FStringView(Name), ESearchCase::CaseSensitive))
+            {
+                bFoundCaseSensitive = true;
+                break;
+            }
+        }
+        if (!bFoundCaseSensitive)
         {
             return Fail(OutError, Path, FString::Printf(TEXT("missing field '%s'"), Name));
         }
@@ -291,6 +301,10 @@ bool ParseRobotDescriptionJson(
     FString& OutError)
 {
     OutError.Reset();
+    if (!DeferredTeleop::Json::ValidateFieldNameSpelling(Json, OutError))
+    {
+        return false;
+    }
     TSharedPtr<FJsonObject> Root;
     const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
     if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopJsonFieldExactnessTests.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopJsonFieldExactnessTests.cpp
@@ -1,0 +1,252 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Articulated/DeferredTeleopArticulatedViewParser.h"
+#include "DeferredTeleopMissionViewParser.h"
+#include "Kinematics/DeferredTeleopKinematicsLibrary.h"
+#include "Dom/JsonObject.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+namespace DeferredTeleop::JsonFieldExactnessTests
+{
+using FJsonObjectPtr = TSharedPtr<FJsonObject>;
+using FJsonValuePtr = TSharedPtr<FJsonValue>;
+
+FString RepositoryPath(const TCHAR* RelativePath)
+{
+    return FPaths::ConvertRelativePathToFull(
+        FPaths::ProjectDir() / TEXT("../../") / RelativePath);
+}
+
+bool LoadText(const FString& Path, FString& OutText)
+{
+    return FFileHelper::LoadFileToString(OutText, *Path);
+}
+
+int32 CountExactOccurrences(const FString& Text, const FString& Needle)
+{
+    int32 Count = 0;
+    int32 SearchFrom = 0;
+    for (;;)
+    {
+        const int32 FoundAt = Text.Find(
+            *Needle,
+            ESearchCase::CaseSensitive,
+            ESearchDir::FromStart,
+            SearchFrom);
+        if (FoundAt == INDEX_NONE)
+        {
+            return Count;
+        }
+        ++Count;
+        SearchFrom = FoundAt + Needle.Len();
+    }
+}
+
+bool ReadString(
+    const FJsonObjectPtr& Object,
+    const TCHAR* Name,
+    FString& OutValue,
+    FString& OutError)
+{
+    if (!Object.IsValid() || !Object->TryGetStringField(FStringView(Name), OutValue))
+    {
+        OutError = FString::Printf(TEXT("manifest field '%s' must be a string"), Name);
+        return false;
+    }
+    return true;
+}
+
+bool ParseJsonFieldCase(
+    const FString& Parser,
+    const FString& Json,
+    FString& OutValue,
+    FString& OutError)
+{
+    if (Parser == TEXT("mission_view"))
+    {
+        FDeferredTeleopMissionViewState State;
+        State.SourceId = TEXT("sentinel-before-parse");
+        const bool bParsed = DeferredTeleop::MissionView::Parse(Json, State, OutError);
+        OutValue = State.SourceId;
+        return bParsed;
+    }
+
+    if (Parser == TEXT("robot_model"))
+    {
+        FDttRobotDescription Description;
+        Description.ModelId = TEXT("sentinel-before-parse");
+        const bool bParsed = DeferredTeleop::RobotModel::ParseRobotDescriptionJson(
+            Json,
+            Description,
+            OutError);
+        OutValue = Description.ModelId;
+        return bParsed;
+    }
+
+    if (Parser == TEXT("articulated_view"))
+    {
+        FDeferredTeleopArticulatedViewState State;
+        State.SourceId = TEXT("sentinel-before-parse");
+        const bool bParsed = DeferredTeleop::ArticulatedView::ParseArticulated(
+            Json,
+            State,
+            OutError);
+        OutValue = State.bHasConfirmedRobotState
+            ? State.ConfirmedRobotState.ModelReference.ModelId
+            : State.SourceId;
+        return bParsed;
+    }
+
+    OutError = FString::Printf(TEXT("unsupported parser '%s'"), *Parser);
+    return false;
+}
+} // namespace DeferredTeleop::JsonFieldExactnessTests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopJsonFieldExactnessTest,
+    "DeferredTeleop.M2.JsonFieldExactness.SharedMatrix",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopJsonFieldExactnessTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    using namespace DeferredTeleop::JsonFieldExactnessTests;
+
+    FString ManifestJson;
+    if (!TestTrue(
+            TEXT("shared exactness manifest loads"),
+            LoadText(RepositoryPath(TEXT("fixtures/m2/json-field-exactness.json")), ManifestJson)))
+    {
+        return false;
+    }
+
+    FJsonObjectPtr Manifest;
+    const TSharedRef<TJsonReader<>> ManifestReader = TJsonReaderFactory<>::Create(ManifestJson);
+    if (!TestTrue(
+            TEXT("shared exactness manifest parses"),
+            FJsonSerializer::Deserialize(ManifestReader, Manifest) && Manifest.IsValid()))
+    {
+        return false;
+    }
+
+    FString SchemaVersion;
+    FString ManifestError;
+    if (!TestTrue(
+            TEXT("shared exactness manifest has its declared schema"),
+            ReadString(Manifest, TEXT("schema_version"), SchemaVersion, ManifestError)))
+    {
+        return false;
+    }
+    if (!TestEqual(
+            TEXT("shared exactness manifest schema is current"),
+            SchemaVersion,
+            FString(TEXT("dtt.json-field-exactness/0"))))
+    {
+        return false;
+    }
+
+    const TArray<FJsonValuePtr>* Cases = nullptr;
+    if (!TestTrue(
+            TEXT("shared exactness manifest has cases"),
+            Manifest->TryGetArrayField(FStringView(TEXT("cases")), Cases)
+                && Cases != nullptr))
+    {
+        return false;
+    }
+
+    for (int32 Index = 0; Index < Cases->Num(); ++Index)
+    {
+        const FJsonObjectPtr Case = (*Cases)[Index].IsValid()
+            ? (*Cases)[Index]->AsObject()
+            : nullptr;
+        if (!TestTrue(
+                *FString::Printf(TEXT("matrix case %d is an object"), Index),
+                Case.IsValid()))
+        {
+            continue;
+        }
+
+        FString Name;
+        FString Parser;
+        FString Fixture;
+        FString Before;
+        FString After;
+        FString Expected;
+        if (!ReadString(Case, TEXT("name"), Name, ManifestError)
+            || !ReadString(Case, TEXT("parser"), Parser, ManifestError)
+            || !ReadString(Case, TEXT("fixture"), Fixture, ManifestError)
+            || !ReadString(Case, TEXT("before"), Before, ManifestError)
+            || !ReadString(Case, TEXT("after"), After, ManifestError)
+            || !ReadString(Case, TEXT("expected"), Expected, ManifestError))
+        {
+            AddError(FString::Printf(TEXT("matrix case %d is missing a required field"), Index));
+            continue;
+        }
+
+        FString FixtureJson;
+        if (!TestTrue(
+                *FString::Printf(TEXT("%s fixture loads"), *Name),
+                LoadText(RepositoryPath(*Fixture), FixtureJson)))
+        {
+            continue;
+        }
+
+        const int32 MatchCount = CountExactOccurrences(FixtureJson, Before);
+        if (!TestEqual(
+                *FString::Printf(TEXT("%s has one exact mutation anchor"), *Name),
+                MatchCount,
+                1))
+        {
+            continue;
+        }
+
+        const FString MutatedJson = FixtureJson.Replace(
+            *Before,
+            *After,
+            ESearchCase::CaseSensitive);
+        if (!TestTrue(
+                *FString::Printf(TEXT("%s mutation changes the fixture bytes"), *Name),
+                MutatedJson.Compare(FixtureJson, ESearchCase::CaseSensitive) != 0))
+        {
+            continue;
+        }
+
+        FString Error;
+        FString ParsedValue;
+        const bool bParsed = ParseJsonFieldCase(Parser, MutatedJson, ParsedValue, Error);
+        if (Expected == TEXT("REJECT"))
+        {
+            TestFalse(*FString::Printf(TEXT("%s rejects"), *Name), bParsed);
+            TestTrue(
+                *FString::Printf(TEXT("%s reports a rejection diagnostic"), *Name),
+                !Error.IsEmpty());
+            TestEqual(
+                *FString::Printf(TEXT("%s keeps the prior parsed value"), *Name),
+                ParsedValue,
+                FString(TEXT("sentinel-before-parse")));
+        }
+        else if (Expected == TEXT("ACCEPT"))
+        {
+            TestTrue(*FString::Printf(TEXT("%s accepts"), *Name), bParsed);
+            FString ExpectedValue;
+            if (Case->TryGetStringField(FStringView(TEXT("value")), ExpectedValue))
+            {
+                TestEqual(
+                    *FString::Printf(TEXT("%s applies exact-duplicate last-wins"), *Name),
+                    ParsedValue,
+                    ExpectedValue);
+            }
+        }
+        else
+        {
+            AddError(FString::Printf(TEXT("%s declares unsupported outcome %s"), *Name, *Expected));
+        }
+    }
+    return true;
+}
+
+#endif

--- a/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopStrictJsonFieldsTests.cpp
+++ b/unreal/DeferredTeleopDemo/Plugins/DeferredTeleop/Source/DeferredTeleopRuntime/Private/Tests/DeferredTeleopStrictJsonFieldsTests.cpp
@@ -1,0 +1,159 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "RobotModel/DeferredTeleopRobotModelTypes.h"
+
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+namespace DeferredTeleop::StrictJsonFieldsTests
+{
+FString RepositoryPath(const TCHAR* RelativePath)
+{
+    return FPaths::ConvertRelativePathToFull(
+        FPaths::ProjectDir() / TEXT("../../") / RelativePath);
+}
+
+int32 CountExactOccurrences(const FString& Text, const FString& Needle)
+{
+    int32 Count = 0;
+    int32 SearchFrom = 0;
+    for (;;)
+    {
+        const int32 FoundAt = Text.Find(
+            *Needle,
+            ESearchCase::CaseSensitive,
+            ESearchDir::FromStart,
+            SearchFrom);
+        if (FoundAt == INDEX_NONE)
+        {
+            return Count;
+        }
+        ++Count;
+        SearchFrom = FoundAt + Needle.Len();
+    }
+}
+} // namespace DeferredTeleop::StrictJsonFieldsTests
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FDeferredTeleopStrictJsonFieldsTest,
+    "DeferredTeleop.M2.JsonFieldExactness.NonSchemaObjects",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FDeferredTeleopStrictJsonFieldsTest::RunTest(const FString& Parameters)
+{
+    (void)Parameters;
+    using namespace DeferredTeleop::StrictJsonFieldsTests;
+
+    FString FixtureJson;
+    if (!TestTrue(
+            TEXT("robot fixture loads"),
+            FFileHelper::LoadFileToString(
+                FixtureJson,
+                *RepositoryPath(TEXT("robots/so101/generated/so101.kinematics.json")))))
+    {
+        return false;
+    }
+
+    struct FCase
+    {
+        const TCHAR* Name;
+        const TCHAR* FirstBefore;
+        const TCHAR* FirstAfter;
+        bool bExpected;
+        bool bAddArraySiblingVariant;
+    };
+
+    const FCase Cases[] = {
+        {
+            TEXT("opaque escaped uppercase key and sibling case variant accept"),
+            TEXT("\"visual_id\": \"base_link.visual.0\","),
+            TEXT("\"visual_id\": \"base_link.visual.0\",\n"
+                 "          \"\\u0055PPER_EXTENSION\": \"braces { and comma, stay in string}\","),
+            true,
+            true,
+        },
+        {
+            TEXT("opaque exact duplicate with escaped spelling accept"),
+            TEXT("\"visual_id\": \"base_link.visual.0\","),
+            TEXT("\"visual_id\": \"base_link.visual.0\",\n"
+                 "          \"\\u0076isual_id\": \"escaped exact duplicate\","),
+            true,
+            false,
+        },
+        {
+            TEXT("opaque escaped case collision reject"),
+            TEXT("\"visual_id\": \"base_link.visual.0\","),
+            TEXT("\"visual_id\": \"base_link.visual.0\",\n"
+                 "          \"\\u0056ISUAL_ID\": \"escaped case alias\","),
+            false,
+            false,
+        },
+    };
+
+    for (const FCase& Case : Cases)
+    {
+        FString MutatedJson = FixtureJson;
+        const int32 FirstCount = CountExactOccurrences(MutatedJson, Case.FirstBefore);
+        if (!TestEqual(
+                *FString::Printf(TEXT("%s first anchor is unique"), Case.Name),
+                FirstCount,
+                1))
+        {
+            continue;
+        }
+        MutatedJson = MutatedJson.Replace(
+            Case.FirstBefore,
+            Case.FirstAfter,
+            ESearchCase::CaseSensitive);
+
+        if (Case.bAddArraySiblingVariant)
+        {
+            const TCHAR* SecondBefore = TEXT("\"visual_id\": \"shoulder_link.visual.0\",");
+            const TCHAR* SecondAfter = TEXT("\"visual_id\": \"shoulder_link.visual.0\",\n"
+                                            "          \"upper_extension\": \"different object scope\",");
+            const int32 SecondCount = CountExactOccurrences(MutatedJson, SecondBefore);
+            if (!TestEqual(
+                    *FString::Printf(TEXT("%s second anchor is unique"), Case.Name),
+                    SecondCount,
+                    1))
+            {
+                continue;
+            }
+            MutatedJson = MutatedJson.Replace(
+                SecondBefore,
+                SecondAfter,
+                ESearchCase::CaseSensitive);
+        }
+
+        FDttRobotDescription Description;
+        Description.ModelId = TEXT("sentinel-before-parse");
+        FString Error;
+        const bool bParsed = DeferredTeleop::RobotModel::ParseRobotDescriptionJson(
+            MutatedJson,
+            Description,
+            Error);
+        if (Case.bExpected)
+        {
+            TestTrue(*FString::Printf(TEXT("%s accepts"), Case.Name), bParsed);
+            TestEqual(
+                *FString::Printf(TEXT("%s keeps the canonical model"), Case.Name),
+                Description.ModelId,
+                FString(TEXT("so101_new_calib")));
+        }
+        else
+        {
+            TestFalse(*FString::Printf(TEXT("%s rejects"), Case.Name), bParsed);
+            TestTrue(
+                *FString::Printf(TEXT("%s reports a diagnostic"), Case.Name),
+                !Error.IsEmpty());
+            TestEqual(
+                *FString::Printf(TEXT("%s preserves prior output"), Case.Name),
+                Description.ModelId,
+                FString(TEXT("sentinel-before-parse")));
+        }
+    }
+    return true;
+}
+
+#endif


### PR DESCRIPTION
UE 5.8.2 accepted fields such as `PROTOCOL_VERSION` and collapsed canonical/alias pairs before strict field validation. A shared Unreal token-reader preflight now rejects case-only collisions before DOM construction; the three parsers check stored field names with exact comparisons. Identical duplicate names retain last-wins behavior. Unique uppercase opaque keys remain valid, while case-only collisions are rejected throughout the document, including opaque objects.

Closes #47. This is a bounded conformance correction for the legacy Mission view, articulated Mission view, and robot-description parser; full JSON parity and #20/#21/full M2.9 remain outside scope.

Validation: the unchanged 21-case raw matrix produced 54 failing assertions on each platform before correction. Afterwards, Linux and Win64 UE 5.8.2 each pass 52 tests (50 successes, two expected warning cases, zero failures/unexecuted tests; build/editor exit 0). Both JSON groups pass without warnings. The public platform record binds report hashes and 54 compiled inputs, and includes the failing baseline. Python: 15 shared matrix checks, 200 integrated tests, and Ruff pass. Independent critical review: GO source and publication; merge requires green post-push CI.